### PR TITLE
Add API rate limiting

### DIFF
--- a/server/src/routes/api/chat.js
+++ b/server/src/routes/api/chat.js
@@ -10,7 +10,7 @@ const router = Router();
 // limit paged message requests to 60 per minute per IP
 const messagesLimiter = rateLimit({
   windowMs: 60 * 1000,
-  max: 60,
+  max: 3000,
   standardHeaders: true,
   legacyHeaders: false,
   message: { error: "Too many requests, please try again later." },
@@ -22,7 +22,7 @@ router.get(
   auth.required,
   async (req, res) => {
   const { roomId } = req.params;
-  const limit = parseInt(req.query.limit) || 50;
+  const limit = Math.min(parseInt(req.query.limit), 100) || 50;
   const offset = parseInt(req.query.offset) || 0;
   try {
     const room = await RoomModel.findById(roomId).populate({

--- a/server/src/routes/api/chat.js
+++ b/server/src/routes/api/chat.js
@@ -2,10 +2,25 @@ import { Router } from "express";
 import { auth } from "../auth.js";
 import RoomModel from "../../models/Room.js";
 import logger from "../../logger.js";
+import rateLimit from "express-rate-limit";
 
 const router = Router();
 
-router.get("/rooms/:roomId/messages", auth.required, async (req, res) => {
+// ─── MESSAGES RATE LIMITER ─────────────────────────────────────────────────---
+// limit paged message requests to 60 per minute per IP
+const messagesLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 60,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." },
+});
+
+router.get(
+  "/rooms/:roomId/messages",
+  messagesLimiter,
+  auth.required,
+  async (req, res) => {
   const { roomId } = req.params;
   const limit = parseInt(req.query.limit) || 50;
   const offset = parseInt(req.query.offset) || 0;
@@ -25,6 +40,6 @@ router.get("/rooms/:roomId/messages", auth.required, async (req, res) => {
     logger.error("Error fetching paged messages:", err);
     return res.sendStatus(500);
   }
-});
+);
 
 export default router;

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -7,14 +7,7 @@ import jwt from "jsonwebtoken";
 import passport from "passport";
 
 import logger from "../../logger.js";
-import {
-  sendFriendRequest,
-  validateFriendById,
-  validateUserById,
-  removeFriend,
-  declineFriend,
-  cancelFriend,
-} from "../../models/helpers/UserHelper.js";
+import { sendFriendRequest, validateFriendById, validateUserById, removeFriend, declineFriend, cancelFriend } from "../../models/helpers/UserHelper.js";
 
 import multer from "multer";
 import databaseServer from "../../database/index.js"; // <— your DatabaseServer instance
@@ -33,30 +26,30 @@ const upload = multer({ storage: multer.memoryStorage() });
 // ─── AUTH RATE LIMITER ────────────────────────────────────────────────────────
 // max 10 login/register attempts per hour per IP
 const authLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000, // 1 hour
-  max: 10,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: "Too many auth attempts, please try again later." },
+	windowMs: 60 * 60 * 1000, // 1 hour
+	max: 20,
+	standardHeaders: true,
+	legacyHeaders: false,
+	message: { error: "Too many auth attempts, please try again later." },
 });
 // ─── MODIFY RATE LIMITER ────────────────────────────────────────────────────────
 // max 8 modify profile attempts per 30 minutes per IP
 const modifyLimiter = rateLimit({
-  windowMs: 30 * 60 * 1000, // 1 hour
-  max: 8,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: "Too many modification attempts, please try again later." },
+	windowMs: 30 * 60 * 1000, // 1 hour
+	max: 8,
+	standardHeaders: true,
+	legacyHeaders: false,
+	message: { error: "Too many modification attempts, please try again later." },
 });
 
 // ─── GENERAL RATE LIMITER ─────────────────────────────────────────────────────
 // fallback limiter for other user endpoints
 const generalLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: "Too many requests, please try again later." },
+	windowMs: 15 * 60 * 1000, // 15 minutes
+	max: 100,
+	standardHeaders: true,
+	legacyHeaders: false,
+	message: { error: "Too many requests, please try again later." },
 });
 
 /**
@@ -64,19 +57,19 @@ const generalLimiter = rateLimit({
  * Verify a user via token. Checks that the account is active and returns authentication data.
  */
 router.post("/users/verify", generalLimiter, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
+	const token = getTokenFromHeader(req);
 
-  try {
-    const decoded = jwt.verify(token, process.env.SECRET);
-    const user = await UserModel.findById(decoded.id);
-    if (!user || user.active === false) {
-      return res.status(401).json({ error: "Invalid or deactivated account." });
-    }
-    return res.json({ user: user.toAuthJSON() });
-  } catch (err) {
-    logger.error(`Verification error: ${err.message}`);
-    return next(err);
-  }
+	try {
+		const decoded = jwt.verify(token, process.env.SECRET);
+		const user = await UserModel.findById(decoded.id);
+		if (!user || user.active === false) {
+			return res.status(401).json({ error: "Invalid or deactivated account." });
+		}
+		return res.json({ user: user.toAuthJSON() });
+	} catch (err) {
+		logger.error(`Verification error: ${err.message}`);
+		return next(err);
+	}
 });
 
 /**
@@ -87,32 +80,32 @@ router.post("/users/verify", generalLimiter, async (req, res, next) => {
  * Otherwise, returns the private profile.
  */
 router.get("/users/profile", generalLimiter, auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  try {
-    const decoded = jwt.verify(token, process.env.SECRET);
-    // Use provided id if any, otherwise default to the logged-in user's id.
-    const targetUserId = req.query.id || decoded.id;
-    const user = await UserModel.findById(targetUserId);
+	const token = getTokenFromHeader(req);
+	try {
+		const decoded = jwt.verify(token, process.env.SECRET);
+		// Use provided id if any, otherwise default to the logged-in user's id.
+		const targetUserId = req.query.id || decoded.id;
+		const user = await UserModel.findById(targetUserId);
 
-    if (!user) {
-      return res.sendStatus(404);
-    }
+		if (!user) {
+			return res.sendStatus(404);
+		}
 
-    let profile;
-    // If the request is for the owner's profile, return the private version.
-    if (decoded.id === user._id.toString()) {
-      profile = await user.toProfilePrivJSON(user);
-    } else {
-      // For public profile, fetch the querying user's document to calculate mutual fields.
-      const queryingUser = await UserModel.findById(decoded.id);
-      profile = await user.toProfilePubJSON(queryingUser);
-    }
+		let profile;
+		// If the request is for the owner's profile, return the private version.
+		if (decoded.id === user._id.toString()) {
+			profile = await user.toProfilePrivJSON(user);
+		} else {
+			// For public profile, fetch the querying user's document to calculate mutual fields.
+			const queryingUser = await UserModel.findById(decoded.id);
+			profile = await user.toProfilePubJSON(queryingUser);
+		}
 
-    return res.json({ user: profile });
-  } catch (err) {
-    logger.error(`Profile retrieval error: ${err.message}`);
-    return next(err);
-  }
+		return res.json({ user: profile });
+	} catch (err) {
+		logger.error(`Profile retrieval error: ${err.message}`);
+		return next(err);
+	}
 });
 
 /**
@@ -120,24 +113,24 @@ router.get("/users/profile", generalLimiter, auth.required, async (req, res, nex
  * Log in a user using passport local strategy.
  */
 router.post("/users/login", authLimiter, (req, res, next) => {
-  if (!req.body?.user?.email) {
-    return res.status(422).json({ errors: { email: "is required" } });
-  }
-  if (!req.body?.user?.password) {
-    return res.status(422).json({ errors: { password: "is required" } });
-  }
+	if (!req.body?.user?.email) {
+		return res.status(422).json({ errors: { email: "is required" } });
+	}
+	if (!req.body?.user?.password) {
+		return res.status(422).json({ errors: { password: "is required" } });
+	}
 
-  passport.authenticate("local", { session: false }, (err, user, info) => {
-    if (err) {
-      logger.error(`Login error: ${err.message}`);
-      return next(err);
-    }
-    if (user) {
-      return res.json({ user: user.toAuthJSON() });
-    } else {
-      return res.status(422).json(info);
-    }
-  })(req, res, next);
+	passport.authenticate("local", { session: false }, (err, user, info) => {
+		if (err) {
+			logger.error(`Login error: ${err.message}`);
+			return next(err);
+		}
+		if (user) {
+			return res.json({ user: user.toAuthJSON() });
+		} else {
+			return res.status(422).json(info);
+		}
+	})(req, res, next);
 });
 
 /**
@@ -145,20 +138,20 @@ router.post("/users/login", authLimiter, (req, res, next) => {
  * Register a new user. Checks for a password with a minimum length.
  */
 router.post("/users/register", authLimiter, async (req, res, next) => {
-  try {
-    const { username, email, displayName, bio, password } = req.body.user;
-    if (!password || password.trim().length < 8) {
-      return res.status(422).json({ errors: { password: "is invalid" } });
-    }
-    const user = new UserModel({ username, email, displayName, bio });
-    user.setPassword(password);
+	try {
+		const { username, email, displayName, bio, password } = req.body.user;
+		if (!password || password.trim().length < 8) {
+			return res.status(422).json({ errors: { password: "is invalid" } });
+		}
+		const user = new UserModel({ username, email, displayName, bio });
+		user.setPassword(password);
 
-    await user.save();
-    return res.json({ user: user.toAuthJSON() });
-  } catch (err) {
-    logger.error(`Registration error: ${err.message}`);
-    return next(err);
-  }
+		await user.save();
+		return res.json({ user: user.toAuthJSON() });
+	} catch (err) {
+		logger.error(`Registration error: ${err.message}`);
+		return next(err);
+	}
 });
 
 /**
@@ -167,85 +160,80 @@ router.post("/users/register", authLimiter, async (req, res, next) => {
  * This endpoint uses a transaction, which is important for replica sets.
  */
 router.put(
-  "/users/modify",
-  modifyLimiter,
-  auth.required,
-  upload.fields([
-    { name: "banner", maxCount: 1 },
-    { name: "avatar", maxCount: 1 },
-  ]),
-  async (req, res, next) => {
-    // 1) Verify token
-    const token = getTokenFromHeader(req);
-    let decoded;
-    try {
-      decoded = jwt.verify(token, process.env.SECRET);
-    } catch (err) {
-      logger.error(`Token verification error in modify: ${err.message}`);
-      return res.sendStatus(401);
-    }
+	"/users/modify",
+	modifyLimiter,
+	auth.required,
+	upload.fields([
+		{ name: "banner", maxCount: 1 },
+		{ name: "avatar", maxCount: 1 },
+	]),
+	async (req, res, next) => {
+		// 1) Verify token
+		const token = getTokenFromHeader(req);
+		let decoded;
+		try {
+			decoded = jwt.verify(token, process.env.SECRET);
+		} catch (err) {
+			logger.error(`Token verification error in modify: ${err.message}`);
+			return res.sendStatus(401);
+		}
 
-    // 2) Start a session & transaction
-    const session = await mongoose.startSession();
-    try {
-      await session.withTransaction(async () => {
-        // 3) Load user under the session
-        const user = await UserModel.findById(decoded.id)
-          .session(session)
-          .exec();
-        if (!user) {
-          // throwing will abort the transaction
-          const err = new Error("User not found");
-          err.status = 404;
-          throw err;
-        }
+		// 2) Start a session & transaction
+		const session = await mongoose.startSession();
+		try {
+			await session.withTransaction(async () => {
+				// 3) Load user under the session
+				const user = await UserModel.findById(decoded.id).session(session).exec();
+				if (!user) {
+					// throwing will abort the transaction
+					const err = new Error("User not found");
+					err.status = 404;
+					throw err;
+				}
 
-        // 4) Update text fields
-        const { displayName, bio } = req.body;
-        if (displayName != null) user.displayName = displayName;
-        if (bio != null) user.bio = bio;
+				// 4) Update text fields
+				const { displayName, bio } = req.body;
+				if (displayName != null) user.displayName = displayName;
+				if (bio != null) user.bio = bio;
 
-        // 5) File‐upload helper
-        const uploadToGrid = async (file, fieldName) => {
-          const ext = file.originalname.split(".").pop();
-          const filename = `${fieldName}-${decoded.id}-${Date.now()}.${ext}`;
-          const uploadStream = databaseServer.gridfsBucket.openUploadStream(
-            filename,
-            { contentType: file.mimetype },
-          );
-          uploadStream.end(file.buffer);
-          await once(uploadStream, "finish");
-          return filename;
-        };
+				// 5) File‐upload helper
+				const uploadToGrid = async (file, fieldName) => {
+					const ext = file.originalname.split(".").pop();
+					const filename = `${fieldName}-${decoded.id}-${Date.now()}.${ext}`;
+					const uploadStream = databaseServer.gridfsBucket.openUploadStream(filename, { contentType: file.mimetype });
+					uploadStream.end(file.buffer);
+					await once(uploadStream, "finish");
+					return filename;
+				};
 
-        // 6) Banner & avatar
-        if (req.files?.banner?.[0]) {
-          const storedName = await uploadToGrid(req.files.banner[0], "banner");
-          user.bannerUrl = `/content/${storedName}`;
-        }
-        if (req.files?.avatar?.[0]) {
-          const storedName = await uploadToGrid(req.files.avatar[0], "avatar");
-          user.avatarUrl = `/content/${storedName}`;
-        }
+				// 6) Banner & avatar
+				if (req.files?.banner?.[0]) {
+					const storedName = await uploadToGrid(req.files.banner[0], "banner");
+					user.bannerUrl = `/content/${storedName}`;
+				}
+				if (req.files?.avatar?.[0]) {
+					const storedName = await uploadToGrid(req.files.avatar[0], "avatar");
+					user.avatarUrl = `/content/${storedName}`;
+				}
 
-        // 7) Persist under the session
-        await user.save({ session });
-      });
+				// 7) Persist under the session
+				await user.save({ session });
+			});
 
-      // 8) After commit succeed: notify watchers & respond
-      serverWatchers.onUserSaved(decoded.id.toString());
-      const updated = await UserModel.findById(decoded.id).exec();
-      const profile = await updated.toProfilePrivJSON(updated);
-      return res.json({ user: profile });
-    } catch (err) {
-      // If you threw an Error with a .status, honor it:
-      if (err.status === 404) return res.sendStatus(404);
-      logger.error(`User modification error: ${err.message}`);
-      return next(err);
-    } finally {
-      session.endSession();
-    }
-  },
+			// 8) After commit succeed: notify watchers & respond
+			serverWatchers.onUserSaved(decoded.id.toString());
+			const updated = await UserModel.findById(decoded.id).exec();
+			const profile = await updated.toProfilePrivJSON(updated);
+			return res.json({ user: profile });
+		} catch (err) {
+			// If you threw an Error with a .status, honor it:
+			if (err.status === 404) return res.sendStatus(404);
+			logger.error(`User modification error: ${err.message}`);
+			return next(err);
+		} finally {
+			session.endSession();
+		}
+	}
 );
 
 /**
@@ -258,29 +246,29 @@ router.put(
  * The sender is the authenticated user and the recipient is provided in the request body.
  */
 router.put("/users/addfriend", generalLimiter, auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  let decoded;
-  try {
-    decoded = jwt.verify(token, process.env.SECRET);
-  } catch (err) {
-    logger.error(`Token verification error in addfriend: ${err.message}`);
-    return res.sendStatus(401);
-  }
+	const token = getTokenFromHeader(req);
+	let decoded;
+	try {
+		decoded = jwt.verify(token, process.env.SECRET);
+	} catch (err) {
+		logger.error(`Token verification error in addfriend: ${err.message}`);
+		return res.sendStatus(401);
+	}
 
-  // Prevent a user from sending a friend request to themselves.
-  if (decoded.id === req.body.recipientId) {
-    return res.sendStatus(403);
-  }
+	// Prevent a user from sending a friend request to themselves.
+	if (decoded.id === req.body.recipientId) {
+		return res.sendStatus(403);
+	}
 
-  try {
-    const sender = await validateUserById(decoded.id);
-    const recipient = await validateUserById(req.body.recipientId);
-    const result = await sendFriendRequest(sender, recipient);
-    return res.json(result);
-  } catch (err) {
-    logger.error(`Add friend error: ${err.message}`);
-    return next(err);
-  }
+	try {
+		const sender = await validateUserById(decoded.id);
+		const recipient = await validateUserById(req.body.recipientId);
+		const result = await sendFriendRequest(sender, recipient);
+		return res.json(result);
+	} catch (err) {
+		logger.error(`Add friend error: ${err.message}`);
+		return next(err);
+	}
 });
 
 /**
@@ -289,30 +277,30 @@ router.put("/users/addfriend", generalLimiter, auth.required, async (req, res, n
  * Only the intended recipient may confirm the request.
  */
 router.put("/users/acceptfriend", generalLimiter, auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  let decoded;
-  try {
-    decoded = jwt.verify(token, process.env.SECRET);
-  } catch (err) {
-    logger.error(`Token verification error in acceptfriend: ${err.message}`);
-    return res.sendStatus(401);
-  }
+	const token = getTokenFromHeader(req);
+	let decoded;
+	try {
+		decoded = jwt.verify(token, process.env.SECRET);
+	} catch (err) {
+		logger.error(`Token verification error in acceptfriend: ${err.message}`);
+		return res.sendStatus(401);
+	}
 
-  try {
-    const friend = await validateFriendById(req.body.friendId);
-    if (friend.confirmed) {
-      return res.sendStatus(403);
-    }
-    if (friend.recipient.toString() !== decoded.id) {
-      return res.sendStatus(401);
-    }
-    friend.confirmed = true;
-    await friend.save();
-    return res.sendStatus(200);
-  } catch (err) {
-    logger.error(`Accept friend error: ${err.message}`);
-    return next(err);
-  }
+	try {
+		const friend = await validateFriendById(req.body.friendId);
+		if (friend.confirmed) {
+			return res.sendStatus(403);
+		}
+		if (friend.recipient.toString() !== decoded.id) {
+			return res.sendStatus(401);
+		}
+		friend.confirmed = true;
+		await friend.save();
+		return res.sendStatus(200);
+	} catch (err) {
+		logger.error(`Accept friend error: ${err.message}`);
+		return next(err);
+	}
 });
 
 /**
@@ -320,23 +308,23 @@ router.put("/users/acceptfriend", generalLimiter, auth.required, async (req, res
  * Decline a pending friend request.
  */
 router.put("/users/declinefriend", generalLimiter, auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  let decoded;
-  try {
-    decoded = jwt.verify(token, process.env.SECRET);
-  } catch (err) {
-    logger.error(`Token verification error in declinefriend: ${err.message}`);
-    return res.sendStatus(401);
-  }
+	const token = getTokenFromHeader(req);
+	let decoded;
+	try {
+		decoded = jwt.verify(token, process.env.SECRET);
+	} catch (err) {
+		logger.error(`Token verification error in declinefriend: ${err.message}`);
+		return res.sendStatus(401);
+	}
 
-  try {
-    // Call declineFriend with the friend request ID and current user ID.
-    await declineFriend(req.body.friendId, decoded.id);
-    return res.sendStatus(200);
-  } catch (err) {
-    logger.error(`Decline friend error: ${err.message}`);
-    return next(err);
-  }
+	try {
+		// Call declineFriend with the friend request ID and current user ID.
+		await declineFriend(req.body.friendId, decoded.id);
+		return res.sendStatus(200);
+	} catch (err) {
+		logger.error(`Decline friend error: ${err.message}`);
+		return next(err);
+	}
 });
 
 /**
@@ -344,22 +332,22 @@ router.put("/users/declinefriend", generalLimiter, auth.required, async (req, re
  * Cancel a sent friend request.
  */
 router.put("/users/cancelfriend", generalLimiter, auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  let decoded;
-  try {
-    decoded = jwt.verify(token, process.env.SECRET);
-  } catch (err) {
-    logger.error(`Token verification error in cancelfriend: ${err.message}`);
-    return res.sendStatus(401);
-  }
+	const token = getTokenFromHeader(req);
+	let decoded;
+	try {
+		decoded = jwt.verify(token, process.env.SECRET);
+	} catch (err) {
+		logger.error(`Token verification error in cancelfriend: ${err.message}`);
+		return res.sendStatus(401);
+	}
 
-  try {
-    await cancelFriend(req.body.friendId, decoded.id);
-    return res.sendStatus(200);
-  } catch (err) {
-    logger.error(`Cancel friend error: ${err.message}`);
-    return next(err);
-  }
+	try {
+		await cancelFriend(req.body.friendId, decoded.id);
+		return res.sendStatus(200);
+	} catch (err) {
+		logger.error(`Cancel friend error: ${err.message}`);
+		return next(err);
+	}
 });
 
 /**
@@ -367,22 +355,22 @@ router.put("/users/cancelfriend", generalLimiter, auth.required, async (req, res
  * Remove an existing friend.
  */
 router.put("/users/removefriend", generalLimiter, auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  let decoded;
-  try {
-    decoded = jwt.verify(token, process.env.SECRET);
-  } catch (err) {
-    logger.error(`Token verification error in removefriend: ${err.message}`);
-    return res.sendStatus(401);
-  }
+	const token = getTokenFromHeader(req);
+	let decoded;
+	try {
+		decoded = jwt.verify(token, process.env.SECRET);
+	} catch (err) {
+		logger.error(`Token verification error in removefriend: ${err.message}`);
+		return res.sendStatus(401);
+	}
 
-  try {
-    await removeFriend(req.body.friendId, decoded.id);
-    return res.sendStatus(200);
-  } catch (err) {
-    logger.error(`Remove friend error: ${err.message}`);
-    return next(err);
-  }
+	try {
+		await removeFriend(req.body.friendId, decoded.id);
+		return res.sendStatus(200);
+	} catch (err) {
+		logger.error(`Remove friend error: ${err.message}`);
+		return next(err);
+	}
 });
 
 export default router;

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -49,11 +49,21 @@ const modifyLimiter = rateLimit({
   message: { error: "Too many modification attempts, please try again later." },
 });
 
+// ─── GENERAL RATE LIMITER ─────────────────────────────────────────────────────
+// fallback limiter for other user endpoints
+const generalLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." },
+});
+
 /**
  * /users/verify
  * Verify a user via token. Checks that the account is active and returns authentication data.
  */
-router.post("/users/verify", async (req, res, next) => {
+router.post("/users/verify", generalLimiter, async (req, res, next) => {
   const token = getTokenFromHeader(req);
 
   try {
@@ -76,7 +86,7 @@ router.post("/users/verify", async (req, res, next) => {
  * returns the public profile (with mutual friend and server info).
  * Otherwise, returns the private profile.
  */
-router.get("/users/profile", auth.required, async (req, res, next) => {
+router.get("/users/profile", generalLimiter, auth.required, async (req, res, next) => {
   const token = getTokenFromHeader(req);
   try {
     const decoded = jwt.verify(token, process.env.SECRET);
@@ -247,7 +257,7 @@ router.put(
  * Send a friend request.
  * The sender is the authenticated user and the recipient is provided in the request body.
  */
-router.put("/users/addfriend", auth.required, async (req, res, next) => {
+router.put("/users/addfriend", generalLimiter, auth.required, async (req, res, next) => {
   const token = getTokenFromHeader(req);
   let decoded;
   try {
@@ -278,7 +288,7 @@ router.put("/users/addfriend", auth.required, async (req, res, next) => {
  * Accept a pending friend request.
  * Only the intended recipient may confirm the request.
  */
-router.put("/users/acceptfriend", auth.required, async (req, res, next) => {
+router.put("/users/acceptfriend", generalLimiter, auth.required, async (req, res, next) => {
   const token = getTokenFromHeader(req);
   let decoded;
   try {
@@ -309,7 +319,7 @@ router.put("/users/acceptfriend", auth.required, async (req, res, next) => {
  * /users/declinefriend
  * Decline a pending friend request.
  */
-router.put("/users/declinefriend", auth.required, async (req, res, next) => {
+router.put("/users/declinefriend", generalLimiter, auth.required, async (req, res, next) => {
   const token = getTokenFromHeader(req);
   let decoded;
   try {
@@ -333,7 +343,7 @@ router.put("/users/declinefriend", auth.required, async (req, res, next) => {
  * /users/cancelfriend
  * Cancel a sent friend request.
  */
-router.put("/users/cancelfriend", auth.required, async (req, res, next) => {
+router.put("/users/cancelfriend", generalLimiter, auth.required, async (req, res, next) => {
   const token = getTokenFromHeader(req);
   let decoded;
   try {
@@ -356,7 +366,7 @@ router.put("/users/cancelfriend", auth.required, async (req, res, next) => {
  * /users/removefriend
  * Remove an existing friend.
  */
-router.put("/users/removefriend", auth.required, async (req, res, next) => {
+router.put("/users/removefriend", generalLimiter, auth.required, async (req, res, next) => {
   const token = getTokenFromHeader(req);
   let decoded;
   try {

--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -9,40 +9,37 @@ const router = Router();
 // ─── DOWNLOAD RATE LIMITER ─────────────────────────────────────────────────---
 // limit downloads to 20 per minute per IP
 const downloadLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 20,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: "Too many download requests, please try again later." },
+	windowMs: 60 * 1000,
+	max: 50,
+	standardHeaders: true,
+	legacyHeaders: false,
+	message: { error: "Too many download requests, please try again later." },
 });
 
 // GET /content/:filename
 router.get("/content/:filename", downloadLimiter, async (req, res) => {
-  const bucket = databaseServer.gridfsBucket;
-  if (!bucket) {
-    return res.status(503).send("File store not ready");
-  }
+	const bucket = databaseServer.gridfsBucket;
+	if (!bucket) {
+		return res.status(503).send("File store not ready");
+	}
 
-  const { filename } = req.params;
-  const clean = path.basename(filename);
+	const { filename } = req.params;
+	const clean = path.basename(filename);
 
-  if (clean !== filename || !/^[A-Za-z0-9._-]+$/.test(filename)) {
-    return res.status(400).send("Invalid filename");
-  }
+	if (clean !== filename || !/^[A-Za-z0-9._-]+$/.test(filename)) {
+		return res.status(400).send("Invalid filename");
+	}
 
-  try {
-    const downloadStream = bucket.openDownloadStreamByName(filename);
+	try {
+		const downloadStream = bucket.openDownloadStreamByName(filename);
 
-    res.setHeader(
-      "Content-Type",
-      mime.getType(filename) || "application/octet-stream",
-    );
+		res.setHeader("Content-Type", mime.getType(filename) || "application/octet-stream");
 
-    downloadStream.on("error", () => res.sendStatus(404)).pipe(res);
-  } catch (err) {
-    console.error("GridFS download error:", err);
-    res.sendStatus(500);
-  }
+		downloadStream.on("error", () => res.sendStatus(404)).pipe(res);
+	} catch (err) {
+		console.error("GridFS download error:", err);
+		res.sendStatus(500);
+	}
 });
 
 export default router;

--- a/server/src/routes/content.js
+++ b/server/src/routes/content.js
@@ -2,11 +2,22 @@ import { Router } from "express";
 import mime from "mime";
 import path from "path";
 import databaseServer from "../database/index.js"; // ← import your DatabaseServer
+import rateLimit from "express-rate-limit";
 
 const router = Router();
 
+// ─── DOWNLOAD RATE LIMITER ─────────────────────────────────────────────────---
+// limit downloads to 20 per minute per IP
+const downloadLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 20,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many download requests, please try again later." },
+});
+
 // GET /content/:filename
-router.get("/content/:filename", async (req, res) => {
+router.get("/content/:filename", downloadLimiter, async (req, res) => {
   const bucket = databaseServer.gridfsBucket;
   if (!bucket) {
     return res.status(503).send("File store not ready");


### PR DESCRIPTION
## Summary
- limit chat room message pagination requests
- limit content downloads
- add a general limiter for most user API routes

## Testing
- `pnpm test` *(fails: command not found)*
- `cd server && pnpm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6843f6d5fc708327beae6f87f893799a