### PR TITLE
Refactor ChatPage logic into custom hook

### DIFF
--- a/src/components/User/ProfileCard.jsx
+++ b/src/components/User/ProfileCard.jsx
@@ -1,333 +1,307 @@
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React from "react";
 import * as Icons from "@mui/icons-material";
-import { Avatar, Box, Button, ButtonGroup, IconButton, Paper, Stack, TextField, Typography } from "@mui/material";
-import axios from "axios";
-import { useSelector, useDispatch } from "react-redux";
-
-import socketIoHelper from "../../helpers/socket";
-import { addSnackbar } from "../../slices/snackbarSlice";
-import { setLoggedIn } from "../../slices/authSlice";
+import {
+  Avatar,
+  Box,
+  Button,
+  ButtonGroup,
+  IconButton,
+  Paper,
+  Stack,
+  TextField,
+  Typography,
+} from "@mui/material";
+import useProfileCard from "./useProfileCard";
 
 /* -------------------------------------------------- */
-/*  Constants & helpers                              */
-/* -------------------------------------------------- */
-const REQUEST_BASE = process.env.NODE_ENV === "development" ? "http://localhost:6001/api" : globalThis.IN_ELECTRON_ENV ? "https://rebound.nexus/api" : "/api";
-const API_BASE = `${REQUEST_BASE}/users`;
-const cache = (u) => {
-	if (!u) return null;
-	const cleaned = u.replace(/([?&])t=\d+(&)?/, (_, sep, trailing) => (trailing ? sep : ""));
-	return `${cleaned}${cleaned.includes("?") ? "&" : "?"}t=${Date.now()}`;
-};
-
-const DEFAULT_USER = {
-	id: null,
-	displayName: "",
-	username: "",
-	bio: "",
-	avatarUrl: null,
-	bannerUrl: null,
-	friends: [],
-};
-
-function useFilePreview(initialUrl) {
-	const [file, setFile] = useState(null);
-	const [preview, setPrev] = useState(cache(initialUrl));
-
-	const onChange = (e) => {
-		const f = e.target.files?.[0];
-		if (!f) return;
-		setFile(f);
-		setPrev(URL.createObjectURL(f));
-	};
-
-	const reset = (url) => {
-		setFile(null);
-		setPrev(cache(url));
-	};
-
-	return { file, preview, onChange, reset };
-}
 
 const CameraInput = ({ onChange, sx }) => (
-	<IconButton component="label" sx={sx} size="small">
-		<input hidden type="file" accept="image/*" onChange={onChange} />
-		<Icons.CameraAlt fontSize="small" />
-	</IconButton>
+  <IconButton component="label" sx={sx} size="small">
+    <input hidden type="file" accept="image/*" onChange={onChange} />
+    <Icons.CameraAlt fontSize="small" />
+  </IconButton>
 );
 
 function FriendButtons({ status, friendId, profile, onAction }) {
-	switch (status) {
-		case "none":
-			return (
-				<Button
-					fullWidth
-					size="small"
-					variant="contained"
-					color="secondary"
-					startIcon={<Icons.PersonAdd />}
-					onClick={() => onAction("addfriend", { recipientId: profile.id }, `Sent request to ${profile.displayName}`)}
-				>
-					Add
-				</Button>
-			);
-		case "sent":
-			return (
-				<Button
-					fullWidth
-					size="small"
-					variant="outlined"
-					color="info"
-					startIcon={<Icons.PersonOff />}
-					onClick={() => onAction("cancelfriend", { friendId }, `Canceled request to ${profile.displayName}`, "info")}
-				>
-					Cancel
-				</Button>
-			);
-		case "received":
-			return (
-				<ButtonGroup fullWidth size="small" variant="contained">
-					<Button color="success" startIcon={<Icons.PersonAdd />} onClick={() => onAction("acceptfriend", { friendId }, `Accepted request from ${profile.displayName}`)}>
-						Accept
-					</Button>
-					<Button color="error" startIcon={<Icons.PersonRemove />} onClick={() => onAction("declinefriend", { friendId }, `Declined request from ${profile.displayName}`, "warning")}>
-						Decline
-					</Button>
-				</ButtonGroup>
-			);
-		case "friends":
-			return (
-				<Button
-					fullWidth
-					size="small"
-					variant="contained"
-					color="error"
-					startIcon={<Icons.PersonRemove />}
-					onClick={() => onAction("removefriend", { friendId }, `Removed ${profile.displayName} from friends`)}
-				>
-					Remove
-				</Button>
-			);
-		default:
-			return (
-				<Button fullWidth size="small" variant="contained" disabled>
-					---
-				</Button>
-			);
-	}
+  switch (status) {
+    case "none":
+      return (
+        <Button
+          fullWidth
+          size="small"
+          variant="contained"
+          color="secondary"
+          startIcon={<Icons.PersonAdd />}
+          onClick={() =>
+            onAction(
+              "addfriend",
+              { recipientId: profile.id },
+              `Sent request to ${profile.displayName}`,
+            )
+          }
+        >
+          Add
+        </Button>
+      );
+    case "sent":
+      return (
+        <Button
+          fullWidth
+          size="small"
+          variant="outlined"
+          color="info"
+          startIcon={<Icons.PersonOff />}
+          onClick={() =>
+            onAction(
+              "cancelfriend",
+              { friendId },
+              `Canceled request to ${profile.displayName}`,
+              "info",
+            )
+          }
+        >
+          Cancel
+        </Button>
+      );
+    case "received":
+      return (
+        <ButtonGroup fullWidth size="small" variant="contained">
+          <Button
+            color="success"
+            startIcon={<Icons.PersonAdd />}
+            onClick={() =>
+              onAction(
+                "acceptfriend",
+                { friendId },
+                `Accepted request from ${profile.displayName}`,
+              )
+            }
+          >
+            Accept
+          </Button>
+          <Button
+            color="error"
+            startIcon={<Icons.PersonRemove />}
+            onClick={() =>
+              onAction(
+                "declinefriend",
+                { friendId },
+                `Declined request from ${profile.displayName}`,
+                "warning",
+              )
+            }
+          >
+            Decline
+          </Button>
+        </ButtonGroup>
+      );
+    case "friends":
+      return (
+        <Button
+          fullWidth
+          size="small"
+          variant="contained"
+          color="error"
+          startIcon={<Icons.PersonRemove />}
+          onClick={() =>
+            onAction(
+              "removefriend",
+              { friendId },
+              `Removed ${profile.displayName} from friends`,
+            )
+          }
+        >
+          Remove
+        </Button>
+      );
+    default:
+      return (
+        <Button fullWidth size="small" variant="contained" disabled>
+          ---
+        </Button>
+      );
+  }
 }
 
-export default function ProfileCard({ user, self: forceSelf = false, type = "full", width = "auto", passStyle }) {
-	const dispatch = useDispatch();
-	const auth = useSelector((s) => s.auth);
+export default function ProfileCard({
+  user,
+  self: forceSelf = false,
+  type = "full",
+  width = "auto",
+  passStyle,
+}) {
+  const {
+    isSelf,
+    profile,
+    editMode,
+    setEdit,
+    name,
+    setName,
+    bio,
+    setBio,
+    banner,
+    avatar,
+    status,
+    friendId,
+    callApi,
+    saveProfile,
+  } = useProfileCard(user, forceSelf);
 
-	// determine if own profile
-	const isSelf = forceSelf || user?.id === auth.userId;
-	// rawData: either auth (for self) or user or DEFAULT_USER (when user=null)
-	const rawData = isSelf ? auth : (user ?? DEFAULT_USER);
+  /* ---------- placeholder when no user ---------- */
+  if (!user && !forceSelf) {
+    return <></>;
+  }
 
-	// hooks (always same order)
-	const [profile, setProfile] = useState(rawData);
-	const [editMode, setEdit] = useState(false);
-	const [name, setName] = useState(rawData.displayName);
-	const [bio, setBio] = useState(rawData.bio);
-	const banner = useFilePreview(rawData.bannerUrl);
-	const avatar = useFilePreview(rawData.avatarUrl);
+  if (type === "mini") return <Paper>mini</Paper>;
+  if (type === "popout") return <Paper>popout</Paper>;
 
-	// sync local state when rawData fields change
-	useEffect(() => {
-		setProfile(rawData);
-		setName(rawData.displayName);
-		setBio(rawData.bio);
-		banner.reset(rawData.bannerUrl);
-		avatar.reset(rawData.avatarUrl);
-	}, [rawData.id, rawData.displayName, rawData.bio, rawData.avatarUrl, rawData.bannerUrl]);
+  /* ---------- main render ---------- */
+  return (
+    <Paper
+      sx={{
+        width,
+        maxHeight: passStyle?.maxHeight,
+        display: "flex",
+        flexDirection: "column",
+        overflow: "hidden",
+        ...passStyle,
+      }}
+      elevation={3}
+    >
+      <Stack spacing={1} sx={{ p: 1, flex: 1 }}>
+        {/* Banner */}
+        <Box position="relative">
+          <Box
+            component="img"
+            src={
+              banner.preview ||
+              (window.isElectron ? "banner.webp" : "/banner.webp")
+            }
+            alt="banner"
+            sx={{
+              width: "100%",
+              height: 120,
+              borderRadius: 1,
+              objectFit: "cover",
+            }}
+            key={banner.preview}
+          />
+          {isSelf && editMode && (
+            <CameraInput
+              onChange={banner.onChange}
+              sx={{
+                position: "absolute",
+                top: 8,
+                right: 8,
+                bgcolor: "rgba(255,255,255,0.7)",
+              }}
+            />
+          )}
+        </Box>
 
-	/* ---------- socket watch ---------- */
-	const socket = socketIoHelper.getSocket();
-	const watchRef = useRef(null);
-	const watchId = profile.id;
+        {/* Avatar + Name */}
+        <Stack direction="row" spacing={2} alignItems="center">
+          <Box position="relative">
+            <Avatar
+              src={
+                avatar.preview ||
+                (window.isElectron ? "defaultpfp.webp" : "/defaultpfp.webp")
+              }
+              sx={{ width: 56, height: 56 }}
+            />
+            {isSelf && editMode && (
+              <CameraInput
+                onChange={avatar.onChange}
+                sx={{
+                  position: "absolute",
+                  bottom: -4,
+                  right: -4,
+                  bgcolor: "white",
+                }}
+              />
+            )}
+          </Box>
+          <Box flex={1} minWidth={0}>
+            {editMode ? (
+              <TextField
+                fullWidth
+                size="small"
+                label="Display Name"
+                value={name}
+                onChange={(e) => setName(e.target.value)}
+              />
+            ) : (
+              <Typography variant="h6" noWrap>
+                {profile.displayName}
+              </Typography>
+            )}
+            <Typography variant="body2" color="text.secondary">
+              @{profile.username}
+            </Typography>
+          </Box>
+        </Stack>
 
-	useEffect(() => {
-		if (!socket?.connected) return;
-		// unwatch when switching profile or entering edit
-		if (watchRef.current && (watchRef.current !== watchId || editMode)) {
-			socket.emit("unwatch_user", watchRef.current);
-			watchRef.current = null;
-		}
-		// watch when not editing
-		if (!editMode && watchId && watchRef.current !== watchId) {
-			socket.emit("watch_user", watchId);
-			watchRef.current = watchId;
-		}
-		// cleanup on unmount
-		return () => {
-			if (watchRef.current) {
-				socket.emit("unwatch_user", watchRef.current);
-				watchRef.current = null;
-			}
-		};
-	}, [socket, watchId, editMode]);
+        {/* Bio */}
+        <Paper variant="outlined" sx={{ p: 1, flex: 1, minHeight: 80 }}>
+          <Typography variant="subtitle2">About Me</Typography>
+          {editMode ? (
+            <TextField
+              fullWidth
+              multiline
+              rows={4}
+              label="Bio"
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+            />
+          ) : (
+            <Typography variant="body2" color="text.secondary">
+              {profile.bio || "This user hasn’t written a bio yet."}
+            </Typography>
+          )}
+        </Paper>
 
-	useEffect(() => {
-		if (!socket) return;
-		const onSaved = ([id, data]) => {
-			if (id !== watchId) return;
-			const av = data.avatarUrl ? cache(REQUEST_BASE + data.avatarUrl) : null;
-			const bn = data.bannerUrl ? cache(REQUEST_BASE + data.bannerUrl) : null;
-			setProfile((p) => ({ ...p, ...data, avatarUrl: av, bannerUrl: bn }));
-			avatar.reset(av);
-			banner.reset(bn);
-			setName(data.displayName);
-			setBio(data.bio);
-		};
-		socket.on("watched_user_saved", onSaved);
-		return () => {
-			socket.off("watched_user_saved", onSaved);
-		};
-	}, [socket, watchId, avatar, banner]);
-
-	/* ---------- friend-button derivation ---------- */
-	const { status, friendId } = useMemo(() => {
-		if (isSelf) return { status: "self", friendId: null };
-		const rel = profile.friends.find((f) => f.requester === auth.userId || f.recipient === auth.userId);
-		if (!rel) return { status: "none", friendId: null };
-		if (rel.confirmed) return { status: "friends", friendId: rel._id };
-		return rel.requester === auth.userId ? { status: "sent", friendId: rel._id } : { status: "received", friendId: rel._id };
-	}, [profile.friends, isSelf, auth.userId]);
-
-	/* ---------- API & save ---------- */
-	const callApi = (ep, data, msg, sev = "success") =>
-		axios
-			.put(`${API_BASE}/${ep}`, data, {
-				headers: { Authorization: `Bearer ${auth.authToken}` },
-			})
-			.then(() => dispatch(addSnackbar({ snackbarMsg: msg, snackbarSeverity: sev, autoHideDuration: 1500 })))
-			.catch(() => dispatch(addSnackbar({ snackbarMsg: "Error", snackbarSeverity: "error", autoHideDuration: 1500 })));
-
-	const saveProfile = () => {
-		const fd = new FormData();
-		fd.append("displayName", name);
-		fd.append("bio", bio);
-		if (banner.file) fd.append("banner", banner.file);
-		if (avatar.file) fd.append("avatar", avatar.file);
-
-		axios
-			.put(`${API_BASE}/modify`, fd, {
-				headers: { Authorization: `Bearer ${auth.authToken}` },
-			})
-			.then(({ data }) => {
-				const u = data.user;
-				const full = {
-					...u,
-					avatarUrl: u.avatarUrl ? cache(REQUEST_BASE + u.avatarUrl) : null,
-					bannerUrl: u.bannerUrl ? cache(REQUEST_BASE + u.bannerUrl) : null,
-				};
-				dispatch(
-					setLoggedIn({
-						avatarUrl: full.avatarUrl,
-						bannerUrl: full.bannerUrl,
-						displayName: full.displayName,
-						username: full.username,
-						bio: full.bio,
-					})
-				);
-				setProfile((p) => ({ ...p, ...full }));
-				dispatch(addSnackbar({ snackbarMsg: "Profile updated", snackbarSeverity: "success", autoHideDuration: 1500 }));
-				setEdit(false);
-				avatar.reset(full.avatarUrl);
-				banner.reset(full.bannerUrl);
-			})
-			.catch(() => dispatch(addSnackbar({ snackbarMsg: "Update failed", snackbarSeverity: "error", autoHideDuration: 1500 })));
-	};
-
-	/* ---------- placeholder when no user ---------- */
-	if (!user && !forceSelf) {
-		return <></>;
-	}
-
-	if (type === "mini") return <Paper>mini</Paper>;
-	if (type === "popout") return <Paper>popout</Paper>;
-
-	/* ---------- main render ---------- */
-	return (
-		<Paper
-			sx={{
-				width,
-				maxHeight: passStyle?.maxHeight,
-				display: "flex",
-				flexDirection: "column",
-				overflow: "hidden",
-				...passStyle,
-			}}
-			elevation={3}
-		>
-			<Stack spacing={1} sx={{ p: 1, flex: 1 }}>
-				{/* Banner */}
-				<Box position="relative">
-					<Box
-						component="img"
-						src={banner.preview || (window.isElectron ? "banner.webp" : "/banner.webp")}
-						alt="banner"
-						sx={{ width: "100%", height: 120, borderRadius: 1, objectFit: "cover" }}
-						key={banner.preview}
-					/>
-					{isSelf && editMode && <CameraInput onChange={banner.onChange} sx={{ position: "absolute", top: 8, right: 8, bgcolor: "rgba(255,255,255,0.7)" }} />}
-				</Box>
-
-				{/* Avatar + Name */}
-				<Stack direction="row" spacing={2} alignItems="center">
-					<Box position="relative">
-						<Avatar src={avatar.preview || (window.isElectron ? "defaultpfp.webp" : "/defaultpfp.webp")} sx={{ width: 56, height: 56 }} />
-						{isSelf && editMode && <CameraInput onChange={avatar.onChange} sx={{ position: "absolute", bottom: -4, right: -4, bgcolor: "white" }} />}
-					</Box>
-					<Box flex={1} minWidth={0}>
-						{editMode ? (
-							<TextField fullWidth size="small" label="Display Name" value={name} onChange={(e) => setName(e.target.value)} />
-						) : (
-							<Typography variant="h6" noWrap>
-								{profile.displayName}
-							</Typography>
-						)}
-						<Typography variant="body2" color="text.secondary">
-							@{profile.username}
-						</Typography>
-					</Box>
-				</Stack>
-
-				{/* Bio */}
-				<Paper variant="outlined" sx={{ p: 1, flex: 1, minHeight: 80 }}>
-					<Typography variant="subtitle2">About Me</Typography>
-					{editMode ? (
-						<TextField fullWidth multiline rows={4} label="Bio" value={bio} onChange={(e) => setBio(e.target.value)} />
-					) : (
-						<Typography variant="body2" color="text.secondary">
-							{profile.bio || "This user hasn’t written a bio yet."}
-						</Typography>
-					)}
-				</Paper>
-
-				{/* Actions */}
-				<Box sx={{ pt: 1 }}>
-					{isSelf ? (
-						editMode ? (
-							<Stack direction="row" spacing={1}>
-								<Button fullWidth variant="contained" size="small" onClick={saveProfile}>
-									Save
-								</Button>
-								<Button fullWidth variant="outlined" size="small" onClick={() => setEdit(false)}>
-									Cancel
-								</Button>
-							</Stack>
-						) : (
-							<Button fullWidth variant="contained" size="small" onClick={() => setEdit(true)}>
-								Edit Profile
-							</Button>
-						)
-					) : (
-						<FriendButtons status={status} friendId={friendId} profile={profile} onAction={callApi} />
-					)}
-				</Box>
-			</Stack>
-		</Paper>
-	);
+        {/* Actions */}
+        <Box sx={{ pt: 1 }}>
+          {isSelf ? (
+            editMode ? (
+              <Stack direction="row" spacing={1}>
+                <Button
+                  fullWidth
+                  variant="contained"
+                  size="small"
+                  onClick={saveProfile}
+                >
+                  Save
+                </Button>
+                <Button
+                  fullWidth
+                  variant="outlined"
+                  size="small"
+                  onClick={() => setEdit(false)}
+                >
+                  Cancel
+                </Button>
+              </Stack>
+            ) : (
+              <Button
+                fullWidth
+                variant="contained"
+                size="small"
+                onClick={() => setEdit(true)}
+              >
+                Edit Profile
+              </Button>
+            )
+          ) : (
+            <FriendButtons
+              status={status}
+              friendId={friendId}
+              profile={profile}
+              onAction={callApi}
+            />
+          )}
+        </Box>
+      </Stack>
+    </Paper>
+  );
 }

--- a/src/components/User/useProfileCard.js
+++ b/src/components/User/useProfileCard.js
@@ -1,0 +1,223 @@
+import { useState, useEffect, useMemo, useRef } from "react";
+import axios from "axios";
+import { useSelector, useDispatch } from "react-redux";
+import socketIoHelper from "../../helpers/socket";
+import { addSnackbar } from "../../slices/snackbarSlice";
+import { setLoggedIn } from "../../slices/authSlice";
+
+const REQUEST_BASE =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:6001/api"
+    : globalThis.IN_ELECTRON_ENV
+      ? "https://rebound.nexus/api"
+      : "/api";
+const API_BASE = `${REQUEST_BASE}/users`;
+
+const cache = (u) => {
+  if (!u) return null;
+  const cleaned = u.replace(/([?&])t=\d+(&)?/, (_, sep, trailing) =>
+    trailing ? sep : "",
+  );
+  return `${cleaned}${cleaned.includes("?") ? "&" : "?"}t=${Date.now()}`;
+};
+
+export function useFilePreview(initialUrl) {
+  const [file, setFile] = useState(null);
+  const [preview, setPrev] = useState(cache(initialUrl));
+
+  const onChange = (e) => {
+    const f = e.target.files?.[0];
+    if (!f) return;
+    setFile(f);
+    setPrev(URL.createObjectURL(f));
+  };
+
+  const reset = (url) => {
+    setFile(null);
+    setPrev(cache(url));
+  };
+
+  return { file, preview, onChange, reset };
+}
+
+export default function useProfileCard(user, forceSelf) {
+  const dispatch = useDispatch();
+  const auth = useSelector((s) => s.auth);
+
+  const isSelf = forceSelf || user?.id === auth.userId;
+  const rawData = isSelf
+    ? auth
+    : (user ?? {
+        id: null,
+        displayName: "",
+        username: "",
+        bio: "",
+        avatarUrl: null,
+        bannerUrl: null,
+        friends: [],
+      });
+
+  const [profile, setProfile] = useState(rawData);
+  const [editMode, setEdit] = useState(false);
+  const [name, setName] = useState(rawData.displayName);
+  const [bio, setBio] = useState(rawData.bio);
+  const banner = useFilePreview(rawData.bannerUrl);
+  const avatar = useFilePreview(rawData.avatarUrl);
+
+  useEffect(() => {
+    setProfile(rawData);
+    setName(rawData.displayName);
+    setBio(rawData.bio);
+    banner.reset(rawData.bannerUrl);
+    avatar.reset(rawData.avatarUrl);
+  }, [
+    rawData.id,
+    rawData.displayName,
+    rawData.bio,
+    rawData.avatarUrl,
+    rawData.bannerUrl,
+  ]);
+
+  const socket = socketIoHelper.getSocket();
+  const watchRef = useRef(null);
+  const watchId = profile.id;
+
+  useEffect(() => {
+    if (!socket?.connected) return;
+    if (watchRef.current && (watchRef.current !== watchId || editMode)) {
+      socket.emit("unwatch_user", watchRef.current);
+      watchRef.current = null;
+    }
+    if (!editMode && watchId && watchRef.current !== watchId) {
+      socket.emit("watch_user", watchId);
+      watchRef.current = watchId;
+    }
+    return () => {
+      if (watchRef.current) {
+        socket.emit("unwatch_user", watchRef.current);
+        watchRef.current = null;
+      }
+    };
+  }, [socket, watchId, editMode]);
+
+  useEffect(() => {
+    if (!socket) return;
+    const onSaved = ([id, data]) => {
+      if (id !== watchId) return;
+      const av = data.avatarUrl ? cache(REQUEST_BASE + data.avatarUrl) : null;
+      const bn = data.bannerUrl ? cache(REQUEST_BASE + data.bannerUrl) : null;
+      setProfile((p) => ({ ...p, ...data, avatarUrl: av, bannerUrl: bn }));
+      avatar.reset(av);
+      banner.reset(bn);
+      setName(data.displayName);
+      setBio(data.bio);
+    };
+    socket.on("watched_user_saved", onSaved);
+    return () => {
+      socket.off("watched_user_saved", onSaved);
+    };
+  }, [socket, watchId, avatar, banner]);
+
+  const { status, friendId } = useMemo(() => {
+    if (isSelf) return { status: "self", friendId: null };
+    const rel = profile.friends.find(
+      (f) => f.requester === auth.userId || f.recipient === auth.userId,
+    );
+    if (!rel) return { status: "none", friendId: null };
+    if (rel.confirmed) return { status: "friends", friendId: rel._id };
+    return rel.requester === auth.userId
+      ? { status: "sent", friendId: rel._id }
+      : { status: "received", friendId: rel._id };
+  }, [profile.friends, isSelf, auth.userId]);
+
+  const callApi = (ep, data, msg, sev = "success") =>
+    axios
+      .put(`${API_BASE}/${ep}`, data, {
+        headers: { Authorization: `Bearer ${auth.authToken}` },
+      })
+      .then(() =>
+        dispatch(
+          addSnackbar({
+            snackbarMsg: msg,
+            snackbarSeverity: sev,
+            autoHideDuration: 1500,
+          }),
+        ),
+      )
+      .catch(() =>
+        dispatch(
+          addSnackbar({
+            snackbarMsg: "Error",
+            snackbarSeverity: "error",
+            autoHideDuration: 1500,
+          }),
+        ),
+      );
+
+  const saveProfile = () => {
+    const fd = new FormData();
+    fd.append("displayName", name);
+    fd.append("bio", bio);
+    if (banner.file) fd.append("banner", banner.file);
+    if (avatar.file) fd.append("avatar", avatar.file);
+
+    axios
+      .put(`${API_BASE}/modify`, fd, {
+        headers: { Authorization: `Bearer ${auth.authToken}` },
+      })
+      .then(({ data }) => {
+        const u = data.user;
+        const full = {
+          ...u,
+          avatarUrl: u.avatarUrl ? cache(REQUEST_BASE + u.avatarUrl) : null,
+          bannerUrl: u.bannerUrl ? cache(REQUEST_BASE + u.bannerUrl) : null,
+        };
+        dispatch(
+          setLoggedIn({
+            avatarUrl: full.avatarUrl,
+            bannerUrl: full.bannerUrl,
+            displayName: full.displayName,
+            username: full.username,
+            bio: full.bio,
+          }),
+        );
+        setProfile((p) => ({ ...p, ...full }));
+        dispatch(
+          addSnackbar({
+            snackbarMsg: "Profile updated",
+            snackbarSeverity: "success",
+            autoHideDuration: 1500,
+          }),
+        );
+        setEdit(false);
+        avatar.reset(full.avatarUrl);
+        banner.reset(full.bannerUrl);
+      })
+      .catch(() =>
+        dispatch(
+          addSnackbar({
+            snackbarMsg: "Update failed",
+            snackbarSeverity: "error",
+            autoHideDuration: 1500,
+          }),
+        ),
+      );
+  };
+
+  return {
+    isSelf,
+    profile,
+    editMode,
+    setEdit,
+    name,
+    setName,
+    bio,
+    setBio,
+    banner,
+    avatar,
+    status,
+    friendId,
+    callApi,
+    saveProfile,
+  };
+}

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -1,9 +1,16 @@
-// src/pages/ChatPage.jsx
-import React, { useState, useEffect } from "react";
+import React from "react";
 import * as Icons from "@mui/icons-material";
-import { Box, Button, Divider, Paper, Popover, Typography, useTheme } from "@mui/material";
-import axios from "axios";
-import { useDispatch, useSelector } from "react-redux";
+import {
+  Box,
+  Button,
+  Divider,
+  Paper,
+  Popover,
+  Typography,
+  useTheme,
+} from "@mui/material";
+
+import useChatPage from "./useChatPage";
 
 import ChatRoomMenu from "../../components/Chat/ChatRoomMenu";
 import UserListMenu from "../../components/Chat/UserListMenu";
@@ -12,334 +19,161 @@ import ChatInput from "../../components/Chat/ChatInput";
 import MessageContextMenu from "../../components/Chat/MessageContextMenu";
 import ProfileCard from "../../components/User/ProfileCard";
 
-import socketIoHelper from "../../helpers/socket";
-import { setSocketRoom } from "../../slices/authSlice";
-import { addSnackbar } from "../../slices/snackbarSlice";
-
-/* -------------------------------------------------- */
-/*  Constants & helpers                               */
-/* -------------------------------------------------- */
-const REQUEST_BASE = process.env.NODE_ENV === "development" ? `http://localhost:6001/api` : globalThis.IN_ELECTRON_ENV ? `https://rebound.nexus/api` : "/api";
-
-// cache‑bust so new images show up instantly
-const cache = (u) => {
-	if (!u) return null;
-	// remove any existing “t=” parameter
-	const cleaned = u.replace(/([?&])t=\d+(&)?/, (_, sep, trailing) => (trailing ? sep : ""));
-	// append new timestamp (use & if there are still other query params)
-	return `${cleaned}${cleaned.includes("?") ? "&" : "?"}t=${Date.now()}`;
-};
-
-// sanitize message objects with cached avatar URLs
-const mapMessages = (msgs) =>
-	msgs.map((m) => ({
-		...m,
-		sender: {
-			...m.sender,
-			avatarUrl: m.sender?.avatarUrl ? cache(REQUEST_BASE + m.sender.avatarUrl) : null,
-		},
-	}));
-
-/* fetch complete profile for a given user id */
-async function getUserInfo(userId, authToken) {
-	const url = `${REQUEST_BASE}/users/profile`;
-
-	try {
-		const { data } = await axios.get(url, {
-			headers: {
-				"Content-Type": "application/json",
-				"Allow-Control-Allow-Origin": "*",
-				Authorization: `Bearer ${authToken}`,
-			},
-			params: { id: userId },
-		});
-
-		const u = data.user;
-		return {
-			...u,
-			avatarUrl: u.avatarUrl ? cache(REQUEST_BASE + u.avatarUrl) : null,
-			bannerUrl: u.bannerUrl ? cache(REQUEST_BASE + u.bannerUrl) : null,
-		};
-	} catch (err) {
-		console.error(err);
-		return null;
-	}
-}
-
-/* -------------------------------------------------- */
-/*  Main component                                   */
-/* -------------------------------------------------- */
 function ChatPage() {
-	/* ----- global & theme ----- */
-	const authState = useSelector((state) => state.auth);
-	const dispatch = useDispatch();
-	const theme = useTheme();
+  const theme = useTheme();
+  const {
+    authState,
+    message,
+    setMessage,
+    messages,
+    channels,
+    users,
+    roomAnchorEl,
+    setRoomAnchorEl,
+    userListAnchorEl,
+    setUserListAnchorEl,
+    userPreviewEl,
+    setUserPreviewEl,
+    userPreviewUser,
+    setUserPreviewUser,
+    selectedMessage,
+    msgMenuPos,
+    editingMessageId,
+    editingText,
+    setEditingText,
+    setMessages,
+    sendMessage,
+    clickRoomSelect,
+    clickUserList,
+    previewUser,
+    openMessageMenu,
+    closeMessageMenu,
+    startEditSelectedMessage,
+    confirmDeleteSelectedMessage,
+    commitEditMessage,
+    cancelEditMessage,
+  } = useChatPage();
 
-	/* ----- local UI state ---- */
-	const [message, setMessage] = useState("");
-	const [messages, setMessages] = useState([]);
-	const [channels, setChannels] = useState({});
-	const [users, setUsers] = useState([]);
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexGrow: 1,
+        flexDirection: "column",
+        justifyContent: "center",
+        overflow: "hidden",
+      }}
+    >
+      {/* user preview popover */}
+      <Popover
+        anchorOrigin={{ vertical: "top", horizontal: "right" }}
+        transformOrigin={{ vertical: "bottom", horizontal: "left" }}
+        anchorEl={userPreviewEl}
+        open={Boolean(userPreviewEl)}
+        onClose={() => {
+          setUserPreviewEl(null);
+          setUserPreviewUser(null);
+        }}
+        sx={{ mb: 2 }}
+      >
+        <ProfileCard
+          self={authState.userId === userPreviewUser?.id}
+          user={userPreviewUser}
+          width="300px"
+          passStyle={{ maxWidth: "300px" }}
+        />
+      </Popover>
 
-	/* menus & preview popovers */
-	const [roomAnchorEl, setRoomAnchorEl] = useState(null);
-	const [userListAnchorEl, setUserListAnchorEl] = useState(null);
-	const [userPreviewEl, setUserPreviewEl] = useState(null);
-	const [userPreviewUser, setUserPreviewUser] = useState(null);
-	const [msgMenuPos, setMsgMenuPos] = useState(null);
-	const [selectedMessage, setSelectedMessage] = useState(null);
-	const [editingMessageId, setEditingMessageId] = useState(null);
-	const [editingText, setEditingText] = useState("");
+      {/* menus */}
+      <ChatRoomMenu
+        anchorEl={roomAnchorEl}
+        setAnchorEl={setRoomAnchorEl}
+        channels={channels}
+        setMessages={setMessages}
+      />
+      <UserListMenu
+        anchorEl={userListAnchorEl}
+        setAnchorEl={setUserListAnchorEl}
+        users={users}
+      />
+      <MessageContextMenu
+        anchorPosition={msgMenuPos}
+        setAnchorPosition={closeMessageMenu}
+        onEdit={startEditSelectedMessage}
+        onDelete={confirmDeleteSelectedMessage}
+        allowEdit={selectedMessage?.sender?._id === authState.userId}
+      />
 
-	/* -------------------------------------------------- */
-	/*  Socket lifecycle                                  */
-	/* -------------------------------------------------- */
-	// grab the current socket instance once per render
-	const socket = socketIoHelper.getSocket();
+      {/* shell */}
+      <Paper
+        sx={{
+          position: "relative",
+          display: "flex",
+          flexDirection: "column",
+          width: "100%",
+          flexGrow: 1,
+          height: "100%",
+        }}
+      >
+        {/* header */}
+        <Box
+          sx={{
+            display: "flex",
+            alignItems: "center",
+            p: 1,
+            height: `calc(56px * ${theme.spacing(2)})`,
+          }}
+        >
+          <Button
+            variant="outlined"
+            color="secondary"
+            startIcon={<Icons.MenuRounded />}
+            onClick={clickRoomSelect}
+            sx={{ textTransform: "initial" }}
+          >
+            <Typography variant="h6" align="center">
+              {channels[authState.socketInfo.currentRoom]?.name || "No Room"}
+            </Typography>
+          </Button>
+          <Box flexGrow={1} />
+          <Button
+            variant="outlined"
+            color="secondary"
+            endIcon={<Icons.PeopleRounded />}
+            onClick={clickUserList}
+            sx={{ textTransform: "initial" }}
+          >
+            <Typography variant="h6" align="center">
+              {users.length}
+            </Typography>
+          </Button>
+        </Box>
 
-	useEffect(() => {
-		if (authState.loggedIn && socket) {
-			// rooms
-			socket.on("room_list", ([idMap, roomObjs]) => {
-				setChannels(roomObjs);
-				if (!authState.socketInfo.currentRoom) {
-					dispatch(
-						setSocketRoom({
-							lastRoom: null,
-							currentRoom: Object.keys(idMap)[0] || null,
-						})
-					);
-				}
-			});
-			// messages
-			socket.on("joined_room", (_id, msgs) => setMessages(mapMessages(msgs)));
-			socket.on("message_sent", (_id, msgs) => setMessages(mapMessages(msgs)));
-			socket.on("new_message", (_id, msgs) => setMessages(mapMessages(msgs)));
-			socket.on("messages_updated", (_id, msgs) => setMessages(mapMessages(msgs)));
-			// presence
-			socket.on("user_list", (_roomId, list, sender, evt) => {
-				if (sender.id !== authState.userId) {
-					dispatch(
-						addSnackbar({
-							snackbarMsg: `'${sender.displayName}' ${evt === "join" ? "joined!" : "left."}`,
-							snackbarSeverity: "info",
-							autoHideDuration: 1500,
-						})
-					);
-				}
-				setUsers(list);
-			});
-			// initial pull (buffered until actually connected)
-			socket.emit("list_rooms");
-		} else if (!authState.loggingIn && !authState.loggedIn) {
-			// only warn if truly not logged in
-			dispatch(
-				addSnackbar({
-					snackbarMsg: "Login or register to use this page.",
-					snackbarSeverity: "warning",
-					autoHideDuration: 1500,
-				})
-			);
-		}
+        <Divider />
 
-		return () => {
-			if (socket) {
-				socket.off("room_list");
-				socket.off("joined_room");
-				socket.off("message_sent");
-				socket.off("new_message");
-				socket.off("messages_updated");
-				socket.off("user_list");
-			}
-			setChannels({});
-			setMessages([]);
-			setUsers([]);
-		};
-		// now re-run this effect not just on auth flags, but also as soon as the socket object changes
-	}, [authState.loggedIn, authState.loggingIn, authState.socketInfo.currentRoom, authState.userId, socket, dispatch]);
+        {/* messages */}
+        <Box sx={{ flexGrow: 1, position: "relative", width: "100%" }}>
+          <ChatArea
+            messages={messages}
+            previewUser={previewUser}
+            onContextMenu={openMessageMenu}
+            editingMessageId={editingMessageId}
+            editingText={editingText}
+            setEditingText={setEditingText}
+            commitEdit={commitEditMessage}
+            cancelEdit={cancelEditMessage}
+          />
+        </Box>
 
-	/* Clear user list when switching rooms */
-	useEffect(() => {
-		setUsers([]);
-	}, [authState.socketInfo.currentRoom]);
-
-	/* Reset currentRoom on unmount */
-	useEffect(
-		() => () => {
-			dispatch(setSocketRoom({ currentRoom: null }));
-		},
-		[dispatch]
-	);
-
-	/* -------------------------------------------------- */
-	/*  Handlers                                          */
-	/* -------------------------------------------------- */
-	const sendMessage = (e) => {
-		e?.preventDefault();
-
-		if (!message || !authState.socketInfo.currentRoom) return;
-
-		const socket = socketIoHelper.getSocket();
-		socket.emit("message_room", [authState.socketInfo.currentRoom, message]);
-		setMessage("");
-	};
-
-	const clickRoomSelect = (e) => {
-		setRoomAnchorEl(e.currentTarget);
-		setUserListAnchorEl(null);
-	};
-
-	const clickUserList = (e) => {
-		setUserListAnchorEl(e.currentTarget);
-		setRoomAnchorEl(null);
-	};
-
-	const previewUser = async (elRef, u) => {
-		if (!elRef?.current) {
-			setUserPreviewEl(null);
-			setUserPreviewUser(null);
-			return;
-		}
-
-		if (!u?._id) return;
-
-		const info = await getUserInfo(u._id, authState.authToken);
-		if (info) {
-			setUserPreviewEl(elRef.current);
-			setUserPreviewUser(info);
-		}
-	};
-
-	const openMessageMenu = (msg, pos) => {
-		setSelectedMessage(msg);
-		setMsgMenuPos(pos);
-	};
-
-	const closeMessageMenu = () => {
-		setMsgMenuPos(null);
-		setSelectedMessage(null);
-	};
-
-	const startEditSelectedMessage = () => {
-		if (!selectedMessage) return;
-		setEditingMessageId(selectedMessage._id);
-		setEditingText(selectedMessage.content);
-		closeMessageMenu();
-	};
-
-	const confirmDeleteSelectedMessage = () => {
-		if (!selectedMessage) return;
-		const socket = socketIoHelper.getSocket();
-		socket.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
-		closeMessageMenu();
-	};
-
-	const commitEditMessage = () => {
-		if (!editingMessageId) return;
-		const socket = socketIoHelper.getSocket();
-		socket.emit("edit_message", authState.socketInfo.currentRoom, editingMessageId, editingText);
-		setEditingMessageId(null);
-		setEditingText("");
-	};
-
-	const cancelEditMessage = () => {
-		setEditingMessageId(null);
-		setEditingText("");
-	};
-
-	/* -------------------------------------------------- */
-	/*  Render                                            */
-	/* -------------------------------------------------- */
-	return (
-		<Box
-			sx={{
-				display: "flex",
-				flexGrow: 1,
-				flexDirection: "column",
-				justifyContent: "center",
-				overflow: "hidden",
-			}}
-		>
-			{/* user preview popover */}
-			<Popover
-				anchorOrigin={{ vertical: "top", horizontal: "right" }}
-				transformOrigin={{ vertical: "bottom", horizontal: "left" }}
-				anchorEl={userPreviewEl}
-				open={Boolean(userPreviewEl)}
-				onClose={() => {
-					setUserPreviewEl(null);
-					setUserPreviewUser(null);
-				}}
-				sx={{ mb: 2 }}
-			>
-				<ProfileCard self={authState.userId === userPreviewUser?.id} user={userPreviewUser} width="300px" passStyle={{ maxWidth: "300px" }} />
-			</Popover>
-
-			{/* menus */}
-			<ChatRoomMenu anchorEl={roomAnchorEl} setAnchorEl={setRoomAnchorEl} channels={channels} setMessages={setMessages} />
-			<UserListMenu anchorEl={userListAnchorEl} setAnchorEl={setUserListAnchorEl} users={users} />
-			<MessageContextMenu
-				anchorPosition={msgMenuPos}
-				setAnchorPosition={closeMessageMenu}
-				onEdit={startEditSelectedMessage}
-				onDelete={confirmDeleteSelectedMessage}
-				allowEdit={selectedMessage?.sender?._id === authState.userId}
-			/>
-
-			{/* shell */}
-			<Paper
-				sx={{
-					position: "relative",
-					display: "flex",
-					flexDirection: "column",
-					width: "100%",
-					flexGrow: 1,
-					height: "100%",
-				}}
-			>
-				{/* header */}
-				<Box
-					sx={{
-						display: "flex",
-						alignItems: "center",
-						p: 1,
-						height: `calc(56px * ${theme.spacing(2)})`,
-					}}
-				>
-					<Button variant="outlined" color="secondary" startIcon={<Icons.MenuRounded />} onClick={clickRoomSelect} sx={{ textTransform: "initial" }}>
-						<Typography variant="h6" align="center">
-							{channels[authState.socketInfo.currentRoom]?.name || "No Room"}
-						</Typography>
-					</Button>
-					<Box flexGrow={1} />
-					<Button variant="outlined" color="secondary" endIcon={<Icons.PeopleRounded />} onClick={clickUserList} sx={{ textTransform: "initial" }}>
-						<Typography variant="h6" align="center">
-							{users.length}
-						</Typography>
-					</Button>
-				</Box>
-
-				<Divider />
-
-				{/* messages */}
-				<Box sx={{ flexGrow: 1, position: "relative", width: "100%" }}>
-					<ChatArea
-						messages={messages}
-						previewUser={previewUser}
-						onContextMenu={openMessageMenu}
-						editingMessageId={editingMessageId}
-						editingText={editingText}
-						setEditingText={setEditingText}
-						commitEdit={commitEditMessage}
-						cancelEdit={cancelEditMessage}
-					/>
-				</Box>
-
-				{/* input */}
-				<ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} />
-			</Paper>
-		</Box>
-	);
+        {/* input */}
+        <ChatInput
+          message={message}
+          setMessage={setMessage}
+          sendMessage={sendMessage}
+        />
+      </Paper>
+    </Box>
+  );
 }
 
 export default React.memo(ChatPage);

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -1,0 +1,262 @@
+import { useState, useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import axios from "axios";
+import socketIoHelper from "../../helpers/socket";
+import { setSocketRoom } from "../../slices/authSlice";
+import { addSnackbar } from "../../slices/snackbarSlice";
+
+const REQUEST_BASE =
+  process.env.NODE_ENV === "development"
+    ? `http://localhost:6001/api`
+    : globalThis.IN_ELECTRON_ENV
+      ? `https://rebound.nexus/api`
+      : "/api";
+
+const cache = (u) => {
+  if (!u) return null;
+  const cleaned = u.replace(/([?&])t=\d+(&)?/, (_, sep, trailing) =>
+    trailing ? sep : "",
+  );
+  return `${cleaned}${cleaned.includes("?") ? "&" : "?"}t=${Date.now()}`;
+};
+
+const mapMessages = (msgs) =>
+  msgs.map((m) => ({
+    ...m,
+    sender: {
+      ...m.sender,
+      avatarUrl: m.sender?.avatarUrl
+        ? cache(REQUEST_BASE + m.sender.avatarUrl)
+        : null,
+    },
+  }));
+
+async function getUserInfo(userId, authToken) {
+  const url = `${REQUEST_BASE}/users/profile`;
+  try {
+    const { data } = await axios.get(url, {
+      headers: {
+        "Content-Type": "application/json",
+        "Allow-Control-Allow-Origin": "*",
+        Authorization: `Bearer ${authToken}`,
+      },
+      params: { id: userId },
+    });
+    const u = data.user;
+    return {
+      ...u,
+      avatarUrl: u.avatarUrl ? cache(REQUEST_BASE + u.avatarUrl) : null,
+      bannerUrl: u.bannerUrl ? cache(REQUEST_BASE + u.bannerUrl) : null,
+    };
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+}
+
+export default function useChatPage() {
+  const authState = useSelector((state) => state.auth);
+  const dispatch = useDispatch();
+
+  const [message, setMessage] = useState("");
+  const [messages, setMessages] = useState([]);
+  const [channels, setChannels] = useState({});
+  const [users, setUsers] = useState([]);
+
+  const [roomAnchorEl, setRoomAnchorEl] = useState(null);
+  const [userListAnchorEl, setUserListAnchorEl] = useState(null);
+  const [userPreviewEl, setUserPreviewEl] = useState(null);
+  const [userPreviewUser, setUserPreviewUser] = useState(null);
+  const [msgMenuPos, setMsgMenuPos] = useState(null);
+  const [selectedMessage, setSelectedMessage] = useState(null);
+  const [editingMessageId, setEditingMessageId] = useState(null);
+  const [editingText, setEditingText] = useState("");
+
+  const socket = socketIoHelper.getSocket();
+
+  useEffect(() => {
+    if (authState.loggedIn && socket) {
+      socket.on("room_list", ([idMap, roomObjs]) => {
+        setChannels(roomObjs);
+        if (!authState.socketInfo.currentRoom) {
+          dispatch(
+            setSocketRoom({
+              lastRoom: null,
+              currentRoom: Object.keys(idMap)[0] || null,
+            }),
+          );
+        }
+      });
+      socket.on("joined_room", (_id, msgs) => setMessages(mapMessages(msgs)));
+      socket.on("message_sent", (_id, msgs) => setMessages(mapMessages(msgs)));
+      socket.on("new_message", (_id, msgs) => setMessages(mapMessages(msgs)));
+      socket.on("messages_updated", (_id, msgs) =>
+        setMessages(mapMessages(msgs)),
+      );
+      socket.on("user_list", (_roomId, list, sender, evt) => {
+        if (sender.id !== authState.userId) {
+          dispatch(
+            addSnackbar({
+              snackbarMsg: `'${sender.displayName}' ${evt === "join" ? "joined!" : "left."}`,
+              snackbarSeverity: "info",
+              autoHideDuration: 1500,
+            }),
+          );
+        }
+        setUsers(list);
+      });
+      socket.emit("list_rooms");
+    } else if (!authState.loggingIn && !authState.loggedIn) {
+      dispatch(
+        addSnackbar({
+          snackbarMsg: "Login or register to use this page.",
+          snackbarSeverity: "warning",
+          autoHideDuration: 1500,
+        }),
+      );
+    }
+
+    return () => {
+      if (socket) {
+        socket.off("room_list");
+        socket.off("joined_room");
+        socket.off("message_sent");
+        socket.off("new_message");
+        socket.off("messages_updated");
+        socket.off("user_list");
+      }
+      setChannels({});
+      setMessages([]);
+      setUsers([]);
+    };
+  }, [
+    authState.loggedIn,
+    authState.loggingIn,
+    authState.socketInfo.currentRoom,
+    authState.userId,
+    socket,
+    dispatch,
+  ]);
+
+  useEffect(() => {
+    setUsers([]);
+  }, [authState.socketInfo.currentRoom]);
+
+  useEffect(
+    () => () => {
+      dispatch(setSocketRoom({ currentRoom: null }));
+    },
+    [dispatch],
+  );
+
+  const sendMessage = (e) => {
+    e?.preventDefault();
+    if (!message || !authState.socketInfo.currentRoom) return;
+    const s = socketIoHelper.getSocket();
+    s.emit("message_room", [authState.socketInfo.currentRoom, message]);
+    setMessage("");
+  };
+
+  const clickRoomSelect = (e) => {
+    setRoomAnchorEl(e.currentTarget);
+    setUserListAnchorEl(null);
+  };
+
+  const clickUserList = (e) => {
+    setUserListAnchorEl(e.currentTarget);
+    setRoomAnchorEl(null);
+  };
+
+  const previewUser = async (elRef, u) => {
+    if (!elRef?.current) {
+      setUserPreviewEl(null);
+      setUserPreviewUser(null);
+      return;
+    }
+    if (!u?._id) return;
+    const info = await getUserInfo(u._id, authState.authToken);
+    if (info) {
+      setUserPreviewEl(elRef.current);
+      setUserPreviewUser(info);
+    }
+  };
+
+  const openMessageMenu = (msg, pos) => {
+    setSelectedMessage(msg);
+    setMsgMenuPos(pos);
+  };
+
+  const closeMessageMenu = () => {
+    setMsgMenuPos(null);
+    setSelectedMessage(null);
+  };
+
+  const startEditSelectedMessage = () => {
+    if (!selectedMessage) return;
+    setEditingMessageId(selectedMessage._id);
+    setEditingText(selectedMessage.content);
+    closeMessageMenu();
+  };
+
+  const confirmDeleteSelectedMessage = () => {
+    if (!selectedMessage) return;
+    const s = socketIoHelper.getSocket();
+    s.emit(
+      "delete_message",
+      authState.socketInfo.currentRoom,
+      selectedMessage._id,
+    );
+    closeMessageMenu();
+  };
+
+  const commitEditMessage = () => {
+    if (!editingMessageId) return;
+    const s = socketIoHelper.getSocket();
+    s.emit(
+      "edit_message",
+      authState.socketInfo.currentRoom,
+      editingMessageId,
+      editingText,
+    );
+    setEditingMessageId(null);
+    setEditingText("");
+  };
+
+  const cancelEditMessage = () => {
+    setEditingMessageId(null);
+    setEditingText("");
+  };
+
+  return {
+    authState,
+    message,
+    setMessage,
+    messages,
+    setMessages,
+    channels,
+    users,
+    roomAnchorEl,
+    setRoomAnchorEl,
+    userListAnchorEl,
+    setUserListAnchorEl,
+    userPreviewEl,
+    setUserPreviewEl,
+    userPreviewUser,
+    setUserPreviewUser,
+    msgMenuPos,
+    selectedMessage,
+    editingMessageId,
+    editingText,
+    setEditingText,
+    sendMessage,
+    clickRoomSelect,
+    clickUserList,
+    previewUser,
+    openMessageMenu,
+    closeMessageMenu,
+    startEditSelectedMessage,
+    confirmDeleteSelectedMessage,
+    commitEditMessage,
+    cancelEditMessage,
+  };
+}

--- a/src/routes/FriendPage/FriendListItem.jsx
+++ b/src/routes/FriendPage/FriendListItem.jsx
@@ -1,0 +1,159 @@
+import React from "react";
+import {
+  Paper,
+  Box,
+  Avatar,
+  Typography,
+  Button,
+  Stack,
+  Tooltip,
+} from "@mui/material";
+import ChatIcon from "@mui/icons-material/Chat";
+import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
+import CancelIcon from "@mui/icons-material/Cancel";
+import CheckCircleIcon from "@mui/icons-material/CheckCircle";
+import HighlightOffIcon from "@mui/icons-material/HighlightOff";
+
+const defaultAvatar = window.isElectron
+  ? "defaultpfp.webp"
+  : "/defaultpfp.webp";
+
+const FriendListItem = React.forwardRef(
+  ({ relation, profile, status, onPreview, onChat, onAction }, ref) => (
+    <Paper
+      ref={ref}
+      sx={{
+        p: 2,
+        display: "flex",
+        justifyContent: "space-between",
+        flexDirection: { xs: "column", sm: "row" },
+        alignItems: "center",
+        transition: "box-shadow .3s",
+        "&:hover": { boxShadow: 6 },
+        border: status === "friends" ? "none" : 2,
+        borderColor:
+          status === "sent"
+            ? "info.main"
+            : status === "received"
+              ? "warning.main"
+              : "grey.300",
+        gap: 1,
+      }}
+      elevation={2}
+      onClick={() => onPreview(profile.id, relation._id)}
+    >
+      <Box sx={{ flexDirection: "row", display: "flex", flexGrow: 1 }}>
+        <Avatar
+          src={profile.avatarUrl || defaultAvatar}
+          sx={{
+            width: { xs: 40, sm: 56 },
+            height: { xs: 40, sm: 56 },
+            mb: 0,
+            mr: 2,
+          }}
+        />
+        <Box flex={1} minWidth={0} sx={{ mr: { sm: 2 } }}>
+          <Typography variant="h6" noWrap>
+            {profile.displayName}
+          </Typography>
+          <Typography variant="body2" color="text.secondary" noWrap>
+            @{profile.username}
+          </Typography>
+        </Box>
+      </Box>
+      <Stack direction="row" spacing={1} flexWrap="wrap">
+        {status === "friends" && (
+          <>
+            <Tooltip title="Start Chat">
+              <Button
+                startIcon={<ChatIcon />}
+                variant="contained"
+                color="info"
+                size="small"
+                onClick={() => onChat(profile.id)}
+              >
+                Chat
+              </Button>
+            </Tooltip>
+            <Tooltip title="Remove Friend">
+              <Button
+                startIcon={<PersonRemoveIcon />}
+                variant="outlined"
+                color="error"
+                size="small"
+                onClick={() =>
+                  onAction(
+                    "removefriend",
+                    { friendId: relation._id },
+                    relation._id,
+                  )
+                }
+              >
+                Remove
+              </Button>
+            </Tooltip>
+          </>
+        )}
+        {status === "sent" && (
+          <Tooltip title="Cancel Request">
+            <Button
+              startIcon={<CancelIcon />}
+              variant="outlined"
+              color="warning"
+              size="small"
+              onClick={() =>
+                onAction(
+                  "cancelfriend",
+                  { friendId: relation._id },
+                  relation._id,
+                )
+              }
+            >
+              Cancel
+            </Button>
+          </Tooltip>
+        )}
+        {status === "received" && (
+          <>
+            <Tooltip title="Accept Request">
+              <Button
+                startIcon={<CheckCircleIcon />}
+                variant="contained"
+                color="success"
+                size="small"
+                onClick={() =>
+                  onAction(
+                    "acceptfriend",
+                    { friendId: relation._id },
+                    relation._id,
+                  )
+                }
+              >
+                Accept
+              </Button>
+            </Tooltip>
+            <Tooltip title="Decline Request">
+              <Button
+                startIcon={<HighlightOffIcon />}
+                variant="outlined"
+                color="error"
+                size="small"
+                onClick={() =>
+                  onAction(
+                    "declinefriend",
+                    { friendId: relation._id },
+                    relation._id,
+                  )
+                }
+              >
+                Decline
+              </Button>
+            </Tooltip>
+          </>
+        )}
+      </Stack>
+    </Paper>
+  ),
+);
+
+export default FriendListItem;

--- a/src/routes/FriendPage/FriendPage.route.jsx
+++ b/src/routes/FriendPage/FriendPage.route.jsx
@@ -1,272 +1,84 @@
 // src/pages/FriendsPage.jsx
-import React, { useState, useEffect, useRef } from "react";
-import axios from "axios";
-import { useSelector, useDispatch } from "react-redux";
+import React from "react";
+import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
-import socketIoHelper from "../../helpers/socket";
-import { Box, Paper, Avatar, Typography, Button, Stack, Tooltip, Popover } from "@mui/material";
-import ChatIcon from "@mui/icons-material/Chat";
-import PersonRemoveIcon from "@mui/icons-material/PersonRemove";
-import CancelIcon from "@mui/icons-material/Cancel";
-import CheckCircleIcon from "@mui/icons-material/CheckCircle";
-import HighlightOffIcon from "@mui/icons-material/HighlightOff";
+import { Box, Stack, Popover, Typography } from "@mui/material";
 import ProfileCard from "../../components/User/ProfileCard";
-import { setSocketRoom } from "../../slices/authSlice";
-
-// API base configuration
-const REQUEST_BASE = process.env.NODE_ENV === "development" ? "http://localhost:6001/api" : globalThis.IN_ELECTRON_ENV ? "https://rebound.nexus/api" : "/api";
-const API_BASE = `${REQUEST_BASE}/users`;
-
-// append timestamp and remove old
-const cache = (u) => {
-	if (!u) return null;
-	const cleaned = u.replace(/([?&])t=\d+(&)?/, (_, sep, trailing) => (trailing ? sep : ""));
-	return `${cleaned}${cleaned.includes("?") ? "&" : "?"}t=${Date.now()}`;
-};
-
-// fetch complete profile for a given user id
-async function getUserInfo(userId, authToken) {
-	const url = `${REQUEST_BASE}/users/profile`;
-	try {
-		const { data } = await axios.get(url, {
-			headers: {
-				"Content-Type": "application/json",
-				"Allow-Control-Allow-Origin": "*",
-				Authorization: `Bearer ${authToken}`,
-			},
-			params: { id: userId },
-		});
-		const u = data.user;
-		return {
-			...u,
-			avatarUrl: u.avatarUrl ? cache(REQUEST_BASE + u.avatarUrl) : null,
-			bannerUrl: u.bannerUrl ? cache(REQUEST_BASE + u.bannerUrl) : null,
-		};
-	} catch (err) {
-		console.error(err);
-		return null;
-	}
-}
+import useFriendPage from "./useFriendPage";
+import FriendListItem from "./FriendListItem";
 
 export default function FriendsPage() {
-	const dispatch = useDispatch();
-	const navigate = useNavigate();
-	const auth = useSelector((state) => state.auth);
-	const [friendItems, setFriendItems] = useState([]);
-	const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+  const auth = useSelector((state) => state.auth);
+  const {
+    friendItems,
+    loading,
+    paperRefs,
+    userPreviewEl,
+    setUserPreviewEl,
+    userPreviewUser,
+    setUserPreviewUser,
+    handleProfilePreview,
+    callApi,
+  } = useFriendPage();
 
-	// profile preview popover state
-	const paperRefs = useRef({});
-	const [userPreviewEl, setUserPreviewEl] = useState(null);
-	const [userPreviewUser, setUserPreviewUser] = useState(null);
+  const handleChat = () => navigate("/chat");
 
-	// Close preview if anchor node is removed (e.g., after unfriending)
-	useEffect(() => {
-		if (userPreviewEl && !document.body.contains(userPreviewEl)) {
-			setUserPreviewEl(null);
-			setUserPreviewUser(null);
-		}
-	}, [friendItems, userPreviewEl]);
+  if (!auth.loggedIn) return <Typography>Please login.</Typography>;
+  if (loading) return <Typography>Loading friends...</Typography>;
+  if (!friendItems.length)
+    return <Typography>No friends or pending requests.</Typography>;
 
-	// preview handler
-	// preview handler: look up the ref by relationId
-	const handleProfilePreview = async (userId, relationId) => {
-		if (!userId) return;
-		const info = await getUserInfo(userId, auth.authToken);
-		if (info && paperRefs.current[relationId]) {
-			setUserPreviewEl(paperRefs.current[relationId]);
-			setUserPreviewUser(info);
-		}
-	};
+  return (
+    <Box
+      sx={{
+        display: "flex",
+        flexDirection: { xs: "column", sm: "row" },
+        justifyContent: "flex-start",
+        overflow: "auto",
+        flexGrow: 1,
+      }}
+    >
+      <Popover
+        anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
+        transformOrigin={{ vertical: "top", horizontal: "center" }}
+        anchorEl={userPreviewEl}
+        open={Boolean(userPreviewEl)}
+        onClose={() => {
+          setUserPreviewEl(null);
+          setUserPreviewUser(null);
+        }}
+        sx={{ mb: 2 }}
+      >
+        <ProfileCard
+          self={auth.userId === userPreviewUser?.id}
+          user={userPreviewUser}
+          width="300px"
+          passStyle={{ maxWidth: "300px" }}
+        />
+      </Popover>
 
-	useEffect(() => {
-		if (!auth.loggedIn) {
-			setLoading(false);
-			return;
-		}
-		let isMounted = true;
-		const socket = socketIoHelper.getSocket();
-
-		async function loadRelations() {
-			setLoading(true);
-			try {
-				const res = await axios.get(`${API_BASE}/profile`, {
-					headers: { Authorization: `Bearer ${auth.authToken}` },
-				});
-				const relations = res.data.user.friends;
-				const items = await Promise.all(
-					relations.map(async (rel) => {
-						const myId = auth.userId;
-						let status, otherId;
-						if (rel.confirmed) {
-							status = "friends";
-							otherId = rel.requester === myId ? rel.recipient : rel.requester;
-						} else if (rel.requester === myId) {
-							status = "sent";
-							otherId = rel.recipient;
-						} else {
-							status = "received";
-							otherId = rel.requester;
-						}
-						const profileRes = await axios.get(`${API_BASE}/profile`, {
-							headers: { Authorization: `Bearer ${auth.authToken}` },
-							params: { id: otherId },
-						});
-						return {
-							relation: rel,
-							profile: {
-								...profileRes.data.user,
-								avatarUrl: profileRes.data.user?.avatarUrl && profileRes.data.user.avatarUrl !== "" ? cache(REQUEST_BASE + profileRes.data.user.avatarUrl) : null,
-								bannerUrl: profileRes.data.user?.bannerUrl && profileRes.data.user.bannerUrl !== "" ? cache(REQUEST_BASE + profileRes.data.user.bannerUrl) : null,
-							},
-							status,
-						};
-					})
-				);
-				if (isMounted) setFriendItems(items);
-			} catch (err) {
-				console.error("Error loading friend relations:", err);
-			} finally {
-				if (isMounted) setLoading(false);
-			}
-		}
-
-		loadRelations();
-		if (socket) {
-			socket.emit("watch_user", auth.userId);
-			socket.on("watched_user_saved", ([watchedId]) => {
-				if (watchedId === auth.userId) loadRelations();
-			});
-		}
-		return () => {
-			isMounted = false;
-			if (socket) {
-				socket.emit("unwatch_user", auth.userId);
-				socket.off("watched_user_saved");
-			}
-		};
-	}, [auth.authToken, auth.userId, auth.loggedIn]);
-
-	const handleChat = (roomId) => {
-		navigate("/chat");
-	};
-
-	// Unified API caller that also closes any open profile popover
-	const callApi = async (ep, data, onSuccessId) => {
-		try {
-			await axios.put(`${API_BASE}/${ep}`, data, {
-				headers: { Authorization: `Bearer ${auth.authToken}` },
-			});
-			setFriendItems((prev) => prev.filter((item) => item.relation._id !== onSuccessId));
-			setUserPreviewEl(null);
-			setUserPreviewUser(null);
-		} catch (err) {
-			console.error(`${ep} failed`, err);
-		}
-	};
-
-	if (!auth.loggedIn) return <Typography>Please login.</Typography>;
-	if (loading) return <Typography>Loading friends...</Typography>;
-	if (!friendItems.length) return <Typography>No friends or pending requests.</Typography>;
-
-	return (
-		<Box
-			sx={{
-				display: "flex",
-				flexDirection: { xs: "column", sm: "row" },
-				justifyContent: "flex-start",
-				overflow: "auto",
-				flexGrow: 1,
-			}}
-		>
-			<Popover
-				anchorOrigin={{ vertical: "bottom", horizontal: "center" }}
-				transformOrigin={{ vertical: "top", horizontal: "center" }}
-				anchorEl={userPreviewEl}
-				open={Boolean(userPreviewEl)}
-				onClose={() => {
-					setUserPreviewEl(null);
-					setUserPreviewUser(null);
-				}}
-				sx={{ mb: 2 }}
-			>
-				<ProfileCard self={auth.userId === userPreviewUser?.id} user={userPreviewUser} width="300px" passStyle={{ maxWidth: "300px" }} />
-			</Popover>
-
-			<Stack spacing={2} sx={{ width: "100%", maxWidth: { xs: "100%", sm: 500 }, p: 0 }}>
-				{friendItems.map(({ relation, profile, status }) => {
-					if (!paperRefs.current[relation._id]) paperRefs.current[relation._id] = null;
-					return (
-						<Paper
-							ref={(el) => (paperRefs.current[relation._id] = el)}
-							key={relation._id}
-							sx={{
-								p: 2,
-								display: "flex",
-								justifyContent: "space-between",
-								flexDirection: { xs: "column", sm: "row" },
-								alignItems: "center",
-								transition: "box-shadow .3s",
-								"&:hover": { boxShadow: 6 },
-								border: status === "friends" ? "none" : 2,
-								borderColor: status === "sent" ? "info.main" : status === "received" ? "warning.main" : "grey.300",
-								gap: 1,
-							}}
-							elevation={2}
-							onClick={() => handleProfilePreview(profile.id, relation._id)}
-						>
-							<Box sx={{ flexDirection: "row", display: "flex", flexGrow: 1 }} style={{ cursor: "pointer" }}>
-								<Avatar src={profile.avatarUrl || (window.isElectron ? "defaultpfp.webp" : "/defaultpfp.webp")} sx={{ width: { xs: 40, sm: 56 }, height: { xs: 40, sm: 56 }, mb: 0, mr: 2 }} />
-								<Box flex={1} minWidth={0} sx={{ mr: { sm: 2 } }}>
-									<Typography variant="h6" noWrap>
-										{profile.displayName}
-									</Typography>
-									<Typography variant="body2" color="text.secondary" noWrap>
-										@{profile.username}
-									</Typography>
-								</Box>
-							</Box>
-							<Stack direction="row" spacing={1} flexWrap="wrap">
-								{status === "friends" && (
-									<>
-										<Tooltip title="Start Chat">
-											<Button startIcon={<ChatIcon />} variant="contained" color="info" size="small" onClick={() => handleChat(profile.id)}>
-												Chat
-											</Button>
-										</Tooltip>
-										<Tooltip title="Remove Friend">
-											<Button startIcon={<PersonRemoveIcon />} variant="outlined" color="error" size="small" onClick={() => callApi("removefriend", { friendId: relation._id }, relation._id)}>
-												Remove
-											</Button>
-										</Tooltip>
-									</>
-								)}
-								{status === "sent" && (
-									<Tooltip title="Cancel Request">
-										<Button startIcon={<CancelIcon />} variant="outlined" color="warning" size="small" onClick={() => callApi("cancelfriend", { friendId: relation._id }, relation._id)}>
-											Cancel
-										</Button>
-									</Tooltip>
-								)}
-								{status === "received" && (
-									<>
-										<Tooltip title="Accept Request">
-											<Button startIcon={<CheckCircleIcon />} variant="contained" color="success" size="small" onClick={() => callApi("acceptfriend", { friendId: relation._id }, relation._id)}>
-												Accept
-											</Button>
-										</Tooltip>
-										<Tooltip title="Decline Request">
-											<Button startIcon={<HighlightOffIcon />} variant="outlined" color="error" size="small" onClick={() => callApi("declinefriend", { friendId: relation._id }, relation._id)}>
-												Decline
-											</Button>
-										</Tooltip>
-									</>
-								)}
-							</Stack>
-						</Paper>
-					);
-				})}
-			</Stack>
-		</Box>
-	);
+      <Stack
+        spacing={2}
+        sx={{ width: "100%", maxWidth: { xs: "100%", sm: 500 }, p: 0 }}
+      >
+        {friendItems.map(({ relation, profile, status }) => {
+          if (!paperRefs.current[relation._id])
+            paperRefs.current[relation._id] = null;
+          return (
+            <FriendListItem
+              key={relation._id}
+              ref={(el) => (paperRefs.current[relation._id] = el)}
+              relation={relation}
+              profile={profile}
+              status={status}
+              onPreview={handleProfilePreview}
+              onChat={handleChat}
+              onAction={callApi}
+            />
+          );
+        })}
+      </Stack>
+    </Box>
+  );
 }

--- a/src/routes/FriendPage/useFriendPage.js
+++ b/src/routes/FriendPage/useFriendPage.js
@@ -1,0 +1,173 @@
+import { useState, useEffect, useRef } from "react";
+import { useSelector } from "react-redux";
+import axios from "axios";
+import socketIoHelper from "../../helpers/socket";
+
+const REQUEST_BASE =
+  process.env.NODE_ENV === "development"
+    ? "http://localhost:6001/api"
+    : globalThis.IN_ELECTRON_ENV
+      ? "https://rebound.nexus/api"
+      : "/api";
+const API_BASE = `${REQUEST_BASE}/users`;
+
+const cache = (u) => {
+  if (!u) return null;
+  const cleaned = u.replace(/([?&])t=\d+(&)?/, (_, sep, trailing) =>
+    trailing ? sep : "",
+  );
+  return `${cleaned}${cleaned.includes("?") ? "&" : "?"}t=${Date.now()}`;
+};
+
+async function getUserInfo(userId, authToken) {
+  const url = `${REQUEST_BASE}/users/profile`;
+  try {
+    const { data } = await axios.get(url, {
+      headers: {
+        "Content-Type": "application/json",
+        "Allow-Control-Allow-Origin": "*",
+        Authorization: `Bearer ${authToken}`,
+      },
+      params: { id: userId },
+    });
+    const u = data.user;
+    return {
+      ...u,
+      avatarUrl: u.avatarUrl ? cache(REQUEST_BASE + u.avatarUrl) : null,
+      bannerUrl: u.bannerUrl ? cache(REQUEST_BASE + u.bannerUrl) : null,
+    };
+  } catch (err) {
+    console.error(err);
+    return null;
+  }
+}
+
+export default function useFriendPage() {
+  const auth = useSelector((state) => state.auth);
+
+  const [friendItems, setFriendItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  const paperRefs = useRef({});
+  const [userPreviewEl, setUserPreviewEl] = useState(null);
+  const [userPreviewUser, setUserPreviewUser] = useState(null);
+
+  useEffect(() => {
+    if (userPreviewEl && !document.body.contains(userPreviewEl)) {
+      setUserPreviewEl(null);
+      setUserPreviewUser(null);
+    }
+  }, [friendItems, userPreviewEl]);
+
+  const handleProfilePreview = async (userId, relationId) => {
+    if (!userId) return;
+    const info = await getUserInfo(userId, auth.authToken);
+    if (info && paperRefs.current[relationId]) {
+      setUserPreviewEl(paperRefs.current[relationId]);
+      setUserPreviewUser(info);
+    }
+  };
+
+  useEffect(() => {
+    if (!auth.loggedIn) {
+      setLoading(false);
+      return;
+    }
+    let isMounted = true;
+    const socket = socketIoHelper.getSocket();
+
+    async function loadRelations() {
+      setLoading(true);
+      try {
+        const res = await axios.get(`${API_BASE}/profile`, {
+          headers: { Authorization: `Bearer ${auth.authToken}` },
+        });
+        const relations = res.data.user.friends;
+        const items = await Promise.all(
+          relations.map(async (rel) => {
+            const myId = auth.userId;
+            let status, otherId;
+            if (rel.confirmed) {
+              status = "friends";
+              otherId = rel.requester === myId ? rel.recipient : rel.requester;
+            } else if (rel.requester === myId) {
+              status = "sent";
+              otherId = rel.recipient;
+            } else {
+              status = "received";
+              otherId = rel.requester;
+            }
+            const profileRes = await axios.get(`${API_BASE}/profile`, {
+              headers: { Authorization: `Bearer ${auth.authToken}` },
+              params: { id: otherId },
+            });
+            return {
+              relation: rel,
+              profile: {
+                ...profileRes.data.user,
+                avatarUrl:
+                  profileRes.data.user?.avatarUrl &&
+                  profileRes.data.user.avatarUrl !== ""
+                    ? cache(REQUEST_BASE + profileRes.data.user.avatarUrl)
+                    : null,
+                bannerUrl:
+                  profileRes.data.user?.bannerUrl &&
+                  profileRes.data.user.bannerUrl !== ""
+                    ? cache(REQUEST_BASE + profileRes.data.user.bannerUrl)
+                    : null,
+              },
+              status,
+            };
+          }),
+        );
+        if (isMounted) setFriendItems(items);
+      } catch (err) {
+        console.error("Error loading friend relations:", err);
+      } finally {
+        if (isMounted) setLoading(false);
+      }
+    }
+
+    loadRelations();
+    if (socket) {
+      socket.emit("watch_user", auth.userId);
+      socket.on("watched_user_saved", ([watchedId]) => {
+        if (watchedId === auth.userId) loadRelations();
+      });
+    }
+    return () => {
+      isMounted = false;
+      if (socket) {
+        socket.emit("unwatch_user", auth.userId);
+        socket.off("watched_user_saved");
+      }
+    };
+  }, [auth.authToken, auth.userId, auth.loggedIn]);
+
+  const callApi = async (ep, data, onSuccessId) => {
+    try {
+      await axios.put(`${API_BASE}/${ep}`, data, {
+        headers: { Authorization: `Bearer ${auth.authToken}` },
+      });
+      setFriendItems((prev) =>
+        prev.filter((item) => item.relation._id !== onSuccessId),
+      );
+      setUserPreviewEl(null);
+      setUserPreviewUser(null);
+    } catch (err) {
+      console.error(`${ep} failed`, err);
+    }
+  };
+
+  return {
+    friendItems,
+    loading,
+    paperRefs,
+    userPreviewEl,
+    setUserPreviewEl,
+    userPreviewUser,
+    setUserPreviewUser,
+    handleProfilePreview,
+    callApi,
+  };
+}


### PR DESCRIPTION
## Summary
- extract ChatPage state logic into `useChatPage`
- simplify `ChatPage.jsx` to use the new hook

## Testing
- `pnpm test`
- `pnpm --prefix server test`

------
https://chatgpt.com/codex/tasks/task_e_6843e411bd8483279fd636bedc6552b0