### PR TITLE
Load full chat history initially

### DIFF
--- a/server/src/routes/api/chat.js
+++ b/server/src/routes/api/chat.js
@@ -22,24 +22,22 @@ router.get(
   auth.required,
   async (req, res, next) => {
     const { roomId } = req.params;
-    const limit = Math.min(parseInt(req.query.limit), 100) || 50;
-    const offset = parseInt(req.query.offset) || 0;
     try {
-      const meta = await RoomModel.findById(roomId).select("messages").lean();
-      if (!meta) return res.sendStatus(404);
       const room = await RoomModel.findById(roomId)
         .populate({
           path: "messages",
-          options: { sort: { createdAt: -1 }, skip: offset, limit },
+          options: { sort: { createdAt: 1 } },
           populate: { path: "sender", select: "displayName avatarUrl" },
         })
         .lean();
 
-      const total = meta.messages.length;
+      if (!room) return res.sendStatus(404);
+
+      const total = room.messages.length;
 
       return res.json({ messages: room.messages, total });
     } catch (err) {
-      logger.error("Error fetching paged messages:", err);
+      logger.error("Error fetching messages:", err);
       return next(err);
     }
   },

--- a/server/src/socketio/rooms.js
+++ b/server/src/socketio/rooms.js
@@ -133,6 +133,7 @@ class ServerRooms {
 
         const roomDoc = await RoomModel.findById(roomId).populate({
           path: "messages",
+          options: { sort: { createdAt: 1 } },
           populate: { path: "sender", select: "displayName avatarUrl" },
         });
 
@@ -198,6 +199,7 @@ class ServerRooms {
 
         await roomDoc.populate({
           path: "messages",
+          options: { sort: { createdAt: 1 } },
           populate: { path: "sender", select: "displayName avatarUrl" },
         });
 
@@ -237,6 +239,7 @@ class ServerRooms {
 
         const roomDoc = await RoomModel.findById(roomId).populate({
           path: "messages",
+          options: { sort: { createdAt: 1 } },
           populate: { path: "sender", select: "displayName avatarUrl" },
         });
 
@@ -268,6 +271,7 @@ class ServerRooms {
 
         const roomDoc = await RoomModel.findById(roomId).populate({
           path: "messages",
+          options: { sort: { createdAt: 1 } },
           populate: { path: "sender", select: "displayName avatarUrl" },
         });
 

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -53,7 +53,6 @@ function ChatPage() {
     confirmDeleteSelectedMessage,
     commitEditMessage,
     cancelEditMessage,
-    handleScroll,
     listRef,
   } = useChatPage();
 
@@ -165,7 +164,6 @@ function ChatPage() {
             setEditingText={setEditingText}
             commitEdit={commitEditMessage}
             cancelEdit={cancelEditMessage}
-            onScroll={handleScroll}
             listRef={listRef}
           />
         </Box>

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -67,40 +67,24 @@ export default function useChatPage() {
   const [editingText, setEditingText] = useState("");
   const listRef = useRef(null);
   const fetchingRef = useRef(false);
-  const CHUNK_SIZE = 40;
-  const [offset, setOffset] = useState(0);
-  const [hasMore, setHasMore] = useState(true);
-  const [totalMessages, setTotalMessages] = useState(0);
 
-  const fetchChunk = useCallback(
-    async (newOffset = 0) => {
-      if (!authState.socketInfo.currentRoom || fetchingRef.current) return;
-      fetchingRef.current = true;
-      try {
-        const { data } = await axios.get(
-          `${REQUEST_BASE}/rooms/${authState.socketInfo.currentRoom}/messages`,
-          {
-            headers: { Authorization: `Bearer ${authState.authToken}` },
-            params: { offset: newOffset, limit: CHUNK_SIZE },
-          },
-        );
-        const mapped = mapMessages(data.messages.reverse());
-        setMessages((prev) =>
-          newOffset === 0
-            ? mapped
-            : [...mapped, ...prev].slice(-CHUNK_SIZE * 3),
-        );
-        setOffset(newOffset);
-        setTotalMessages(data.total);
-        setHasMore(newOffset + CHUNK_SIZE < data.total);
-      } catch (err) {
-        console.error("load messages error", err);
-      } finally {
-        fetchingRef.current = false;
-      }
-    },
-    [authState.socketInfo.currentRoom, authState.authToken],
-  );
+  const fetchMessages = useCallback(async () => {
+    if (!authState.socketInfo.currentRoom || fetchingRef.current) return;
+    fetchingRef.current = true;
+    try {
+      const { data } = await axios.get(
+        `${REQUEST_BASE}/rooms/${authState.socketInfo.currentRoom}/messages`,
+        {
+          headers: { Authorization: `Bearer ${authState.authToken}` },
+        },
+      );
+      setMessages(mapMessages(data.messages));
+    } catch (err) {
+      console.error("load messages error", err);
+    } finally {
+      fetchingRef.current = false;
+    }
+  }, [authState.socketInfo.currentRoom, authState.authToken]);
 
   useEffect(() => {
     const socket = socketIoHelper.getSocket();
@@ -116,22 +100,18 @@ export default function useChatPage() {
           );
         }
       });
-      socket.on("joined_room", () => fetchChunk(0));
+      socket.on("joined_room", (_id, msgs) => {
+        setMessages(mapMessages(msgs));
+      });
       socket.on("message_sent", (_id, msgs) => {
-        const last = msgs[msgs.length - 1];
-        if (!last) return;
-        setMessages((prev) =>
-          [...prev, ...mapMessages([last])].slice(-CHUNK_SIZE * 3),
-        );
+        setMessages(mapMessages(msgs));
       });
       socket.on("new_message", (_id, msgs) => {
-        const last = msgs[msgs.length - 1];
-        if (!last) return;
-        setMessages((prev) =>
-          [...prev, ...mapMessages([last])].slice(-CHUNK_SIZE * 3),
-        );
+        setMessages(mapMessages(msgs));
       });
-      socket.on("messages_updated", () => fetchChunk(0));
+      socket.on("messages_updated", (_id, msgs) => {
+        setMessages(mapMessages(msgs));
+      });
       socket.on("user_list", (_roomId, list, sender, evt) => {
         if (sender.id !== authState.userId) {
           dispatch(
@@ -175,7 +155,6 @@ export default function useChatPage() {
     authState.userId,
     authState.socketInfo.connected,
     dispatch,
-    fetchChunk,
   ]);
 
   useEffect(() => {
@@ -184,10 +163,8 @@ export default function useChatPage() {
 
   useEffect(() => {
     setMessages([]);
-    setOffset(0);
-    setHasMore(true);
-    fetchChunk(0);
-  }, [authState.socketInfo.currentRoom, fetchChunk]);
+    fetchMessages();
+  }, [authState.socketInfo.currentRoom, fetchMessages]);
 
   useEffect(
     () => () => {
@@ -274,23 +251,14 @@ export default function useChatPage() {
     setEditingText("");
   };
 
-  const handleScroll = async () => {
-    const el = listRef.current;
-    if (!el || !hasMore) return;
-    const distanceFromTop = el.scrollHeight - el.clientHeight - el.scrollTop;
-    if (distanceFromTop <= 100) {
-      const prevHeight = el.scrollHeight;
-      await fetchChunk(offset + CHUNK_SIZE);
-      requestAnimationFrame(() => {
-        el.scrollTop += el.scrollHeight - prevHeight;
-      });
-    }
-  };
-
   const { width, height } = useWindowDimensions();
 
   useEffect(() => {
-    handleScroll();
+    const el = listRef.current;
+    if (!el) return;
+    requestAnimationFrame(() => {
+      el.scrollTop = 0;
+    });
   }, [width, height, messages.length]);
 
   return {
@@ -324,9 +292,6 @@ export default function useChatPage() {
     confirmDeleteSelectedMessage,
     commitEditMessage,
     cancelEditMessage,
-    handleScroll,
     listRef,
-    totalMessages,
-    hasMore,
   };
 }


### PR DESCRIPTION
## Summary
- simplify `/rooms/:roomId/messages` to return all messages
- keep server Socket.IO rooms sorted by creation time
- remove chunked message fetching logic
- load entire message list when joining a room

## Testing
- `pnpm --prefix server test`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_68441cc036808327b80beebe4e1bbf1c