### PR TITLE
Add cross-platform scripts for Go services

### DIFF
--- a/backend.bat
+++ b/backend.bat
@@ -1,0 +1,17 @@
+
+@echo off
+
+echo Starting user service...
+
+start "usersvc" cmd /c go run ./microservices/cmd/usersvc
+
+echo Starting chat service...
+
+start "chatsvc" cmd /c go run ./microservices/cmd/chatsvc
+
+echo Starting gateway...
+
+start "gateway" cmd /c go run ./microservices/cmd/gateway
+
+echo All services launched. Close windows to stop them.
+

--- a/backend.sh
+++ b/backend.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Simple script to start all Go microservices
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+cd "$SCRIPT_DIR"
+
+# start services in background
+
+go run ./microservices/cmd/usersvc &
+USERSVC_PID=$!
+
+go run ./microservices/cmd/chatsvc &
+CHATSVC_PID=$!
+
+go run ./microservices/cmd/gateway &
+GATEWAY_PID=$!
+
+trap 'echo "Stopping services..."; kill $USERSVC_PID $CHATSVC_PID $GATEWAY_PID' INT TERM
+
+wait

--- a/microservices/README.md
+++ b/microservices/README.md
@@ -13,3 +13,21 @@ Protobuf definitions are under `proto/` and can be regenerated with `make proto`
 
 This is only a minimal skeleton showing how the existing backend could be
 structured as gRPC microservices.
+
+## Running the services
+
+Convenience scripts are provided to start all services. On Linux or macOS run:
+
+```bash
+./backend.sh
+```
+
+On Windows run:
+
+```cmd
+backend.bat
+```
+
+The scripts launch the user service, chat service and gateway on their default
+ports. Override `USERSVC_PORT`, `CHATSVC_PORT` and `GATEWAY_PORT` to change the
+listening ports.

--- a/microservices/cmd/chatsvc/main.go
+++ b/microservices/cmd/chatsvc/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net"
+	"os"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
@@ -44,14 +45,18 @@ func (s *chatServer) ListMessages(ctx context.Context, req *chatpb.ListRequest) 
 }
 
 func main() {
-	lis, err := net.Listen("tcp", ":50052")
+	port := os.Getenv("CHATSVC_PORT")
+	if port == "" {
+		port = "50052"
+	}
+	lis, err := net.Listen("tcp", ":"+port)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	s := grpc.NewServer()
 	store := data.NewMessageStore()
 	chatpb.RegisterChatServiceServer(s, &chatServer{store: store})
-	log.Println("chat service listening on :50052")
+	log.Printf("chat service listening on :%s", port)
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}

--- a/microservices/cmd/gateway/main.go
+++ b/microservices/cmd/gateway/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net/http"
+	"os"
 
 	"github.com/grpc-ecosystem/grpc-gateway/v2/runtime"
 	"google.golang.org/grpc"
@@ -20,15 +21,29 @@ func main() {
 	mux := runtime.NewServeMux()
 	opts := []grpc.DialOption{grpc.WithInsecure()}
 
-	if err := userpb.RegisterUserServiceHandlerFromEndpoint(ctx, mux, "localhost:50051", opts); err != nil {
+	userAddr := os.Getenv("USERSVC_ADDR")
+	if userAddr == "" {
+		userAddr = "localhost:50051"
+	}
+	chatAddr := os.Getenv("CHATSVC_ADDR")
+	if chatAddr == "" {
+		chatAddr = "localhost:50052"
+	}
+
+	if err := userpb.RegisterUserServiceHandlerFromEndpoint(ctx, mux, userAddr, opts); err != nil {
 		log.Fatalf("failed to register user service: %v", err)
 	}
-	if err := chatpb.RegisterChatServiceHandlerFromEndpoint(ctx, mux, "localhost:50052", opts); err != nil {
+	if err := chatpb.RegisterChatServiceHandlerFromEndpoint(ctx, mux, chatAddr, opts); err != nil {
 		log.Fatalf("failed to register chat service: %v", err)
 	}
 
-	log.Println("gateway listening on :8080")
-	if err := http.ListenAndServe(":8080", mux); err != nil {
+	port := os.Getenv("GATEWAY_PORT")
+	if port == "" {
+		port = "8080"
+	}
+
+	log.Printf("gateway listening on :%s", port)
+	if err := http.ListenAndServe(":"+port, mux); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
 }

--- a/microservices/cmd/usersvc/main.go
+++ b/microservices/cmd/usersvc/main.go
@@ -4,9 +4,12 @@ import (
 	"context"
 	"log"
 	"net"
+	"os"
 
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 
 	"rebound-chat/microservices/internal/data"
 	userpb "rebound-chat/microservices/proto/user"
@@ -17,7 +20,7 @@ type userServer struct {
 	store *data.UserStore
 }
 
-type UserStore = data.userStore
+type UserStore = data.UserStore
 
 func (s *userServer) Register(ctx context.Context, req *userpb.RegisterRequest) (*userpb.AuthResponse, error) {
 	id := uuid.NewString()
@@ -37,7 +40,7 @@ func (s *userServer) Login(ctx context.Context, req *userpb.LoginRequest) (*user
 	if u, ok := s.store.FindByEmail(req.Email); ok && u.Password == req.Password {
 		return &userpb.AuthResponse{UserId: u.ID, Token: "token-placeholder"}, nil
 	}
-	return nil, grpc.Errorf(grpc.Code(grpc.Unauthenticated), "invalid credentials")
+	return nil, status.Errorf(codes.Unauthenticated, "invalid credentials")
 }
 
 func (s *userServer) GetProfile(ctx context.Context, req *userpb.ProfileRequest) (*userpb.ProfileResponse, error) {
@@ -49,18 +52,22 @@ func (s *userServer) GetProfile(ctx context.Context, req *userpb.ProfileRequest)
 			Bio:         u.Bio,
 		}, nil
 	}
-	return nil, grpc.Errorf(grpc.Code(grpc.NotFound), "user not found")
+	return nil, status.Errorf(codes.NotFound, "user not found")
 }
 
 func main() {
-	lis, err := net.Listen("tcp", ":50051")
+	port := os.Getenv("USERSVC_PORT")
+	if port == "" {
+		port = "50051"
+	}
+	lis, err := net.Listen("tcp", ":"+port)
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
 	s := grpc.NewServer()
 	store := data.NewUserStore()
 	userpb.RegisterUserServiceServer(s, &userServer{store: store})
-	log.Println("user service listening on :50051")
+	log.Printf("user service listening on :%s", port)
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}


### PR DESCRIPTION
## Summary
- make Go microservices pick up ports from environment variables
- add shell and batch scripts to start all services
- document how to run the services

## Testing
- `pnpm test`
- `cd server && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_68460e4c06148327b0168102eb104c01