### PR TITLE
Add base test structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,3 +127,24 @@ Get to know more about us and explore all the fun and unique features at
 [Rebound](https://rebound.nexus/).
 
 Enjoy your time with Rebound, where we take social interaction to a whole new level!
+
+## Development and Testing
+
+This repository uses **Mocha** with **Chai** for backend API and Socket.IO tests
+located under `server/tests`. Frontend React components are tested with
+**Jest** via `react-scripts` and React Testing Library in `src/__tests__`.
+
+Run backend tests:
+
+```bash
+npm test --prefix server
+```
+
+Run frontend tests from the repository root:
+
+```bash
+npm test
+```
+
+Test helpers currently contain placeholders that will be filled out when the
+scenarios listed in `tests-todo.txt` are implemented.

--- a/server/package.json
+++ b/server/package.json
@@ -9,7 +9,7 @@
   "main": "./src/app.js",
   "scripts": {
     "dev": "npx kill-port 6001 && npx kill-port 27017 && cross-env NODE_ENV=development nodemon ./src/app.js",
-    "test": "cross-env NODE_ENV=test mocha ./src/tests/users.spec.js --timeout 60000 --exit"
+    "test": "cross-env NODE_ENV=test mocha \"./tests/**/*.spec.js\" --timeout 60000 --exit"
   },
   "author": {
     "name": "Brandon Casamichana",

--- a/server/tests/admin.spec.js
+++ b/server/tests/admin.spec.js
@@ -1,0 +1,19 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { startServer, stopServer } from './helpers/server.js';
+
+chai.use(chaiHttp);
+
+before(async () => {
+  await startServer();
+});
+
+after(async () => {
+  await stopServer();
+});
+
+describe('Admin utilities', () => {
+  describe('POST /admin/users/delete', () => {
+    it('cleans up data when deleting a user');
+  });
+});

--- a/server/tests/auth.spec.js
+++ b/server/tests/auth.spec.js
@@ -1,0 +1,31 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { startServer, stopServer } from './helpers/server.js';
+
+chai.use(chaiHttp);
+
+// Placeholder server instance - will be assigned in startServer()
+let request;
+
+before(async () => {
+  await startServer();
+  // request = chai.request('http://localhost:6001');
+});
+
+after(async () => {
+  await stopServer();
+});
+
+describe('Authentication API', () => {
+  describe('POST /users/verify', () => {
+    it('verifies a user token');
+  });
+
+  describe('POST /users/login', () => {
+    it('logs in a user with valid credentials');
+  });
+
+  describe('POST /users/register', () => {
+    it('registers a new user');
+  });
+});

--- a/server/tests/content.spec.js
+++ b/server/tests/content.spec.js
@@ -1,0 +1,19 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { startServer, stopServer } from './helpers/server.js';
+
+chai.use(chaiHttp);
+
+before(async () => {
+  await startServer();
+});
+
+after(async () => {
+  await stopServer();
+});
+
+describe('Content API', () => {
+  describe('GET /content/:filename', () => {
+    it('retrieves files from GridFS');
+  });
+});

--- a/server/tests/dev.spec.js
+++ b/server/tests/dev.spec.js
@@ -1,0 +1,18 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { startServer, stopServer } from './helpers/server.js';
+
+chai.use(chaiHttp);
+
+before(async () => {
+  await startServer();
+});
+
+after(async () => {
+  await stopServer();
+});
+
+describe('Development utilities', () => {
+  it('wipes the database');
+  it('creates a test room');
+});

--- a/server/tests/friends.spec.js
+++ b/server/tests/friends.spec.js
@@ -1,0 +1,21 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { startServer, stopServer } from './helpers/server.js';
+
+chai.use(chaiHttp);
+
+before(async () => {
+  await startServer();
+});
+
+after(async () => {
+  await stopServer();
+});
+
+describe('Friend request workflow', () => {
+  it('sends a friend request');
+  it('accepts a friend request');
+  it('declines a friend request');
+  it('cancels a sent request');
+  it('removes a friend');
+});

--- a/server/tests/getToken.spec.js
+++ b/server/tests/getToken.spec.js
@@ -1,0 +1,28 @@
+import { expect } from 'chai';
+
+process.env.SECRET = 'dummy';
+let getTokenFromHeader;
+
+before(async () => {
+  ({ getTokenFromHeader } = await import('../src/routes/auth.js'));
+});
+
+describe('getTokenFromHeader', () => {
+  it('returns token from Bearer header', () => {
+    const req = { headers: { authorization: 'Bearer abc123' } };
+    const token = getTokenFromHeader(req);
+    expect(token).to.equal('abc123');
+  });
+
+  it('returns token from Token header body', () => {
+    const req = { body: { headers: { authorization: 'Token xyz456' } } };
+    const token = getTokenFromHeader(req);
+    expect(token).to.equal('xyz456');
+  });
+
+  it('returns null when header is missing', () => {
+    const req = {};
+    const token = getTokenFromHeader(req);
+    expect(token).to.be.null;
+  });
+});

--- a/server/tests/helpers/server.js
+++ b/server/tests/helpers/server.js
@@ -1,0 +1,12 @@
+// Helper to start and stop the backend server for tests.
+// Actual implementation will start the express app using an in-memory
+// MongoDB instance and listen on a test port. For now it is just a
+// placeholder so test files can import these methods.
+
+export async function startServer() {
+  // TODO: spin up the server for tests
+}
+
+export async function stopServer() {
+  // TODO: shut down the server after tests
+}

--- a/server/tests/profile.spec.js
+++ b/server/tests/profile.spec.js
@@ -1,0 +1,25 @@
+import chai from 'chai';
+import chaiHttp from 'chai-http';
+import { startServer, stopServer } from './helpers/server.js';
+
+chai.use(chaiHttp);
+
+before(async () => {
+  await startServer();
+});
+
+after(async () => {
+  await stopServer();
+});
+
+describe('Profile API', () => {
+  describe('GET /users/profile', () => {
+    it('returns the private profile for the owner');
+    it('returns a public profile when querying other users');
+  });
+
+  describe('PUT /users/modify', () => {
+    it('updates profile fields');
+    it('uploads avatar and banner images');
+  });
+});

--- a/server/tests/socket.spec.js
+++ b/server/tests/socket.spec.js
@@ -1,0 +1,22 @@
+import { startServer, stopServer } from './helpers/server.js';
+import { io as Client } from 'socket.io-client';
+import { expect } from 'chai';
+
+let client;
+
+before(async () => {
+  await startServer();
+  // client = new Client('http://localhost:6002');
+});
+
+after(async () => {
+  if (client) client.close();
+  await stopServer();
+});
+
+describe('Socket.IO events', () => {
+  it('authenticates connections with JWT');
+  it('lists, creates, joins and leaves rooms');
+  it('sends, edits and deletes messages');
+  it('notifies watchers on user updates');
+});

--- a/src/__tests__/AutoUpdateDialog.test.jsx
+++ b/src/__tests__/AutoUpdateDialog.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('Auto update dialog', () => {
+  test.todo('prompts the user when an update is available');
+});

--- a/src/__tests__/AutoUpdateDialog.test.jsx
+++ b/src/__tests__/AutoUpdateDialog.test.jsx
@@ -1,5 +1,38 @@
-import { render } from '@testing-library/react';
+import { render, screen, act } from '@testing-library/react';
+import AutoUpdate from '../components/AutoUpdate.jsx';
 
 describe('Auto update dialog', () => {
-  test.todo('prompts the user when an update is available');
+  let originalAPI;
+  let handlers;
+
+  beforeEach(() => {
+    handlers = {};
+    originalAPI = window.electronAPI;
+    window.electronAPI = {
+      onChecking: (cb) => (handlers.checking = cb),
+      onUpdateAvailable: (cb) => (handlers.updateAvailable = cb),
+      onUpdateNotAvailable: (cb) => (handlers.notAvailable = cb),
+      onDownloadProgress: (cb) => (handlers.progress = cb),
+      onUpdateDownloaded: (cb) => (handlers.downloaded = cb),
+      onUpdateError: (cb) => (handlers.error = cb),
+      checkForUpdates: jest.fn(),
+      installUpdate: jest.fn(),
+      downloadUpdate: jest.fn(),
+    };
+  });
+
+  afterEach(() => {
+    window.electronAPI = originalAPI;
+  });
+
+  test('prompts the user when an update is available', () => {
+    render(<AutoUpdate />);
+    expect(window.electronAPI.checkForUpdates).toHaveBeenCalled();
+
+    act(() => {
+      handlers.updateAvailable();
+    });
+
+    expect(screen.getByText(/update available/i)).toBeInTheDocument();
+  });
 });

--- a/src/__tests__/ChannelUserList.test.jsx
+++ b/src/__tests__/ChannelUserList.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('Channel and user lists', () => {
+  test.todo('renders available channels and friends');
+});

--- a/src/__tests__/ChatInterface.test.jsx
+++ b/src/__tests__/ChatInterface.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('Chat interface', () => {
+  test.todo('sends, edits and deletes messages');
+});

--- a/src/__tests__/FriendListProfile.test.jsx
+++ b/src/__tests__/FriendListProfile.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('Friend list and profile pages', () => {
+  test.todo('displays friend details and profile info');
+});

--- a/src/__tests__/HubLandingPage.test.jsx
+++ b/src/__tests__/HubLandingPage.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('Hub and landing page', () => {
+  test.todo('renders application entry points');
+});

--- a/src/__tests__/LoginDialog.test.jsx
+++ b/src/__tests__/LoginDialog.test.jsx
@@ -1,0 +1,5 @@
+import { render, screen } from '@testing-library/react';
+
+describe('LoginDialog component', () => {
+  test.todo('opens and submits credentials');
+});

--- a/src/__tests__/RegistrationDialog.test.jsx
+++ b/src/__tests__/RegistrationDialog.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('RegistrationDialog component', () => {
+  test.todo('validates user input and registers');
+});

--- a/src/__tests__/Snackbar.test.jsx
+++ b/src/__tests__/Snackbar.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('Snackbar notifications', () => {
+  test.todo('shows messages to the user');
+});

--- a/src/__tests__/ThemeDesigner.test.jsx
+++ b/src/__tests__/ThemeDesigner.test.jsx
@@ -1,0 +1,5 @@
+import { render } from '@testing-library/react';
+
+describe('Theme designer page', () => {
+  test.todo('allows customizing the UI theme');
+});

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/tests-todo.txt
+++ b/tests-todo.txt
@@ -1,25 +1,26 @@
 Backend tests:
-- User verification via JWT (/users/verify)
-- User login (/users/login)
-- User registration (/users/register)
-- Retrieve user profiles (public/private) (/users/profile)
-- Modify profile with banner/avatar upload (/users/modify)
-- Friend request workflow (add, accept, decline, cancel, remove)
-- Content retrieval from GridFS (/content/:filename)
-- Admin user deletion cleanup (/admin/users/delete)
-- Development utilities (database wipe, create test room)
-- Socket.IO authentication and events
-  - List, create, join, and leave rooms
-  - Send, edit, and delete messages
-  - Watcher notifications on user updates
+- [x] Token helper (getTokenFromHeader)
+- [ ] User verification via JWT (/users/verify)
+- [ ] User login (/users/login)
+- [ ] User registration (/users/register)
+- [ ] Retrieve user profiles (public/private) (/users/profile)
+- [ ] Modify profile with banner/avatar upload (/users/modify)
+- [ ] Friend request workflow (add, accept, decline, cancel, remove)
+- [ ] Content retrieval from GridFS (/content/:filename)
+- [ ] Admin user deletion cleanup (/admin/users/delete)
+- [ ] Development utilities (database wipe, create test room)
+- [ ] Socket.IO authentication and events
+  - [ ] List, create, join, and leave rooms
+  - [ ] Send, edit, and delete messages
+  - [ ] Watcher notifications on user updates
 
 Frontend tests:
-- Login dialog interactions
-- Registration dialog and validation
-- Chat interface (sending, editing, deleting messages)
-- Channel and user lists
-- Theme designer in Settings page
-- Auto update dialog behavior
-- Friend list and profile pages
-- Hub and landing page rendering
-- Snackbar notifications
+- [ ] Login dialog interactions
+- [ ] Registration dialog and validation
+- [ ] Chat interface (sending, editing, deleting messages)
+- [ ] Channel and user lists
+- [ ] Theme designer in Settings page
+- [x] Auto update dialog behavior
+- [ ] Friend list and profile pages
+- [ ] Hub and landing page rendering
+- [ ] Snackbar notifications


### PR DESCRIPTION
## Summary
- add mocha test scaffolding for the backend
- configure test script to run all specs
- scaffold frontend test files using Jest
- document testing approach

## Testing
- `npm test --prefix server`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6843735dbedc8327860ac5b7b1f42475