### PR TITLE
Add detailed docs for each API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,3 +148,7 @@ npm test
 
 Test helpers currently contain placeholders that will be filled out when the
 scenarios listed in `tests-todo.txt` are implemented.
+
+### API Reference
+
+Detailed backend documentation, including per-endpoint descriptions and Socket.IO events, is available in [server_docs](server_docs/README.md).

--- a/server_docs/README.md
+++ b/server_docs/README.md
@@ -1,0 +1,9 @@
+# Rebound Server Documentation
+
+This folder contains language-agnostic documentation for the backend API and real-time socket interface.
+
+- `architecture.md` – overview of the server design.
+- `endpoints.md` – summary table of HTTP routes.
+- `endpoints/` – detailed descriptions for each endpoint.
+- `socketio.md` – real‑time events sent over Socket.IO.
+

--- a/server_docs/architecture.md
+++ b/server_docs/architecture.md
@@ -1,0 +1,10 @@
+# Architecture Overview
+
+The server runs an HTTP API alongside a Socket.IO real‑time service. It uses a MongoDB database with GridFS for storing uploaded files. The entry point is `server/src/app.js`.
+
+1. **Database Connection** – the server connects to MongoDB using Mongoose. In development a temporary in‑memory replica set is started. When the database connection opens, a `GridFSBucket` is created for file uploads.
+2. **Express Application** – middleware includes CORS handling, body parsing and method override support. A global limiter caps every IP at 150 requests per five minutes with additional per‑route limiters. Passport is configured with a local strategy for logins.
+3. **Routing** – all API routes are mounted under `/api`. File downloads are served from `/content/:filename`.
+4. **Socket.IO** – a separate Socket.IO instance listens on port `6002`. JWT tokens are validated during the WebSocket handshake. When a client connects the server wires up chat room and watcher handlers and emits a `connected` event.
+5. **Graceful Shutdown** – `ServerBackend` exposes `startBackend`, `stopBackend` and `handleShutdown` to close the Socket.IO server, database and HTTP server in order.
+

--- a/server_docs/endpoints.md
+++ b/server_docs/endpoints.md
@@ -1,0 +1,47 @@
+# HTTP Endpoints
+
+All API routes are served under the `/api` prefix. Authentication is handled via JWT in the `Authorization` header.
+
+## Users
+
+| Method | Path | Description |
+|-------|------|-------------|
+| POST | [`/users/verify`](endpoints/users_verify.md) | Validate a token and return authentication data. |
+| GET | [`/users/profile`](endpoints/users_profile.md) | When called by the owner, returns the private profile. When `?id=` is provided for another user, returns a public profile showing mutual friends and servers. |
+| POST | [`/users/login`](endpoints/users_login.md) | Log in with email and password. Returns authentication JSON. |
+| POST | [`/users/register`](endpoints/users_register.md) | Create a new account. Requires a password of at least eight characters. |
+| PUT | [`/users/modify`](endpoints/users_modify.md) | Update display name, bio and optional avatar or banner image. Uses multipart form data. |
+| PUT | [`/users/addfriend`](endpoints/users_addfriend.md) | Send a friend request to another user. |
+| PUT | [`/users/acceptfriend`](endpoints/users_acceptfriend.md) | Accept a pending friend request. |
+| PUT | [`/users/declinefriend`](endpoints/users_declinefriend.md) | Decline a pending friend request. |
+| PUT | [`/users/cancelfriend`](endpoints/users_cancelfriend.md) | Cancel a sent friend request. |
+| PUT | [`/users/removefriend`](endpoints/users_removefriend.md) | Remove a confirmed friend from both parties. |
+
+## Chat
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | [`/rooms/:roomId/messages`](endpoints/rooms_roomId_messages.md) | Retrieve all messages in a room, ordered by creation time. |
+
+## Admin
+
+| Method | Path | Description |
+|-------|------|-------------|
+| POST | [`/admin/users/delete`](endpoints/admin_users_delete.md) | Anonymise a user account and remove related data. |
+| POST | [`/admin/friends/cleanup`](endpoints/admin_friends_cleanup.md) | Repair friend lists and remove orphan friend requests. |
+
+## Development
+
+These endpoints are only available when the server runs in development mode.
+
+| Method | Path | Description |
+|-------|------|-------------|
+| PUT | [`/dev/database/wipe`](endpoints/dev_database_wipe.md) | Delete all users, rooms and messages. |
+| POST | [`/dev/database/testroom`](endpoints/dev_database_testroom.md) | Create a test room and return its id. |
+
+## Content
+
+| Method | Path | Description |
+|-------|------|-------------|
+| GET | [`/content/:filename`](endpoints/content_filename.md) | Download a previously uploaded file from GridFS. |
+

--- a/server_docs/endpoints/admin_friends_cleanup.md
+++ b/server_docs/endpoints/admin_friends_cleanup.md
@@ -1,0 +1,11 @@
+# POST `/admin/friends/cleanup`
+
+Synchronises friend lists and deletes orphan friend request documents.
+
+- **Authentication**: none (endpoint is unsecured).
+- **Rate Limit**: none.
+- **Responses**:
+  - `200` – cleanup completed.
+  - `500` – on error.
+
+Walks through all friend references, removing invalid ones and deleting friend records that are no longer referenced by any user.

--- a/server_docs/endpoints/admin_users_delete.md
+++ b/server_docs/endpoints/admin_users_delete.md
@@ -1,0 +1,15 @@
+# POST `/admin/users/delete`
+
+Anonymises a user account and cleans up related data.
+
+- **Authentication**: none (endpoint is unsecured).
+- **Rate Limit**: none.
+- **Request Body**:
+  ```json
+  { "userId": "<id>" }
+  ```
+- **Responses**:
+  - `200` – user anonymised and related references removed.
+  - `500` – on error.
+
+Operations are performed inside a transaction: friend documents and server invites are cleaned, server ownership is transferred and the user record is anonymised.

--- a/server_docs/endpoints/content_filename.md
+++ b/server_docs/endpoints/content_filename.md
@@ -1,0 +1,15 @@
+# GET `/content/:filename`
+
+Downloads a file stored in GridFS.
+
+- **Authentication**: none.
+- **Rate Limit**: 50 requests per minute per IP (`downloadLimiter`).
+- **Path Parameters**:
+  - `filename` – sanitized filename of the stored file.
+- **Responses**:
+  - `200` – file stream with appropriate content type.
+  - `400` – invalid filename.
+  - `404` – file not found.
+  - `503` – if the file store is not ready.
+
+The filename is validated against a whitelist of characters and served directly from GridFS.

--- a/server_docs/endpoints/dev_database_testroom.md
+++ b/server_docs/endpoints/dev_database_testroom.md
@@ -1,0 +1,12 @@
+# POST `/dev/database/testroom`
+
+Creates a test chat room and returns its identifier.
+
+- **Authentication**: none.
+- **Rate Limit**: none.
+- **Access**: only operates when `NODE_ENV` is `development`; otherwise returns `403`.
+- **Responses**:
+  - `200` – JSON `{ roomId: "<id>" }` when created.
+  - `403` – when called outside development mode.
+
+Used for development to seed a sample chat room.

--- a/server_docs/endpoints/dev_database_wipe.md
+++ b/server_docs/endpoints/dev_database_wipe.md
@@ -1,0 +1,12 @@
+# PUT `/dev/database/wipe`
+
+Deletes all users, rooms and messages from the database.
+
+- **Authentication**: none.
+- **Rate Limit**: none.
+- **Access**: only operates when `NODE_ENV` is `development`; otherwise returns `403`.
+- **Responses**:
+  - `200` – database cleared.
+  - `403` – when called outside development mode.
+
+Intended for local development to reset the database.

--- a/server_docs/endpoints/rooms_roomId_messages.md
+++ b/server_docs/endpoints/rooms_roomId_messages.md
@@ -1,0 +1,13 @@
+# GET `/rooms/:roomId/messages`
+
+Returns all messages in the specified room.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 3000 requests per minute per IP (`messagesLimiter`).
+- **Path Parameters**:
+  - `roomId` – ID of the room to retrieve messages from.
+- **Responses**:
+  - `200` – JSON `{ messages: [...], total: <count> }` sorted by creation time.
+  - `404` – room not found.
+
+Messages are populated with the sender's display name and avatar.

--- a/server_docs/endpoints/users_acceptfriend.md
+++ b/server_docs/endpoints/users_acceptfriend.md
@@ -1,0 +1,17 @@
+# PUT `/users/acceptfriend`
+
+Accepts a pending friend request.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 100 requests per 15 minutes per IP (`generalLimiter`).
+- **Request Body**:
+  ```json
+  { "friendId": "<id>" }
+  ```
+- **Responses**:
+  - `200` – friend request confirmed.
+  - `403` – if already confirmed.
+  - `401` – if the requester is not the recipient.
+  - `404` – request not found.
+
+Only the recipient of the request may call this endpoint. The `confirmed` flag is set on the friend document.

--- a/server_docs/endpoints/users_addfriend.md
+++ b/server_docs/endpoints/users_addfriend.md
@@ -1,0 +1,17 @@
+# PUT `/users/addfriend`
+
+Sends a friend request from the authenticated user to another user.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 100 requests per 15 minutes per IP (`generalLimiter`).
+- **Request Body**:
+  ```json
+  { "recipientId": "<userId>" }
+  ```
+- **Responses**:
+  - `200` – JSON `{ friendId: "<id>" }` when the request is created.
+  - `403` – if the recipient blocked the sender or a request already exists.
+  - `404` – if either user does not exist.
+  - `401` – on invalid token.
+
+Uses `sendFriendRequest` to validate users and create the `Friend` document.

--- a/server_docs/endpoints/users_cancelfriend.md
+++ b/server_docs/endpoints/users_cancelfriend.md
@@ -1,0 +1,17 @@
+# PUT `/users/cancelfriend`
+
+Cancels a friend request previously sent by the authenticated user.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 100 requests per 15 minutes per IP (`generalLimiter`).
+- **Request Body**:
+  ```json
+  { "friendId": "<id>" }
+  ```
+- **Responses**:
+  - `200` – request cancelled and removed.
+  - `401` – if the requester is not the sender.
+  - `403` – if the request has already been confirmed.
+  - `404` – request not found.
+
+Uses `cancelFriend` to remove the Friend document from both users.

--- a/server_docs/endpoints/users_declinefriend.md
+++ b/server_docs/endpoints/users_declinefriend.md
@@ -1,0 +1,16 @@
+# PUT `/users/declinefriend`
+
+Declines a pending friend request.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 100 requests per 15 minutes per IP (`generalLimiter`).
+- **Request Body**:
+  ```json
+  { "friendId": "<id>" }
+  ```
+- **Responses**:
+  - `200` – request declined and removed.
+  - `401` – if the requester is not the recipient.
+  - `404` – request not found.
+
+Internally `declineFriend` removes the Friend document and references from both users.

--- a/server_docs/endpoints/users_login.md
+++ b/server_docs/endpoints/users_login.md
@@ -1,0 +1,20 @@
+# POST `/users/login`
+
+Authenticates a user with email and password using Passport's local strategy.
+
+- **Authentication**: none. Credentials are provided in the body.
+- **Rate Limit**: 20 requests per hour per IP (`authLimiter`).
+- **Request Body**:
+  ```json
+  {
+    "user": {
+      "email": "user@example.com",
+      "password": "secret"
+    }
+  }
+  ```
+- **Responses**:
+  - `200` – JSON `{ user: { ... } }` containing an auth token on success.
+  - `422` – when credentials are missing or invalid.
+
+The route delegates to Passport which returns the user's `toAuthJSON()` on successful authentication.

--- a/server_docs/endpoints/users_modify.md
+++ b/server_docs/endpoints/users_modify.md
@@ -1,0 +1,17 @@
+# PUT `/users/modify`
+
+Updates the authenticated user's profile and optional avatar or banner image.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 8 requests per 30 minutes per IP (`modifyLimiter`).
+- **Request Body**: multipart form fields
+  - `displayName` – optional new display name
+  - `bio` – optional new biography text
+  - `avatar` – optional image file
+  - `banner` – optional image file
+- **Responses**:
+  - `200` – JSON `{ user: { ... } }` with updated private profile.
+  - `404` – user not found.
+  - `401` – invalid token.
+
+The endpoint uses a transaction to load the user, apply changes and upload files to GridFS. On success watchers are notified of the profile update.

--- a/server_docs/endpoints/users_profile.md
+++ b/server_docs/endpoints/users_profile.md
@@ -1,0 +1,14 @@
+# GET `/users/profile`
+
+Returns a user's profile. The behaviour depends on the authenticated user and optional query parameter `id`.
+
+- **Authentication**: required JWT (`auth.required`).
+- **Rate Limit**: 100 requests per 15 minutes per IP (`generalLimiter`).
+- **Query Parameters**:
+  - `id` – if provided and not equal to the authenticated user, returns the public profile for that user. Otherwise returns the private profile of the requester.
+- **Responses**:
+  - `200` – JSON `{ user: { ... } }` with either public or private fields.
+  - `404` – user not found.
+  - `401` – invalid token.
+
+Profiles are generated via `toProfilePrivJSON` or `toProfilePubJSON` which include mutual friends and servers when applicable.

--- a/server_docs/endpoints/users_register.md
+++ b/server_docs/endpoints/users_register.md
@@ -1,0 +1,23 @@
+# POST `/users/register`
+
+Creates a new user account.
+
+- **Authentication**: none.
+- **Rate Limit**: 20 requests per hour per IP (`authLimiter`).
+- **Request Body**:
+  ```json
+  {
+    "user": {
+      "username": "name",
+      "email": "user@example.com",
+      "displayName": "Name",
+      "bio": "Optional bio",
+      "password": "atLeast8Chars"
+    }
+  }
+  ```
+- **Responses**:
+  - `200` – JSON `{ user: { ... } }` including a JWT.
+  - `422` – when validation fails (e.g. short password or duplicate fields).
+
+A new `User` document is created and `setPassword` hashes the password. The returned object includes the authentication token via `toAuthJSON()`.

--- a/server_docs/endpoints/users_removefriend.md
+++ b/server_docs/endpoints/users_removefriend.md
@@ -1,0 +1,17 @@
+# PUT `/users/removefriend`
+
+Removes an existing confirmed friend from both users' lists.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 100 requests per 15 minutes per IP (`generalLimiter`).
+- **Request Body**:
+  ```json
+  { "friendId": "<id>" }
+  ```
+- **Responses**:
+  - `200` – friend relationship removed.
+  - `403` – if the request is not confirmed.
+  - `401` – if neither party matches the authenticated user.
+  - `404` – request not found.
+
+The helper `removeFriend` verifies the caller and deletes the friend document.

--- a/server_docs/endpoints/users_verify.md
+++ b/server_docs/endpoints/users_verify.md
@@ -1,0 +1,12 @@
+# POST `/users/verify`
+
+Validates a JWT sent in the `Authorization` header and returns authentication data for the associated user.
+
+- **Authentication**: JWT in the header using `Token` or `Bearer` scheme.
+- **Rate Limit**: 100 requests per 15 minutes per IP (`generalLimiter`).
+- **Request Body**: none. Token is read from the header.
+- **Responses**:
+  - `200` – JSON `{ user: { ... } }` containing a fresh token and profile fields.
+  - `401` – invalid token or deactivated account.
+
+Internally the endpoint decodes the token with the server secret, loads the user and ensures the account is active.

--- a/server_docs/socketio.md
+++ b/server_docs/socketio.md
@@ -1,0 +1,46 @@
+# Socket.IO Events
+
+Connections are established to port `6002` using the standard Socket.IO client. Clients must provide a JWT in the `Authorization` header during the WebSocket handshake.
+
+After a successful connection the server emits:
+
+- `connected` – indicates the socket is authenticated.
+
+## Chat Rooms
+
+Client‑initiated events handled in `server/src/socketio/rooms.js`:
+
+| Event | Arguments | Description |
+|-------|-----------|-------------|
+| `list_rooms` | – | Request the list of available chat rooms. Server replies with `room_list`. |
+| `make_room` | `name`, `description` | Create a new chat room. Server replies with `room_created`. |
+| `join_room` | `roomId` | Join an existing room. Server emits `joined_room` with the room id and message history and broadcasts `user_list` to all sockets in the room. |
+| `leave_room` | `roomId?` | Leave a specific room or all joined rooms. |
+| `message_room` | `roomId`, `content` | Send a message to a room. Sender receives `message_sent`; others get `new_message`. |
+| `edit_message` | `roomId`, `messageId`, `content` | Edit a previously sent message. Room participants receive `messages_updated`. |
+| `delete_message` | `roomId`, `messageId` | Delete one of the sender's messages. Room participants receive `messages_updated`. |
+
+Server‑emitted events related to rooms:
+
+- `room_list` – `[idToName, idToRoom]` object when listing rooms.
+- `room_created` – newly created room id.
+- `joined_room` – room id and full message list when a socket joins.
+- `left_room` – confirmation that the socket left a room.
+- `user_list` – `roomId`, array of user profiles, joining/leaving user's profile and action (`"join"` or `"leave"`).
+- `message_sent` – updated message list sent back to the sender after posting.
+- `new_message` – updated messages broadcast to others in the room.
+- `messages_updated` – emitted after edits or deletions.
+
+## Watchers
+
+Handlers in `server/src/socketio/watchers.js` let sockets watch user profiles for changes.
+
+| Event | Arguments | Description |
+|-------|-----------|-------------|
+| `watch_user` | `userId` | Start receiving updates when that user's profile changes. |
+| `unwatch_user` | `userId` | Stop watching a user. |
+
+When a watched user saves changes, the server emits to each watcher:
+
+- `watched_user_saved` – `[userId, publicInfo, privateInfo]` where `publicInfo` contains the public profile fields computed for the watcher and `privateInfo` contains private fields only if the watcher is the owner.
+


### PR DESCRIPTION
## Summary
- expand server docs to include individual endpoint pages
- link those pages from `endpoints.md`
- mention the new folder in the docs README
- clarify global rate limit in architecture docs
- link API reference from main README

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6845d2a9cedc83278e297bb5da3e6bb9