### PR TITLE
Add editable/delete context menu for chat messages

### DIFF
--- a/server/src/socketio/rooms.js
+++ b/server/src/socketio/rooms.js
@@ -157,8 +157,8 @@ class ServerRooms {
 		});
 
 		// Client sends a message to a room
-		socket.on("message_room", async (arg1, arg2) => {
-			try {
+                socket.on("message_room", async (arg1, arg2) => {
+                        try {
 				const [idToName] = await this.getRoomList();
 				let roomId, content;
 
@@ -200,12 +200,70 @@ class ServerRooms {
 					}
 				});
 
-				logger.info(`User '${socket.user.username}' sent message '${msg._id}' to room '${roomId}'.`);
-			} catch (err) {
-				logger.error("Error handling message_room:", err);
-			}
-		});
-	}
+                                logger.info(`User '${socket.user.username}' sent message '${msg._id}' to room '${roomId}'.`);
+                        } catch (err) {
+                                logger.error("Error handling message_room:", err);
+                        }
+                });
+
+                // Client edits an existing message
+                socket.on("edit_message", async (roomId, messageId, content) => {
+                        try {
+                                const [idToName] = await this.getRoomList();
+                                if (!idToName[roomId]) {
+                                        throw new Error("Room not found by ID.");
+                                }
+
+                                const msg = await MessageModel.findById(messageId);
+                                if (!msg) return;
+                                if (msg.sender.toString() !== socket.user.id) return;
+
+                                msg.content = content;
+                                await msg.save();
+
+                                const roomDoc = await RoomModel.findById(roomId).populate({
+                                        path: "messages",
+                                        populate: { path: "sender", select: "displayName avatarUrl" },
+                                });
+
+                                const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
+                                socketsInRoom.forEach((s) => {
+                                        s.emit("messages_updated", roomId, roomDoc.messages);
+                                });
+                        } catch (err) {
+                                logger.error("Error handling edit_message:", err);
+                        }
+                });
+
+                // Client deletes a message
+                socket.on("delete_message", async (roomId, messageId) => {
+                        try {
+                                const [idToName] = await this.getRoomList();
+                                if (!idToName[roomId]) {
+                                        throw new Error("Room not found by ID.");
+                                }
+
+                                const msg = await MessageModel.findById(messageId);
+                                if (!msg) return;
+                                if (msg.sender.toString() !== socket.user.id) return;
+
+                                await MessageModel.deleteOne({ _id: messageId });
+                                await RoomModel.findByIdAndUpdate(roomId, { $pull: { messages: messageId } });
+
+                                const roomDoc = await RoomModel.findById(roomId).populate({
+                                        path: "messages",
+                                        populate: { path: "sender", select: "displayName avatarUrl" },
+                                });
+
+                                const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
+                                socketsInRoom.forEach((s) => {
+                                        s.emit("messages_updated", roomId, roomDoc.messages);
+                                });
+                        } catch (err) {
+                                logger.error("Error handling delete_message:", err);
+                        }
+                });
+        }
 }
 
 const serverRooms = new ServerRooms();

--- a/src/components/Chat/ChatArea.jsx
+++ b/src/components/Chat/ChatArea.jsx
@@ -18,10 +18,11 @@ const formatDate = (timestamp) => {
 	return outStringFull;
 };
 
-function IndividualMessage({ msg, shouldDisplayAvatar, currentBlock, currentMsg, hoveredBlock, hoveredMessage, onHoverMessage, requestedTime, onClickMessage }) {
-	const theme = useTheme();
-	let sendTimeText = requestedTime ? formatDate(requestedTime) : formatDate(msg.createdAt);
-	const messageRef = React.useRef(null);
+function IndividualMessage({ msg, shouldDisplayAvatar, currentBlock, currentMsg, hoveredBlock, hoveredMessage, onHoverMessage, requestedTime, onClickMessage, onContextMenu }) {
+        const theme = useTheme();
+        let sendTimeText = requestedTime ? formatDate(requestedTime) : formatDate(msg.createdAt);
+        const messageRef = React.useRef(null);
+        const touchTimer = React.useRef(null);
 
 	const onHoverStart = (_event) => {
 		onHoverMessage(currentMsg);
@@ -30,16 +31,32 @@ function IndividualMessage({ msg, shouldDisplayAvatar, currentBlock, currentMsg,
 		onHoverMessage(-1);
 	};
 
-	return (
-		<ListItem
-			disablePadding
-			sx={{
-				alignItems: "flex-start",
-				display: "flex",
-				flexDirection: "column",
-				width: "100%",
-			}}
-		>
+        const handleContext = (e) => {
+                e.preventDefault();
+                onContextMenu(msg, e.currentTarget);
+        };
+
+        const handleTouchStart = (e) => {
+                touchTimer.current = setTimeout(() => onContextMenu(msg, e.currentTarget), 500);
+        };
+
+        const handleTouchEnd = () => {
+                clearTimeout(touchTimer.current);
+        };
+
+        return (
+                <ListItem
+                        disablePadding
+                        sx={{
+                                alignItems: "flex-start",
+                                display: "flex",
+                                flexDirection: "column",
+                                width: "100%",
+                        }}
+                        onContextMenu={handleContext}
+                        onTouchStart={handleTouchStart}
+                        onTouchEnd={handleTouchEnd}
+                >
 			<Box
 				sx={{
 					display: shouldDisplayAvatar ? "inherit" : "none",
@@ -125,7 +142,7 @@ const divideMessages = (messages) => {
 	return outputMessages;
 };
 
-function GetMessageBlock({ messageBlock, blockIndex, hoveredBlock, setHoveredBlock, previewUser }) {
+function GetMessageBlock({ messageBlock, blockIndex, hoveredBlock, setHoveredBlock, previewUser, onContextMenu }) {
 	const [requestedTime, setRequestedTime] = React.useState(null);
 	const [hoveredMessage, setHoveredMessage] = React.useState(-1);
 
@@ -150,24 +167,25 @@ function GetMessageBlock({ messageBlock, blockIndex, hoveredBlock, setHoveredBlo
 			}
 		};
 
-		return (
-			<IndividualMessage
-				key={msgIndex}
-				msg={msg}
-				shouldDisplayAvatar={shouldDisplayAvatar}
-				currentBlock={blockIndex}
-				currentMsg={msgIndex}
-				hoveredBlock={hoveredBlock}
-				hoveredMessage={hoveredMessage}
-				onHoverMessage={onHoverMessage}
-				requestedTime={requestedTime}
-				onClickMessage={onClickMessage}
-			/>
-		);
-	});
+                return (
+                        <IndividualMessage
+                                key={msgIndex}
+                                msg={msg}
+                                shouldDisplayAvatar={shouldDisplayAvatar}
+                                currentBlock={blockIndex}
+                                currentMsg={msgIndex}
+                                hoveredBlock={hoveredBlock}
+                                hoveredMessage={hoveredMessage}
+                                onHoverMessage={onHoverMessage}
+                                requestedTime={requestedTime}
+                                onClickMessage={onClickMessage}
+                                onContextMenu={onContextMenu}
+                        />
+                );
+        });
 }
 
-const ConstructedMessages = React.memo(function ConstructedMessages({ relevantMsgs, previewUser }) {
+const ConstructedMessages = React.memo(function ConstructedMessages({ relevantMsgs, previewUser, onContextMenu }) {
 	const theme = useTheme();
 	const [hoveredBlock, setHoveredBlock] = React.useState(-1);
 
@@ -185,13 +203,13 @@ const ConstructedMessages = React.memo(function ConstructedMessages({ relevantMs
 					transition: `background ${hoveredBlock !== blockIndex ? "0.3s" : "0.1s"} ease-in-out`,
 				}}
 			>
-				<GetMessageBlock messageBlock={messageBlock} blockIndex={blockIndex} hoveredBlock={hoveredBlock} setHoveredBlock={setHoveredBlock} previewUser={previewUser} />
+                                <GetMessageBlock messageBlock={messageBlock} blockIndex={blockIndex} hoveredBlock={hoveredBlock} setHoveredBlock={setHoveredBlock} previewUser={previewUser} onContextMenu={onContextMenu} />
 			</Box>
 		);
 	});
 });
 
-function ChatArea({ messages, previewUser }) {
+function ChatArea({ messages, previewUser, onContextMenu }) {
 	const boxStyles = useMemo(
 		() => ({
 			position: "absolute",
@@ -212,7 +230,7 @@ function ChatArea({ messages, previewUser }) {
 	return (
 		<Box sx={boxStyles}>
 			<List disablePadding>
-				<ConstructedMessages relevantMsgs={messages} previewUser={previewUser} />
+                                <ConstructedMessages relevantMsgs={messages} previewUser={previewUser} onContextMenu={onContextMenu} />
 			</List>
 		</Box>
 	);

--- a/src/components/Chat/ChatArea.jsx
+++ b/src/components/Chat/ChatArea.jsx
@@ -1,4 +1,4 @@
-import { Box, List, ListItem, Avatar, Typography, useTheme, Link } from "@mui/material";
+import { Box, List, ListItem, Avatar, Typography, useTheme, Link, TextField, Button } from "@mui/material";
 import React, { useMemo } from "react";
 
 import { scrollbarStyles } from "routes/LandingPage/utils/scrollbarStyles";
@@ -18,7 +18,23 @@ const formatDate = (timestamp) => {
 	return outStringFull;
 };
 
-function IndividualMessage({ msg, shouldDisplayAvatar, currentBlock, currentMsg, hoveredBlock, hoveredMessage, onHoverMessage, requestedTime, onClickMessage, onContextMenu }) {
+function IndividualMessage({
+        msg,
+        shouldDisplayAvatar,
+        currentBlock,
+        currentMsg,
+        hoveredBlock,
+        hoveredMessage,
+        onHoverMessage,
+        requestedTime,
+        onClickMessage,
+        onContextMenu,
+        editingMessageId,
+        editingText,
+        setEditingText,
+        commitEdit,
+        cancelEdit,
+}) {
         const theme = useTheme();
         let sendTimeText = requestedTime ? formatDate(requestedTime) : formatDate(msg.createdAt);
         const messageRef = React.useRef(null);
@@ -33,11 +49,12 @@ function IndividualMessage({ msg, shouldDisplayAvatar, currentBlock, currentMsg,
 
         const handleContext = (e) => {
                 e.preventDefault();
-                onContextMenu(msg, e.currentTarget);
+                onContextMenu(msg, { x: e.clientX, y: e.clientY });
         };
 
         const handleTouchStart = (e) => {
-                touchTimer.current = setTimeout(() => onContextMenu(msg, e.currentTarget), 500);
+                const { clientX, clientY } = e.touches[0];
+                touchTimer.current = setTimeout(() => onContextMenu(msg, { x: clientX, y: clientY }), 500);
         };
 
         const handleTouchEnd = () => {
@@ -113,10 +130,32 @@ function IndividualMessage({ msg, shouldDisplayAvatar, currentBlock, currentMsg,
 						justifyContent: "space-between",
 					}}
 				>
-					<Typography variant="subtitle1" sx={{ color: theme.palette.text.secondary }}>
-						{msg.content}
-					</Typography>
-				</Box>
+                                        {editingMessageId === msg._id ? (
+                                                <Box sx={{ display: "flex", gap: 1, width: "100%" }}>
+                                                        <TextField
+                                                                size="small"
+                                                                fullWidth
+                                                                value={editingText}
+                                                                onChange={(e) => setEditingText(e.target.value)}
+                                                                onKeyDown={(e) => {
+                                                                        if (e.key === "Enter") commitEdit();
+                                                                        if (e.key === "Escape") cancelEdit();
+                                                                }}
+                                                                autoFocus
+                                                        />
+                                                        <Button variant="contained" color="primary" onClick={commitEdit} size="small">
+                                                                Save
+                                                        </Button>
+                                                        <Button variant="text" color="secondary" onClick={cancelEdit} size="small">
+                                                                Cancel
+                                                        </Button>
+                                                </Box>
+                                        ) : (
+                                                <Typography variant="subtitle1" sx={{ color: theme.palette.text.secondary }}>
+                                                        {msg.content}
+                                                </Typography>
+                                        )}
+                                </Box>
 			</Box>
 		</ListItem>
 	);
@@ -142,7 +181,19 @@ const divideMessages = (messages) => {
 	return outputMessages;
 };
 
-function GetMessageBlock({ messageBlock, blockIndex, hoveredBlock, setHoveredBlock, previewUser, onContextMenu }) {
+function GetMessageBlock({
+        messageBlock,
+        blockIndex,
+        hoveredBlock,
+        setHoveredBlock,
+        previewUser,
+        onContextMenu,
+        editingMessageId,
+        editingText,
+        setEditingText,
+        commitEdit,
+        cancelEdit,
+}) {
 	const [requestedTime, setRequestedTime] = React.useState(null);
 	const [hoveredMessage, setHoveredMessage] = React.useState(-1);
 
@@ -180,12 +231,26 @@ function GetMessageBlock({ messageBlock, blockIndex, hoveredBlock, setHoveredBlo
                                 requestedTime={requestedTime}
                                 onClickMessage={onClickMessage}
                                 onContextMenu={onContextMenu}
+                                editingMessageId={editingMessageId}
+                                editingText={editingText}
+                                setEditingText={setEditingText}
+                                commitEdit={commitEdit}
+                                cancelEdit={cancelEdit}
                         />
                 );
         });
 }
 
-const ConstructedMessages = React.memo(function ConstructedMessages({ relevantMsgs, previewUser, onContextMenu }) {
+const ConstructedMessages = React.memo(function ConstructedMessages({
+        relevantMsgs,
+        previewUser,
+        onContextMenu,
+        editingMessageId,
+        editingText,
+        setEditingText,
+        commitEdit,
+        cancelEdit,
+}) {
 	const theme = useTheme();
 	const [hoveredBlock, setHoveredBlock] = React.useState(-1);
 
@@ -203,13 +268,34 @@ const ConstructedMessages = React.memo(function ConstructedMessages({ relevantMs
 					transition: `background ${hoveredBlock !== blockIndex ? "0.3s" : "0.1s"} ease-in-out`,
 				}}
 			>
-                                <GetMessageBlock messageBlock={messageBlock} blockIndex={blockIndex} hoveredBlock={hoveredBlock} setHoveredBlock={setHoveredBlock} previewUser={previewUser} onContextMenu={onContextMenu} />
-			</Box>
+                                <GetMessageBlock
+                                        messageBlock={messageBlock}
+                                        blockIndex={blockIndex}
+                                        hoveredBlock={hoveredBlock}
+                                        setHoveredBlock={setHoveredBlock}
+                                        previewUser={previewUser}
+                                        onContextMenu={onContextMenu}
+                                        editingMessageId={editingMessageId}
+                                        editingText={editingText}
+                                        setEditingText={setEditingText}
+                                        commitEdit={commitEdit}
+                                        cancelEdit={cancelEdit}
+                                />
+                        </Box>
 		);
 	});
 });
 
-function ChatArea({ messages, previewUser, onContextMenu }) {
+function ChatArea({
+        messages,
+        previewUser,
+        onContextMenu,
+        editingMessageId,
+        editingText,
+        setEditingText,
+        commitEdit,
+        cancelEdit,
+}) {
 	const boxStyles = useMemo(
 		() => ({
 			position: "absolute",
@@ -230,7 +316,16 @@ function ChatArea({ messages, previewUser, onContextMenu }) {
 	return (
 		<Box sx={boxStyles}>
 			<List disablePadding>
-                                <ConstructedMessages relevantMsgs={messages} previewUser={previewUser} onContextMenu={onContextMenu} />
+                                <ConstructedMessages
+                                        relevantMsgs={messages}
+                                        previewUser={previewUser}
+                                        onContextMenu={onContextMenu}
+                                        editingMessageId={editingMessageId}
+                                        editingText={editingText}
+                                        setEditingText={setEditingText}
+                                        commitEdit={commitEdit}
+                                        cancelEdit={cancelEdit}
+                                />
 			</List>
 		</Box>
 	);

--- a/src/components/Chat/MessageContextMenu.jsx
+++ b/src/components/Chat/MessageContextMenu.jsx
@@ -1,0 +1,54 @@
+import * as Icons from "@mui/icons-material";
+import Menu from "@mui/material/Menu";
+import MenuItem from "@mui/material/MenuItem";
+import { styled, alpha } from "@mui/material/styles";
+import React from "react";
+
+const StyledMenu = styled((props) => (
+  <Menu
+    elevation={5}
+    anchorOrigin={{ vertical: "bottom", horizontal: "right" }}
+    transformOrigin={{ vertical: "top", horizontal: "right" }}
+    {...props}
+  />
+))(({ theme }) => ({
+  "& .MuiPaper-root": {
+    borderRadius: 6,
+    marginTop: theme.spacing(1),
+    minWidth: 150,
+    color: theme.palette.text.primary,
+    boxShadow:
+      "rgb(255, 255, 255) 0px 0px 0px 0px, rgba(0, 0, 0, 0.05) 0px 0px 0px 1px, rgba(0, 0, 0, 0.1) 0px 10px 15px -3px, rgba(0, 0, 0, 0.05) 0px 4px 6px -2px",
+    "& .MuiMenu-list": {
+      padding: "4px 0",
+    },
+    "& .MuiMenuItem-root": {
+      "& .MuiSvgIcon-root": {
+        fontSize: 18,
+        color: theme.palette.text.secondary,
+        marginRight: theme.spacing(1.5),
+      },
+      "&:active": {
+        backgroundColor: alpha(theme.palette.primary.main, theme.palette.action.selectedOpacity),
+      },
+    },
+  },
+}));
+
+export default function MessageContextMenu({ anchorEl, setAnchorEl, onEdit, onDelete, allowEdit }) {
+  const open = Boolean(anchorEl);
+  const handleClose = () => {
+    setAnchorEl(null);
+  };
+
+  return (
+    <StyledMenu id="message-context-menu" anchorEl={anchorEl} open={open} onClose={handleClose}>
+      <MenuItem disabled={!allowEdit} onClick={() => { handleClose(); onEdit(); }} disableRipple>
+        <Icons.Edit /> Edit
+      </MenuItem>
+      <MenuItem disabled={!allowEdit} onClick={() => { handleClose(); onDelete(); }} disableRipple>
+        <Icons.Delete /> Delete
+      </MenuItem>
+    </StyledMenu>
+  );
+}

--- a/src/components/Chat/MessageContextMenu.jsx
+++ b/src/components/Chat/MessageContextMenu.jsx
@@ -2,6 +2,8 @@ import * as Icons from "@mui/icons-material";
 import Menu from "@mui/material/Menu";
 import MenuItem from "@mui/material/MenuItem";
 import { styled, alpha } from "@mui/material/styles";
+import Button from "@mui/material/Button";
+import Typography from "@mui/material/Typography";
 import React from "react";
 
 const StyledMenu = styled((props) => (
@@ -35,20 +37,50 @@ const StyledMenu = styled((props) => (
   },
 }));
 
-export default function MessageContextMenu({ anchorEl, setAnchorEl, onEdit, onDelete, allowEdit }) {
-  const open = Boolean(anchorEl);
+export default function MessageContextMenu({ anchorPosition, setAnchorPosition, onEdit, onDelete, allowEdit }) {
+  const [confirming, setConfirming] = React.useState(false);
+  const open = Boolean(anchorPosition);
   const handleClose = () => {
-    setAnchorEl(null);
+    setConfirming(false);
+    setAnchorPosition(null);
   };
 
   return (
-    <StyledMenu id="message-context-menu" anchorEl={anchorEl} open={open} onClose={handleClose}>
-      <MenuItem disabled={!allowEdit} onClick={() => { handleClose(); onEdit(); }} disableRipple>
-        <Icons.Edit /> Edit
-      </MenuItem>
-      <MenuItem disabled={!allowEdit} onClick={() => { handleClose(); onDelete(); }} disableRipple>
-        <Icons.Delete /> Delete
-      </MenuItem>
+    <StyledMenu
+      id="message-context-menu"
+      anchorReference="anchorPosition"
+      anchorPosition={anchorPosition ? { top: anchorPosition.y, left: anchorPosition.x } : undefined}
+      open={open}
+      onClose={handleClose}
+    >
+      {confirming ? (
+        <div style={{ padding: 8 }}>
+          <Typography sx={{ mb: 1 }}>Are you sure?</Typography>
+          <Button
+            variant="contained"
+            color="error"
+            onClick={() => {
+              handleClose();
+              onDelete();
+            }}
+            sx={{ mr: 1 }}
+          >
+            Yes
+          </Button>
+          <Button variant="outlined" color="error" onClick={handleClose}>
+            No
+          </Button>
+        </div>
+      ) : (
+        <>
+          <MenuItem disabled={!allowEdit} onClick={() => { handleClose(); onEdit(); }} disableRipple>
+            <Icons.Edit /> Edit
+          </MenuItem>
+          <MenuItem disabled={!allowEdit} onClick={() => { setConfirming(true); }} disableRipple>
+            <Icons.Delete /> Delete
+          </MenuItem>
+        </>
+      )}
     </StyledMenu>
   );
 }

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -9,6 +9,7 @@ import ChatRoomMenu from "components/Chat/ChatRoomMenu";
 import UserListMenu from "components/Chat/UserListMenu";
 import ChatArea from "components/Chat/ChatArea";
 import ChatInput from "components/Chat/ChatInput";
+import MessageContextMenu from "components/Chat/MessageContextMenu";
 import ProfileCard from "components/User/ProfileCard";
 
 import socketIoHelper from "helpers/socket";
@@ -83,10 +84,12 @@ function ChatPage() {
 	const [users, setUsers] = useState([]);
 
 	/* menus & preview popovers */
-	const [roomAnchorEl, setRoomAnchorEl] = useState(null);
-	const [userListAnchorEl, setUserListAnchorEl] = useState(null);
-	const [userPreviewEl, setUserPreviewEl] = useState(null);
-	const [userPreviewUser, setUserPreviewUser] = useState(null);
+        const [roomAnchorEl, setRoomAnchorEl] = useState(null);
+        const [userListAnchorEl, setUserListAnchorEl] = useState(null);
+        const [userPreviewEl, setUserPreviewEl] = useState(null);
+        const [userPreviewUser, setUserPreviewUser] = useState(null);
+        const [msgMenuAnchorEl, setMsgMenuAnchorEl] = useState(null);
+        const [selectedMessage, setSelectedMessage] = useState(null);
 
 	/* -------------------------------------------------- */
 	/*  Socket lifecycle                                  */
@@ -112,6 +115,7 @@ function ChatPage() {
                         socket.on("joined_room", (_id, msgs) => setMessages(mapMessages(msgs)));
                         socket.on("message_sent", (_id, msgs) => setMessages(mapMessages(msgs)));
                         socket.on("new_message", (_id, msgs) => setMessages(mapMessages(msgs)));
+                        socket.on("messages_updated", (_id, msgs) => setMessages(mapMessages(msgs)));
 			// presence
 			socket.on("user_list", (_roomId, list, sender, evt) => {
 				if (sender.id !== authState.userId) {
@@ -143,8 +147,9 @@ function ChatPage() {
 				socket.off("room_list");
 				socket.off("joined_room");
 				socket.off("message_sent");
-				socket.off("new_message");
-				socket.off("user_list");
+                                socket.off("new_message");
+                                socket.off("messages_updated");
+                                socket.off("user_list");
 			}
 			setChannels({});
 			setMessages([]);
@@ -189,21 +194,47 @@ function ChatPage() {
 		setRoomAnchorEl(null);
 	};
 
-	const previewUser = async (elRef, u) => {
-		if (!elRef?.current) {
-			setUserPreviewEl(null);
-			setUserPreviewUser(null);
-			return;
-		}
+        const previewUser = async (elRef, u) => {
+                if (!elRef?.current) {
+                        setUserPreviewEl(null);
+                        setUserPreviewUser(null);
+                        return;
+                }
 
 		if (!u?._id) return;
 
 		const info = await getUserInfo(u._id, authState.authToken);
-		if (info) {
-			setUserPreviewEl(elRef.current);
-			setUserPreviewUser(info);
-		}
-	};
+                if (info) {
+                        setUserPreviewEl(elRef.current);
+                        setUserPreviewUser(info);
+                }
+        };
+
+        const openMessageMenu = (msg, el) => {
+                setSelectedMessage(msg);
+                setMsgMenuAnchorEl(el);
+        };
+
+        const editSelectedMessage = () => {
+                if (!selectedMessage) return;
+                const newContent = window.prompt("Edit message", selectedMessage.content);
+                if (newContent !== null && newContent !== selectedMessage.content) {
+                        const socket = socketIoHelper.getSocket();
+                        socket.emit("edit_message", authState.socketInfo.currentRoom, selectedMessage._id, newContent);
+                }
+                setMsgMenuAnchorEl(null);
+                setSelectedMessage(null);
+        };
+
+        const deleteSelectedMessage = () => {
+                if (!selectedMessage) return;
+                if (window.confirm("Delete this message?")) {
+                        const socket = socketIoHelper.getSocket();
+                        socket.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
+                }
+                setMsgMenuAnchorEl(null);
+                setSelectedMessage(null);
+        };
 
 	/* -------------------------------------------------- */
 	/*  Render                                            */
@@ -234,8 +265,15 @@ function ChatPage() {
 			</Popover>
 
 			{/* menus */}
-			<ChatRoomMenu anchorEl={roomAnchorEl} setAnchorEl={setRoomAnchorEl} channels={channels} setMessages={setMessages} />
-			<UserListMenu anchorEl={userListAnchorEl} setAnchorEl={setUserListAnchorEl} users={users} />
+                        <ChatRoomMenu anchorEl={roomAnchorEl} setAnchorEl={setRoomAnchorEl} channels={channels} setMessages={setMessages} />
+                        <UserListMenu anchorEl={userListAnchorEl} setAnchorEl={setUserListAnchorEl} users={users} />
+                        <MessageContextMenu
+                                anchorEl={msgMenuAnchorEl}
+                                setAnchorEl={setMsgMenuAnchorEl}
+                                onEdit={editSelectedMessage}
+                                onDelete={deleteSelectedMessage}
+                                allowEdit={selectedMessage?.sender?._id === authState.userId}
+                        />
 
 			{/* shell */}
 			<Paper
@@ -274,7 +312,7 @@ function ChatPage() {
 
 				{/* messages */}
 				<Box sx={{ flexGrow: 1, position: "relative", width: "100%" }}>
-					<ChatArea messages={messages} previewUser={previewUser} />
+                                <ChatArea messages={messages} previewUser={previewUser} onContextMenu={openMessageMenu} />
 				</Box>
 
 				{/* input */}

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -217,19 +217,23 @@ function ChatPage() {
                 setMsgMenuPos(pos);
         };
 
+        const closeMessageMenu = () => {
+                setMsgMenuPos(null);
+                setSelectedMessage(null);
+        };
+
         const startEditSelectedMessage = () => {
                 if (!selectedMessage) return;
                 setEditingMessageId(selectedMessage._id);
                 setEditingText(selectedMessage.content);
-                setMsgMenuPos(null);
+                closeMessageMenu();
         };
 
         const confirmDeleteSelectedMessage = () => {
                 if (!selectedMessage) return;
                 const socket = socketIoHelper.getSocket();
                 socket.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
-                setMsgMenuPos(null);
-                setSelectedMessage(null);
+                closeMessageMenu();
         };
 
         const commitEditMessage = () => {
@@ -278,7 +282,7 @@ function ChatPage() {
                         <UserListMenu anchorEl={userListAnchorEl} setAnchorEl={setUserListAnchorEl} users={users} />
                         <MessageContextMenu
                                 anchorPosition={msgMenuPos}
-                                setAnchorPosition={setMsgMenuPos}
+                                setAnchorPosition={closeMessageMenu}
                                 onEdit={startEditSelectedMessage}
                                 onDelete={confirmDeleteSelectedMessage}
                                 allowEdit={selectedMessage?.sender?._id === authState.userId}

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -88,8 +88,10 @@ function ChatPage() {
         const [userListAnchorEl, setUserListAnchorEl] = useState(null);
         const [userPreviewEl, setUserPreviewEl] = useState(null);
         const [userPreviewUser, setUserPreviewUser] = useState(null);
-        const [msgMenuAnchorEl, setMsgMenuAnchorEl] = useState(null);
+        const [msgMenuPos, setMsgMenuPos] = useState(null);
         const [selectedMessage, setSelectedMessage] = useState(null);
+        const [editingMessageId, setEditingMessageId] = useState(null);
+        const [editingText, setEditingText] = useState("");
 
 	/* -------------------------------------------------- */
 	/*  Socket lifecycle                                  */
@@ -210,30 +212,37 @@ function ChatPage() {
                 }
         };
 
-        const openMessageMenu = (msg, el) => {
+        const openMessageMenu = (msg, pos) => {
                 setSelectedMessage(msg);
-                setMsgMenuAnchorEl(el);
+                setMsgMenuPos(pos);
         };
 
-        const editSelectedMessage = () => {
+        const startEditSelectedMessage = () => {
                 if (!selectedMessage) return;
-                const newContent = window.prompt("Edit message", selectedMessage.content);
-                if (newContent !== null && newContent !== selectedMessage.content) {
-                        const socket = socketIoHelper.getSocket();
-                        socket.emit("edit_message", authState.socketInfo.currentRoom, selectedMessage._id, newContent);
-                }
-                setMsgMenuAnchorEl(null);
+                setEditingMessageId(selectedMessage._id);
+                setEditingText(selectedMessage.content);
+                setMsgMenuPos(null);
+        };
+
+        const confirmDeleteSelectedMessage = () => {
+                if (!selectedMessage) return;
+                const socket = socketIoHelper.getSocket();
+                socket.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
+                setMsgMenuPos(null);
                 setSelectedMessage(null);
         };
 
-        const deleteSelectedMessage = () => {
-                if (!selectedMessage) return;
-                if (window.confirm("Delete this message?")) {
-                        const socket = socketIoHelper.getSocket();
-                        socket.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
-                }
-                setMsgMenuAnchorEl(null);
-                setSelectedMessage(null);
+        const commitEditMessage = () => {
+                if (!editingMessageId) return;
+                const socket = socketIoHelper.getSocket();
+                socket.emit("edit_message", authState.socketInfo.currentRoom, editingMessageId, editingText);
+                setEditingMessageId(null);
+                setEditingText("");
+        };
+
+        const cancelEditMessage = () => {
+                setEditingMessageId(null);
+                setEditingText("");
         };
 
 	/* -------------------------------------------------- */
@@ -268,10 +277,10 @@ function ChatPage() {
                         <ChatRoomMenu anchorEl={roomAnchorEl} setAnchorEl={setRoomAnchorEl} channels={channels} setMessages={setMessages} />
                         <UserListMenu anchorEl={userListAnchorEl} setAnchorEl={setUserListAnchorEl} users={users} />
                         <MessageContextMenu
-                                anchorEl={msgMenuAnchorEl}
-                                setAnchorEl={setMsgMenuAnchorEl}
-                                onEdit={editSelectedMessage}
-                                onDelete={deleteSelectedMessage}
+                                anchorPosition={msgMenuPos}
+                                setAnchorPosition={setMsgMenuPos}
+                                onEdit={startEditSelectedMessage}
+                                onDelete={confirmDeleteSelectedMessage}
                                 allowEdit={selectedMessage?.sender?._id === authState.userId}
                         />
 
@@ -312,8 +321,17 @@ function ChatPage() {
 
 				{/* messages */}
 				<Box sx={{ flexGrow: 1, position: "relative", width: "100%" }}>
-                                <ChatArea messages={messages} previewUser={previewUser} onContextMenu={openMessageMenu} />
-				</Box>
+                                <ChatArea
+                                        messages={messages}
+                                        previewUser={previewUser}
+                                        onContextMenu={openMessageMenu}
+                                        editingMessageId={editingMessageId}
+                                        editingText={editingText}
+                                        setEditingText={setEditingText}
+                                        commitEdit={commitEditMessage}
+                                        cancelEdit={cancelEditMessage}
+                                />
+                                </Box>
 
 				{/* input */}
 				<ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} />


### PR DESCRIPTION
## Summary
- add `MessageContextMenu` for chat messages
- allow opening message context menu with right click or long press
- hook up edit/delete socket events on client and server

## Testing
- `npm test` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68435f4299308327b7e9ec0ce45516e6