### PR TITLE
Introduce auth thunks

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import { CssBaseline, ThemeProvider } from "@mui/material";
 import { styled } from "@mui/material/styles";
-import axios from "axios";
 import React, { useEffect, Suspense, lazy } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { BrowserRouter, HashRouter, Route, Routes } from "react-router-dom";
@@ -13,7 +12,7 @@ import RegisterDialog from "./components/RegisterDialog";
 import SnackbarMapper from "./components/SnackbarMapper";
 import useDarkTheme from "./helpers/darkTheme";
 import socketIoHelper from "./helpers/socket";
-import { setLoggedIn, setLoggingIn, setSocketStatus } from "./slices/authSlice";
+import { setLoggedIn, setLoggingIn, setSocketStatus, verifyUser } from "./slices/authSlice";
 import { addSnackbar } from "./slices/snackbarSlice";
 
 import useCustomAppBar from "./components/CustomAppBar/useCustomAppBar";
@@ -70,69 +69,35 @@ const App = () => {
 		}, [loggedIn, authToken]);
 	};
 
-	const useVerifyUser = (authState) => {
-		useEffect(() => {
-			const verifyUser = async () => {
-				if (authState.authToken && !authState.loggedIn) {
-					dispatch(setLoggingIn({ loggingIn: true }));
-					let requestStringBase =
-						process.env.NODE_ENV === "development" ? `http://localhost:6001/api` : window.isElectron ? `https://rebound.nexus/api` : "/api";
-					let requestString = `${requestStringBase}/users/verify`;
-
-					try {
-						const response = await axios.post(requestString, {
-							headers: {
-								"Content-Type": "application/json",
-								authorization: `Bearer ${authState.authToken}`,
-							},
-						});
-						dispatch(
-							setLoggedIn({
-								loggedIn: true,
-								userId: response.data.user.id,
-								username: response.data.user.username,
-								displayName: response.data.user.displayName,
-								bio: response.data.user.bio,
-								authToken: authState.authToken,
-								friends: response.data.user.friends,
-								bannerUrl:
-									response?.data?.user?.bannerUrl && response?.data?.user?.bannerUrl !== ""
-										? requestStringBase + response.data.user.bannerUrl
-										: globalThis.IN_ELECTRON_ENV
-											? "banner.webp"
-											: "/banner.webp",
-								avatarUrl:
-									response?.data?.user?.avatarUrl && response?.data?.user?.avatarUrl !== ""
-										? requestStringBase + response.data.user.avatarUrl
-										: globalThis.IN_ELECTRON_ENV
-											? "defaultpfp.webp"
-											: "/defaultpfp.webp",
-							})
-						);
-						dispatch(
-							addSnackbar({
-								snackbarMsg: `Hello ${response.data.user.displayName}!`,
-								snackbarSeverity: "success",
-								autoHideDuration: 1000,
-							})
-						);
-					} catch (error) {
-						dispatch(
-							addSnackbar({
-								snackbarMsg: "Failed to verify user. Please try logging in again.",
-								snackbarSeverity: "error",
-								autoHideDuration: 5000,
-							})
-						);
-						window.localStorage.removeItem("auth-token");
-						dispatch(setLoggedIn({ loggedIn: false, token: null }));
-					}
-				}
-			};
-
-			verifyUser();
-		}, [authState.authToken, authState.loggedIn]);
-	};
+        const useVerifyUser = (authState) => {
+                useEffect(() => {
+                        if (authState.authToken && !authState.loggedIn) {
+                                dispatch(setLoggingIn({ loggingIn: true }));
+                                dispatch(verifyUser(authState.authToken))
+                                        .unwrap()
+                                        .then((user) => {
+                                                dispatch(
+                                                        addSnackbar({
+                                                                snackbarMsg: `Hello ${user.displayName}!`,
+                                                                snackbarSeverity: "success",
+                                                                autoHideDuration: 1000,
+                                                        })
+                                                );
+                                        })
+                                        .catch(() => {
+                                                dispatch(
+                                                        addSnackbar({
+                                                                snackbarMsg: "Failed to verify user. Please try logging in again.",
+                                                                snackbarSeverity: "error",
+                                                                autoHideDuration: 5000,
+                                                        })
+                                                );
+                                                window.localStorage.removeItem("auth-token");
+                                                dispatch(setLoggedIn({ loggedIn: false, token: null }));
+                                        });
+                        }
+                }, [authState.authToken, authState.loggedIn, dispatch]);
+        };
 
 	useSocketConnection(authState.authToken, authState.loggedIn);
 	useVerifyUser(authState);

--- a/src/components/LoginDialog.comp.jsx
+++ b/src/components/LoginDialog.comp.jsx
@@ -1,9 +1,8 @@
 import { Dialog, Box, Typography, TextField, DialogActions, Button, FormGroup, FormControlLabel, Checkbox } from "@mui/material";
-import axios from "axios";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { setLoggedIn } from "../slices/authSlice";
+import { loginUser } from "../slices/authSlice";
 import { setDialogOpened } from "../slices/dialogSlice";
 
 import { addSnackbar } from "../slices/snackbarSlice";
@@ -16,64 +15,33 @@ const LoginDialog = () => {
 	const [password, setPassword] = useState("");
 	const [stayLoggedIn, setStayLoggedIn] = useState(true);
 
-	const handleUserLogin = () => {
-		let requestStringBase = process.env.NODE_ENV === "development" ? `http://localhost:6001/api` : window.isElectron ? `https://rebound.nexus/api` : "/api";
-		let requestString = `${requestStringBase}/users/login`;
-
-		axios
-			.post(requestString, {
-				user: {
-					email: email,
-					password: password,
-					//stayLoggedIn
-				},
-			})
-			.then((res) => {
-				if (res.status === 200) {
-					window.localStorage.setItem("auth-token", res.data.user.token);
-					dispatch(
-						setLoggedIn({
-							loggedIn: true,
-							userId: res.data.user.id,
-							username: res.data.user.username,
-							displayName: res.data.user.displayName,
-							bio: res.data.user.bio,
-							authToken: res.data.user.token,
-							bannerUrl:
-								res?.data?.user?.bannerUrl && res?.data?.user?.bannerUrl !== ""
-									? requestStringBase + res.data.user.bannerUrl
-									: globalThis.IN_ELECTRON_ENV
-										? "banner.webp"
-										: "/banner.webp",
-							avatarUrl:
-								res?.data?.user?.avatarUrl && res?.data?.user?.avatarUrl !== ""
-									? requestStringBase + res.data.user.avatarUrl
-									: globalThis.IN_ELECTRON_ENV
-										? "defaultpfp.webp"
-										: "/defaultpfp.webp",
-						})
-					);
-					dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }));
-					dispatch(
-						addSnackbar({
-							snackbarMsg: `Login Successful. Hello ${res.data.user.displayName}`,
-							snackbarSeverity: "success",
-							autoHideDuration: 2000,
-						})
-					);
-				}
-			})
-			.catch((error) => {
-				console.log(error?.response?.data?.errors || error?.message || "An unknown error occurred during login.");
-				dispatch(
-					addSnackbar({
-						snackbarMsg: `Login Failed! ${JSON.stringify(error?.response?.data?.errors || error?.message || "An unknown error occurred.")}`,
-						snackbarSeverity: "error",
-						autoHideDuration: 4000,
-					})
-				);
-			});
-	};
+        const handleUserLogin = () => {
+                dispatch(loginUser({ email, password }))
+                        .unwrap()
+                        .then((user) => {
+                                if (stayLoggedIn) {
+                                        window.localStorage.setItem("auth-token", user.authToken);
+                                }
+                                dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }));
+                                dispatch(
+                                        addSnackbar({
+                                                snackbarMsg: `Login Successful. Hello ${user.displayName}`,
+                                                snackbarSeverity: "success",
+                                                autoHideDuration: 2000,
+                                        })
+                                );
+                        })
+                        .catch((error) => {
+                                console.log(error);
+                                dispatch(
+                                        addSnackbar({
+                                                snackbarMsg: `Login Failed! ${JSON.stringify(error)}`,
+                                                snackbarSeverity: "error",
+                                                autoHideDuration: 4000,
+                                        })
+                                );
+                        });
+        };
 
 	return (
 		<Dialog open={loginDialogState} onClose={() => dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }))}>

--- a/src/components/LoginDialog.comp.jsx
+++ b/src/components/LoginDialog.comp.jsx
@@ -15,33 +15,50 @@ const LoginDialog = () => {
 	const [password, setPassword] = useState("");
 	const [stayLoggedIn, setStayLoggedIn] = useState(true);
 
-        const handleUserLogin = () => {
-                dispatch(loginUser({ email, password }))
-                        .unwrap()
-                        .then((user) => {
-                                if (stayLoggedIn) {
-                                        window.localStorage.setItem("auth-token", user.authToken);
-                                }
-                                dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }));
-                                dispatch(
-                                        addSnackbar({
-                                                snackbarMsg: `Login Successful. Hello ${user.displayName}`,
-                                                snackbarSeverity: "success",
-                                                autoHideDuration: 2000,
-                                        })
-                                );
-                        })
-                        .catch((error) => {
-                                console.log(error);
-                                dispatch(
-                                        addSnackbar({
-                                                snackbarMsg: `Login Failed! ${JSON.stringify(error)}`,
-                                                snackbarSeverity: "error",
-                                                autoHideDuration: 4000,
-                                        })
-                                );
-                        });
-        };
+	const handleUserLogin = () => {
+		dispatch(loginUser({ email, password }))
+			.unwrap()
+			.then((user) => {
+				if (stayLoggedIn) {
+					window.localStorage.setItem("auth-token", user.authToken);
+				}
+				dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }));
+				dispatch(
+					addSnackbar({
+						snackbarMsg: `Login Successful. Hello ${user.displayName}`,
+						snackbarSeverity: "success",
+						autoHideDuration: 2000,
+					})
+				);
+			})
+			.catch((error) => {
+				console.log(error);
+				const loginErrors = error?.errors;
+				if (!loginErrors) {
+					dispatch(
+						addSnackbar({
+							snackbarMsg: `Login failed, ${JSON.stringify(error) || "Unknown error."}!`,
+							snackbarSeverity: "error",
+							autoHideDuration: 4000,
+						})
+					);
+				} else {
+					const updateErrors = {};
+					Object.entries(loginErrors).forEach(([field, msg]) => {
+						if (!msg) return;
+						const message = Array.isArray(msg) ? msg.join(", ") : msg;
+						updateErrors[field] = message;
+						dispatch(
+							addSnackbar({
+								snackbarMsg: `Login failed, ${field.charAt(0).toUpperCase() + field.slice(1)} ${message}!`,
+								snackbarSeverity: "error",
+								autoHideDuration: 4000,
+							})
+						);
+					});
+				}
+			});
+	};
 
 	return (
 		<Dialog open={loginDialogState} onClose={() => dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }))}>

--- a/src/components/RegisterDialog/useRegisterDialog.jsx
+++ b/src/components/RegisterDialog/useRegisterDialog.jsx
@@ -1,8 +1,7 @@
-import axios from "axios";
 import React, { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { setAuthState, setLoggedIn } from "../../slices/authSlice";
+import { registerUser } from "../../slices/authSlice";
 import { setDialogOpened } from "../../slices/dialogSlice";
 
 import { addSnackbar } from "../../slices/snackbarSlice";
@@ -183,54 +182,46 @@ const useRegisterDialog = () => {
 			(err) => Object.keys(err).length > 0
 		);
 
-	const handleUserRegister = async () => {
-		let requestString = process.env.NODE_ENV === "development" ? `http://localhost:6001/api/users/register` : `/api/users/register`;
-		requestString = process.env.NODE_ENV !== "development" && window.isElectron ? `https://rebound.nexus/api/users/register` : requestString;
-
-		try {
-			const response = await axios.post(requestString, {
-				user: {
-					username: formData.username,
-					email: formData.email,
-					displayName: formData.displayName,
-					bio: formData.bio,
-					password: formData.password,
-					//formData.stayLoggedIn,
-				},
-			});
-
-			if (response.status === 200) {
-				const authToken = response.data.user.token;
-				window.localStorage.setItem("auth-token", authToken);
-				dispatch(setAuthState({ authToken }));
-				dispatch(setLoggedIn({ loggedIn: true }));
-				dispatch(
-					setDialogOpened({
-						dialogName: "registerDialogOpen",
-						newState: false,
-					})
-				);
-				setFormData({ ...formData });
-				dispatch(
-					addSnackbar({
-						snackbarMsg: "Registration Successful!",
-						snackbarSeverity: "success",
-						autoHideDuration: 4000,
-					})
-				);
-			}
-		} catch (error) {
-			const serverErrors = error?.response?.data?.errors;
-			if (!serverErrors) {
-				dispatch(
-					addSnackbar({
-						snackbarMsg: `Registration Failed! ${error?.message || "Unknown error."}`,
-						snackbarSeverity: "error",
-						autoHideDuration: 4000,
-					})
-				);
-			} else {
-				const updateErrors = {};
+        const handleUserRegister = async () => {
+                dispatch(
+                        registerUser({
+                                username: formData.username,
+                                email: formData.email,
+                                displayName: formData.displayName,
+                                bio: formData.bio,
+                                password: formData.password,
+                                stayLoggedIn: formData.stayLoggedIn,
+                        })
+                )
+                        .unwrap()
+                        .then(() => {
+                                dispatch(
+                                        setDialogOpened({
+                                                dialogName: "registerDialogOpen",
+                                                newState: false,
+                                        })
+                                );
+                                setFormData({ ...formData });
+                                dispatch(
+                                        addSnackbar({
+                                                snackbarMsg: "Registration Successful!",
+                                                snackbarSeverity: "success",
+                                                autoHideDuration: 4000,
+                                        })
+                                );
+                        })
+                        .catch((error) => {
+                                const serverErrors = error?.errors;
+                                if (!serverErrors) {
+                                        dispatch(
+                                                addSnackbar({
+                                                        snackbarMsg: `Registration Failed! ${error?.message || "Unknown error."}`,
+                                                        snackbarSeverity: "error",
+                                                        autoHideDuration: 4000,
+                                                })
+                                        );
+                                } else {
+                                        const updateErrors = {};
 				Object.entries(serverErrors).forEach(([field, msg]) => {
 					if (!msg) return;
 					const message = Array.isArray(msg) ? msg.join(", ") : msg;

--- a/src/components/RegisterDialog/useRegisterDialog.jsx
+++ b/src/components/RegisterDialog/useRegisterDialog.jsx
@@ -182,87 +182,87 @@ const useRegisterDialog = () => {
 			(err) => Object.keys(err).length > 0
 		);
 
-        const handleUserRegister = async () => {
-                dispatch(
-                        registerUser({
-                                username: formData.username,
-                                email: formData.email,
-                                displayName: formData.displayName,
-                                bio: formData.bio,
-                                password: formData.password,
-                                stayLoggedIn: formData.stayLoggedIn,
-                        })
-                )
-                        .unwrap()
-                        .then(() => {
-                                dispatch(
-                                        setDialogOpened({
-                                                dialogName: "registerDialogOpen",
-                                                newState: false,
-                                        })
-                                );
-                                setFormData({ ...formData });
-                                dispatch(
-                                        addSnackbar({
-                                                snackbarMsg: "Registration Successful!",
-                                                snackbarSeverity: "success",
-                                                autoHideDuration: 4000,
-                                        })
-                                );
-                        })
-                        .catch((error) => {
-                                const serverErrors = error?.errors;
-                                if (!serverErrors) {
-                                        dispatch(
-                                                addSnackbar({
-                                                        snackbarMsg: `Registration Failed! ${error?.message || "Unknown error."}`,
-                                                        snackbarSeverity: "error",
-                                                        autoHideDuration: 4000,
-                                                })
-                                        );
-                                } else {
-                                        const updateErrors = {};
-				Object.entries(serverErrors).forEach(([field, msg]) => {
-					if (!msg) return;
-					const message = Array.isArray(msg) ? msg.join(", ") : msg;
-					updateErrors[field] = message;
+	const handleUserRegister = async () => {
+		dispatch(
+			registerUser({
+				username: formData.username,
+				email: formData.email,
+				displayName: formData.displayName,
+				bio: formData.bio,
+				password: formData.password,
+				stayLoggedIn: formData.stayLoggedIn,
+			})
+		)
+			.unwrap()
+			.then(() => {
+				dispatch(
+					setDialogOpened({
+						dialogName: "registerDialogOpen",
+						newState: false,
+					})
+				);
+				setFormData({ ...formData });
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Registration Successful!",
+						snackbarSeverity: "success",
+						autoHideDuration: 4000,
+					})
+				);
+			})
+			.catch((error) => {
+				const serverErrors = error?.errors;
+				if (!serverErrors) {
 					dispatch(
 						addSnackbar({
-							snackbarMsg: `${field.charAt(0).toUpperCase() + field.slice(1)} ${message}`,
+							snackbarMsg: `Registration failed, ${error?.message || "Unknown error."}!`,
 							snackbarSeverity: "error",
 							autoHideDuration: 4000,
 						})
 					);
-				});
+				} else {
+					const updateErrors = {};
+					Object.entries(serverErrors).forEach(([field, msg]) => {
+						if (!msg) return;
+						const message = Array.isArray(msg) ? msg.join(", ") : msg;
+						updateErrors[field] = message;
+						dispatch(
+							addSnackbar({
+								snackbarMsg: `Registration failed, ${field.charAt(0).toUpperCase() + field.slice(1)} ${message}!`,
+								snackbarSeverity: "error",
+								autoHideDuration: 4000,
+							})
+						);
+					});
 
-				// apply all server errors at once
-				setFormData((prev) => {
-					const next = { ...prev };
-					if (updateErrors.username)
-						next.usernameErrors = {
-							...validateUsername(prev.username, updateErrors.username),
-						};
-					if (updateErrors.email)
-						next.emailErrors = {
-							...validateEmail(prev.email, updateErrors.email),
-						};
-					if (updateErrors.password)
-						next.passwordErrors = {
-							...validatePassword(prev.password, updateErrors.password),
-						};
-					if (updateErrors.displayName)
-						next.displayNameErrors = {
-							...validateDisplayName(prev.displayName, updateErrors.displayName),
-						};
-					if (updateErrors.bio)
-						next.bioErrors = {
-							...validateBio(prev.bio, updateErrors.bio),
-						};
-					return next;
-				});
-			}
-			setActiveStep(0);
-		}
+					// apply all server errors at once
+					setFormData((prev) => {
+						const next = { ...prev };
+						if (updateErrors.username)
+							next.usernameErrors = {
+								...validateUsername(prev.username, updateErrors.username),
+							};
+						if (updateErrors.email)
+							next.emailErrors = {
+								...validateEmail(prev.email, updateErrors.email),
+							};
+						if (updateErrors.password)
+							next.passwordErrors = {
+								...validatePassword(prev.password, updateErrors.password),
+							};
+						if (updateErrors.displayName)
+							next.displayNameErrors = {
+								...validateDisplayName(prev.displayName, updateErrors.displayName),
+							};
+						if (updateErrors.bio)
+							next.bioErrors = {
+								...validateBio(prev.bio, updateErrors.bio),
+							};
+						return next;
+					});
+				}
+				setActiveStep(0);
+			});
 	};
 
 	const handleNextStep = () => {

--- a/src/components/User/useProfileCard.js
+++ b/src/components/User/useProfileCard.js
@@ -5,8 +5,9 @@ import socketIoHelper from "../../helpers/socket";
 import { addSnackbar } from "../../slices/snackbarSlice";
 import { setLoggedIn } from "../../slices/authSlice";
 import cacheMedia from "../../helpers/cacheMedia";
+import { getApiBase } from "../../helpers/api";
 
-const REQUEST_BASE = process.env.NODE_ENV === "development" ? "http://localhost:6001/api" : globalThis.IN_ELECTRON_ENV ? "https://rebound.nexus/api" : "/api";
+const REQUEST_BASE = getApiBase();
 const API_BASE = `${REQUEST_BASE}/users`;
 
 export function useFilePreview(initialUrl) {

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -1,0 +1,7 @@
+export const getApiBase = () =>
+  process.env.NODE_ENV === 'development'
+    ? 'http://localhost:6001/api'
+    : window.isElectron
+    ? 'https://rebound.nexus/api'
+    : '/api';
+

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -6,8 +6,9 @@ import socketIoHelper from "../../helpers/socket";
 import { setSocketRoom } from "../../slices/authSlice";
 import { addSnackbar } from "../../slices/snackbarSlice";
 import cacheMedia from "../../helpers/cacheMedia";
+import { getApiBase } from "../../helpers/api";
 
-const REQUEST_BASE = process.env.NODE_ENV === "development" ? `http://localhost:6001/api` : globalThis.IN_ELECTRON_ENV ? `https://rebound.nexus/api` : "/api";
+const REQUEST_BASE = getApiBase();
 
 const mapMessages = (msgs) =>
 	msgs.map((m) => ({

--- a/src/routes/FriendPage/useFriendPage.js
+++ b/src/routes/FriendPage/useFriendPage.js
@@ -3,8 +3,9 @@ import { useSelector } from "react-redux";
 import axios from "axios";
 import socketIoHelper from "../../helpers/socket";
 import cacheMedia from "../../helpers/cacheMedia";
+import { getApiBase } from "../../helpers/api";
 
-const REQUEST_BASE = process.env.NODE_ENV === "development" ? "http://localhost:6001/api" : globalThis.IN_ELECTRON_ENV ? "https://rebound.nexus/api" : "/api";
+const REQUEST_BASE = getApiBase();
 const API_BASE = `${REQUEST_BASE}/users`;
 
 async function getUserInfo(userId, authToken) {

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -21,131 +21,92 @@ const initialState = {
 	avatarUrl: null,
 };
 
-export const verifyUser = createAsyncThunk(
-        "auth/verifyUser",
-        async (token, { rejectWithValue }) => {
-                const base = getApiBase();
-                try {
-                        const { data } = await axios.post(
-                                `${base}/users/verify`,
-                                {},
-                                {
-                                        headers: {
-                                                "Content-Type": "application/json",
-                                                authorization: `Bearer ${token}`,
-                                        },
-                                }
-                        );
-                        const u = data.user;
-                        return {
-                                loggedIn: true,
-                                authToken: token,
-                                userId: u.id,
-                                username: u.username,
-                                displayName: u.displayName,
-                                bio: u.bio,
-                                friends: u.friends,
-                                bannerUrl:
-                                        u?.bannerUrl && u.bannerUrl !== ""
-                                                ? base + u.bannerUrl
-                                                : globalThis.IN_ELECTRON_ENV
-                                                ? "banner.webp"
-                                                : "/banner.webp",
-                                avatarUrl:
-                                        u?.avatarUrl && u.avatarUrl !== ""
-                                                ? base + u.avatarUrl
-                                                : globalThis.IN_ELECTRON_ENV
-                                                ? "defaultpfp.webp"
-                                                : "/defaultpfp.webp",
-                        };
-                } catch (err) {
-                        return rejectWithValue(err.response?.data || err.message);
-                }
-        }
-);
+export const verifyUser = createAsyncThunk("auth/verifyUser", async (token, { rejectWithValue }) => {
+	const base = getApiBase();
+	try {
+		const { data } = await axios.post(
+			`${base}/users/verify`,
+			{},
+			{
+				headers: {
+					"Content-Type": "application/json",
+					authorization: `Bearer ${token}`,
+				},
+			}
+		);
+		const u = data.user;
+		return {
+			loggedIn: true,
+			authToken: token,
+			userId: u.id,
+			username: u.username,
+			displayName: u.displayName,
+			bio: u.bio,
+			friends: u.friends,
+			bannerUrl: u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp",
+			avatarUrl: u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp",
+		};
+	} catch (err) {
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
-export const loginUser = createAsyncThunk(
-        "auth/loginUser",
-        async ({ email, password }, { rejectWithValue }) => {
-                const base = getApiBase();
-                try {
-                        const { data } = await axios.post(`${base}/users/login`, {
-                                user: { email, password },
-                        });
-                        const u = data.user;
-                        return {
-                                loggedIn: true,
-                                authToken: u.token,
-                                userId: u.id,
-                                username: u.username,
-                                displayName: u.displayName,
-                                bio: u.bio,
-                                friends: u.friends,
-                                bannerUrl:
-                                        u?.bannerUrl && u.bannerUrl !== ""
-                                                ? base + u.bannerUrl
-                                                : globalThis.IN_ELECTRON_ENV
-                                                ? "banner.webp"
-                                                : "/banner.webp",
-                                avatarUrl:
-                                        u?.avatarUrl && u.avatarUrl !== ""
-                                                ? base + u.avatarUrl
-                                                : globalThis.IN_ELECTRON_ENV
-                                                ? "defaultpfp.webp"
-                                                : "/defaultpfp.webp",
-                        };
-                } catch (err) {
-                        return rejectWithValue(err.response?.data || err.message);
-                }
-        }
-);
+export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, password }, { rejectWithValue }) => {
+	const base = getApiBase();
+	try {
+		const { data } = await axios.post(`${base}/users/login`, {
+			user: { email, password },
+		});
+		const u = data.user;
+		return {
+			loggedIn: true,
+			authToken: u.token,
+			userId: u.id,
+			username: u.username,
+			displayName: u.displayName,
+			bio: u.bio,
+			friends: u.friends,
+			bannerUrl: u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp",
+			avatarUrl: u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp",
+		};
+	} catch (err) {
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
 export const registerUser = createAsyncThunk(
-        "auth/registerUser",
-        async (
-                { username, email, displayName, bio, password, stayLoggedIn },
-                { rejectWithValue }
-        ) => {
-                const base = getApiBase();
-                try {
-                        const { data } = await axios.post(`${base}/users/register`, {
-                                user: { username, email, displayName, bio, password },
-                        });
-                        const u = data.user;
-                        if (stayLoggedIn) {
-                                window.localStorage.setItem("auth-token", u.token);
-                        }
-                        return {
-                                loggedIn: true,
-                                authToken: u.token,
-                                userId: u.id,
-                                username: u.username,
-                                displayName: u.displayName,
-                                bio: u.bio,
-                                friends: u.friends,
-                                bannerUrl:
-                                        u?.bannerUrl && u.bannerUrl !== ""
-                                                ? base + u.bannerUrl
-                                                : globalThis.IN_ELECTRON_ENV
-                                                ? "banner.webp"
-                                                : "/banner.webp",
-                                avatarUrl:
-                                        u?.avatarUrl && u.avatarUrl !== ""
-                                                ? base + u.avatarUrl
-                                                : globalThis.IN_ELECTRON_ENV
-                                                ? "defaultpfp.webp"
-                                                : "/defaultpfp.webp",
-                        };
-                } catch (err) {
-                        return rejectWithValue(err.response?.data || err.message);
-                }
-        }
+	"auth/registerUser",
+	async ({ username, email, displayName, bio, password, stayLoggedIn }, { rejectWithValue }) => {
+		const base = getApiBase();
+		try {
+			const { data } = await axios.post(`${base}/users/register`, {
+				user: { username, email, displayName, bio, password },
+			});
+			const u = data.user;
+			if (stayLoggedIn) {
+				window.localStorage.setItem("auth-token", u.token);
+			}
+			return {
+				loggedIn: true,
+				authToken: u.token,
+				userId: u.id,
+				username: u.username,
+				displayName: u.displayName,
+				bio: u.bio,
+				friends: u.friends,
+				bannerUrl: u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp",
+				avatarUrl: u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp",
+			};
+		} catch (err) {
+			return rejectWithValue(err.response?.data || err.message);
+		}
+	}
 );
 
 const authSlice = createSlice({
-        name: "auth",
-        initialState,
-        reducers: {
+	name: "auth",
+	initialState,
+	reducers: {
 		setAuthState: (state, action) => {
 			if (action.payload.authToken !== undefined) {
 				state.authToken = action.payload.authToken;
@@ -199,8 +160,8 @@ const authSlice = createSlice({
 		setSocketStatus: (state, action) => {
 			state.socketInfo.connected = action.payload.connected;
 		},
-                setSocketRoom: (state, action) => {
-                        const socketClient = socketIoHelper.getSocket();
+		setSocketRoom: (state, action) => {
+			const socketClient = socketIoHelper.getSocket();
 
 			const roomToLeave = action.payload.lastRoom || state.socketInfo.currentRoom;
 			const roomToJoin = action.payload.currentRoom;
@@ -213,82 +174,72 @@ const authSlice = createSlice({
 			if (roomToJoin) {
 				socketClient.emit("join_room", roomToJoin);
 				state.socketInfo.currentRoom = roomToJoin;
-                        }
-                },
-        },
-        extraReducers: (builder) => {
-                builder
-                        .addCase(verifyUser.pending, (state) => {
-                                state.loggingIn = true;
-                        })
-                        .addCase(verifyUser.fulfilled, (state, action) => {
-                                state.loggingIn = false;
-                                state.loggedIn = true;
-                                state.authToken = action.payload.authToken;
-                                state.userId = action.payload.userId;
-                                state.username = action.payload.username;
-                                state.displayName = action.payload.displayName;
-                                state.bio = action.payload.bio;
-                                state.friends = action.payload.friends;
-                                state.bannerUrl = action.payload.bannerUrl;
-                                state.avatarUrl = action.payload.avatarUrl;
-                        })
-                        .addCase(verifyUser.rejected, (state) => {
-                                state.loggingIn = false;
-                                state.loggedIn = false;
-                        })
-                        .addCase(registerUser.pending, (state) => {
-                                state.loggingIn = true;
-                        })
-                        .addCase(registerUser.fulfilled, (state, action) => {
-                                state.loggingIn = false;
-                                state.loggedIn = true;
-                                state.authToken = action.payload.authToken;
-                                state.userId = action.payload.userId;
-                                state.username = action.payload.username;
-                                state.displayName = action.payload.displayName;
-                                state.bio = action.payload.bio;
-                                state.friends = action.payload.friends;
-                                state.bannerUrl = action.payload.bannerUrl;
-                                state.avatarUrl = action.payload.avatarUrl;
-                        })
-                        .addCase(registerUser.rejected, (state) => {
-                                state.loggingIn = false;
-                                state.loggedIn = false;
-                        })
-                        .addCase(loginUser.pending, (state) => {
-                                state.loggingIn = true;
-                        })
-                        .addCase(loginUser.fulfilled, (state, action) => {
-                                state.loggingIn = false;
-                                state.loggedIn = true;
-                                state.authToken = action.payload.authToken;
-                                state.userId = action.payload.userId;
-                                state.username = action.payload.username;
-                                state.displayName = action.payload.displayName;
-                                state.bio = action.payload.bio;
-                                state.friends = action.payload.friends;
-                                state.bannerUrl = action.payload.bannerUrl;
-                                state.avatarUrl = action.payload.avatarUrl;
-                                window.localStorage.setItem(
-                                        "auth-token",
-                                        action.payload.authToken
-                                );
-                        })
-                        .addCase(loginUser.rejected, (state) => {
-                                state.loggingIn = false;
-                                state.loggedIn = false;
-                        });
-        },
+			}
+		},
+	},
+	extraReducers: (builder) => {
+		builder
+			.addCase(verifyUser.pending, (state) => {
+				state.loggingIn = true;
+			})
+			.addCase(verifyUser.fulfilled, (state, action) => {
+				state.loggingIn = false;
+				state.loggedIn = true;
+				state.authToken = action.payload.authToken;
+				state.userId = action.payload.userId;
+				state.username = action.payload.username;
+				state.displayName = action.payload.displayName;
+				state.bio = action.payload.bio;
+				state.friends = action.payload.friends;
+				state.bannerUrl = action.payload.bannerUrl;
+				state.avatarUrl = action.payload.avatarUrl;
+			})
+			.addCase(verifyUser.rejected, (state) => {
+				state.loggingIn = false;
+				state.loggedIn = false;
+			})
+			.addCase(registerUser.pending, (state) => {
+				state.loggingIn = true;
+			})
+			.addCase(registerUser.fulfilled, (state, action) => {
+				state.loggingIn = false;
+				state.loggedIn = true;
+				state.authToken = action.payload.authToken;
+				state.userId = action.payload.userId;
+				state.username = action.payload.username;
+				state.displayName = action.payload.displayName;
+				state.bio = action.payload.bio;
+				state.friends = action.payload.friends;
+				state.bannerUrl = action.payload.bannerUrl;
+				state.avatarUrl = action.payload.avatarUrl;
+			})
+			.addCase(registerUser.rejected, (state) => {
+				state.loggingIn = false;
+				state.loggedIn = false;
+			})
+			.addCase(loginUser.pending, (state) => {
+				state.loggingIn = true;
+			})
+			.addCase(loginUser.fulfilled, (state, action) => {
+				state.loggingIn = false;
+				state.loggedIn = true;
+				state.authToken = action.payload.authToken;
+				state.userId = action.payload.userId;
+				state.username = action.payload.username;
+				state.displayName = action.payload.displayName;
+				state.bio = action.payload.bio;
+				state.friends = action.payload.friends;
+				state.bannerUrl = action.payload.bannerUrl;
+				state.avatarUrl = action.payload.avatarUrl;
+				window.localStorage.setItem("auth-token", action.payload.authToken);
+			})
+			.addCase(loginUser.rejected, (state) => {
+				state.loggingIn = false;
+				state.loggedIn = false;
+			});
+	},
 });
 
-export const {
-        setAuthState,
-        setLoggedIn,
-        setLoggingIn,
-        setSocketStatus,
-        setSocketRoom,
-} = authSlice.actions;
+export const { setAuthState, setLoggedIn, setLoggingIn, setSocketStatus, setSocketRoom } = authSlice.actions;
 
-export { loginUser, verifyUser, registerUser };
 export default authSlice.reducer;

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -1,6 +1,8 @@
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
 
 import socketIoHelper from "../helpers/socket";
+import { getApiBase } from "../helpers/api";
 
 const initialState = {
 	authToken: window.localStorage.getItem("auth-token"),
@@ -19,10 +21,131 @@ const initialState = {
 	avatarUrl: null,
 };
 
+export const verifyUser = createAsyncThunk(
+        "auth/verifyUser",
+        async (token, { rejectWithValue }) => {
+                const base = getApiBase();
+                try {
+                        const { data } = await axios.post(
+                                `${base}/users/verify`,
+                                {},
+                                {
+                                        headers: {
+                                                "Content-Type": "application/json",
+                                                authorization: `Bearer ${token}`,
+                                        },
+                                }
+                        );
+                        const u = data.user;
+                        return {
+                                loggedIn: true,
+                                authToken: token,
+                                userId: u.id,
+                                username: u.username,
+                                displayName: u.displayName,
+                                bio: u.bio,
+                                friends: u.friends,
+                                bannerUrl:
+                                        u?.bannerUrl && u.bannerUrl !== ""
+                                                ? base + u.bannerUrl
+                                                : globalThis.IN_ELECTRON_ENV
+                                                ? "banner.webp"
+                                                : "/banner.webp",
+                                avatarUrl:
+                                        u?.avatarUrl && u.avatarUrl !== ""
+                                                ? base + u.avatarUrl
+                                                : globalThis.IN_ELECTRON_ENV
+                                                ? "defaultpfp.webp"
+                                                : "/defaultpfp.webp",
+                        };
+                } catch (err) {
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
+
+export const loginUser = createAsyncThunk(
+        "auth/loginUser",
+        async ({ email, password }, { rejectWithValue }) => {
+                const base = getApiBase();
+                try {
+                        const { data } = await axios.post(`${base}/users/login`, {
+                                user: { email, password },
+                        });
+                        const u = data.user;
+                        return {
+                                loggedIn: true,
+                                authToken: u.token,
+                                userId: u.id,
+                                username: u.username,
+                                displayName: u.displayName,
+                                bio: u.bio,
+                                friends: u.friends,
+                                bannerUrl:
+                                        u?.bannerUrl && u.bannerUrl !== ""
+                                                ? base + u.bannerUrl
+                                                : globalThis.IN_ELECTRON_ENV
+                                                ? "banner.webp"
+                                                : "/banner.webp",
+                                avatarUrl:
+                                        u?.avatarUrl && u.avatarUrl !== ""
+                                                ? base + u.avatarUrl
+                                                : globalThis.IN_ELECTRON_ENV
+                                                ? "defaultpfp.webp"
+                                                : "/defaultpfp.webp",
+                        };
+                } catch (err) {
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
+
+export const registerUser = createAsyncThunk(
+        "auth/registerUser",
+        async (
+                { username, email, displayName, bio, password, stayLoggedIn },
+                { rejectWithValue }
+        ) => {
+                const base = getApiBase();
+                try {
+                        const { data } = await axios.post(`${base}/users/register`, {
+                                user: { username, email, displayName, bio, password },
+                        });
+                        const u = data.user;
+                        if (stayLoggedIn) {
+                                window.localStorage.setItem("auth-token", u.token);
+                        }
+                        return {
+                                loggedIn: true,
+                                authToken: u.token,
+                                userId: u.id,
+                                username: u.username,
+                                displayName: u.displayName,
+                                bio: u.bio,
+                                friends: u.friends,
+                                bannerUrl:
+                                        u?.bannerUrl && u.bannerUrl !== ""
+                                                ? base + u.bannerUrl
+                                                : globalThis.IN_ELECTRON_ENV
+                                                ? "banner.webp"
+                                                : "/banner.webp",
+                                avatarUrl:
+                                        u?.avatarUrl && u.avatarUrl !== ""
+                                                ? base + u.avatarUrl
+                                                : globalThis.IN_ELECTRON_ENV
+                                                ? "defaultpfp.webp"
+                                                : "/defaultpfp.webp",
+                        };
+                } catch (err) {
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
+
 const authSlice = createSlice({
-	name: "auth",
-	initialState,
-	reducers: {
+        name: "auth",
+        initialState,
+        reducers: {
 		setAuthState: (state, action) => {
 			if (action.payload.authToken !== undefined) {
 				state.authToken = action.payload.authToken;
@@ -76,8 +199,8 @@ const authSlice = createSlice({
 		setSocketStatus: (state, action) => {
 			state.socketInfo.connected = action.payload.connected;
 		},
-		setSocketRoom: (state, action) => {
-			const socketClient = socketIoHelper.getSocket();
+                setSocketRoom: (state, action) => {
+                        const socketClient = socketIoHelper.getSocket();
 
 			const roomToLeave = action.payload.lastRoom || state.socketInfo.currentRoom;
 			const roomToJoin = action.payload.currentRoom;
@@ -90,10 +213,82 @@ const authSlice = createSlice({
 			if (roomToJoin) {
 				socketClient.emit("join_room", roomToJoin);
 				state.socketInfo.currentRoom = roomToJoin;
-			}
-		},
-	},
+                        }
+                },
+        },
+        extraReducers: (builder) => {
+                builder
+                        .addCase(verifyUser.pending, (state) => {
+                                state.loggingIn = true;
+                        })
+                        .addCase(verifyUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
+                                state.authToken = action.payload.authToken;
+                                state.userId = action.payload.userId;
+                                state.username = action.payload.username;
+                                state.displayName = action.payload.displayName;
+                                state.bio = action.payload.bio;
+                                state.friends = action.payload.friends;
+                                state.bannerUrl = action.payload.bannerUrl;
+                                state.avatarUrl = action.payload.avatarUrl;
+                        })
+                        .addCase(verifyUser.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.loggedIn = false;
+                        })
+                        .addCase(registerUser.pending, (state) => {
+                                state.loggingIn = true;
+                        })
+                        .addCase(registerUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
+                                state.authToken = action.payload.authToken;
+                                state.userId = action.payload.userId;
+                                state.username = action.payload.username;
+                                state.displayName = action.payload.displayName;
+                                state.bio = action.payload.bio;
+                                state.friends = action.payload.friends;
+                                state.bannerUrl = action.payload.bannerUrl;
+                                state.avatarUrl = action.payload.avatarUrl;
+                        })
+                        .addCase(registerUser.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.loggedIn = false;
+                        })
+                        .addCase(loginUser.pending, (state) => {
+                                state.loggingIn = true;
+                        })
+                        .addCase(loginUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
+                                state.authToken = action.payload.authToken;
+                                state.userId = action.payload.userId;
+                                state.username = action.payload.username;
+                                state.displayName = action.payload.displayName;
+                                state.bio = action.payload.bio;
+                                state.friends = action.payload.friends;
+                                state.bannerUrl = action.payload.bannerUrl;
+                                state.avatarUrl = action.payload.avatarUrl;
+                                window.localStorage.setItem(
+                                        "auth-token",
+                                        action.payload.authToken
+                                );
+                        })
+                        .addCase(loginUser.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.loggedIn = false;
+                        });
+        },
 });
 
-export const { setAuthState, setLoggedIn, setLoggingIn, setSocketStatus, setSocketRoom } = authSlice.actions;
+export const {
+        setAuthState,
+        setLoggedIn,
+        setLoggingIn,
+        setSocketStatus,
+        setSocketRoom,
+} = authSlice.actions;
+
+export { loginUser, verifyUser, registerUser };
 export default authSlice.reducer;


### PR DESCRIPTION
## Summary
- centralize server URL helper
- move user verification and login logic into Redux thunks
- add registration thunk and update RegisterDialog
- update other components to use the API helper

## Testing
- `pnpm test`
- `cd server && pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6849b67639e883278f3148be684c4615