### PR TITLE
Move frontend endpoint logic into RTK

### DIFF
--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -199,7 +199,7 @@ router.put(
 				// 5) File‐upload helper
 				const uploadToGrid = async (file, fieldName) => {
 					const ext = file.originalname.split(".").pop();
-					const filename = `${fieldName}-${decoded.id}-${Date.now()}.${ext}`;
+					const filename = `${fieldName}-${decoded.id}-${Math.floor(Math.random() * 1000)}-${Date.now()}.${ext}`;
 					const uploadStream = databaseServer.gridfsBucket.openUploadStream(filename, { contentType: file.mimetype });
 					uploadStream.end(file.buffer);
 					await once(uploadStream, "finish");

--- a/src/components/CustomAppBar/AccountMenu.jsx
+++ b/src/components/CustomAppBar/AccountMenu.jsx
@@ -3,7 +3,7 @@ import PersonRemoveRounded from "@mui/icons-material/PersonRemoveRounded";
 import LogoutRounded from "@mui/icons-material/LogoutRounded";
 import { Menu, MenuList, MenuItem, ListItemIcon, ListItemText, Divider, Avatar } from "@mui/material";
 
-const AccountMenu = ({ anchorEl, open, handleClose, handleLogout, theme }) => (
+const AccountMenu = ({ anchorEl, open, handleClose, handleLogout, theme, avatarUrl }) => (
 	<Menu
 		anchorEl={anchorEl}
 		open={open}
@@ -14,22 +14,9 @@ const AccountMenu = ({ anchorEl, open, handleClose, handleLogout, theme }) => (
 		<MenuList>
 			<MenuItem>
 				<ListItemIcon>
-					<Avatar sx={{ width: "28px", height: "28px" }} />
+					<Avatar src={avatarUrl} sx={{ width: "28px", height: "28px" }} />
 				</ListItemIcon>
 				<ListItemText>Main Profile</ListItemText>
-			</MenuItem>
-			<Divider />
-			<MenuItem>
-				<ListItemIcon>
-					<PersonAddRounded fontSize="small" sx={{ color: theme.palette.text.secondary }} />
-				</ListItemIcon>
-				<ListItemText>Add Profile</ListItemText>
-			</MenuItem>
-			<MenuItem>
-				<ListItemIcon>
-					<PersonRemoveRounded fontSize="small" sx={{ color: theme.palette.text.secondary }} />
-				</ListItemIcon>
-				<ListItemText>Remove Profile</ListItemText>
 			</MenuItem>
 			<Divider />
 			<MenuItem onClick={handleLogout}>

--- a/src/components/CustomAppBar/CustomAppBar.jsx
+++ b/src/components/CustomAppBar/CustomAppBar.jsx
@@ -40,7 +40,7 @@ function CustomAppBar({
 				avatarUrl={auth.avatarUrl}
 				theme={theme}
 			/>
-			<AccountMenu anchorEl={anchorEl} open={open} handleClose={handleClose} handleLogout={handleLogout} theme={theme} />
+			<AccountMenu anchorEl={anchorEl} open={open} handleClose={handleClose} handleLogout={handleLogout} theme={theme} avatarUrl={auth.avatarUrl} />
 			<DrawerMenu drawerWidth={drawerWidth} iconWidth={iconWidth} drawerOpen={drawerOpen} setDrawerOpen={setDrawerOpen} theme={theme} />
 			<MainContent drawerWidth={drawerWidth} drawerOpen={drawerOpen} iconWidth={iconWidth} setDrawerOpen={setDrawerOpen}>
 				{children}

--- a/src/components/User/useProfileCard.js
+++ b/src/components/User/useProfileCard.js
@@ -8,25 +8,34 @@ import cacheMedia from "../../helpers/cacheMedia";
 import { getApiBase } from "../../helpers/api";
 
 const REQUEST_BASE = getApiBase();
-const API_BASE = `${REQUEST_BASE}/users`;
 
 export function useFilePreview(initialUrl) {
-	const [file, setFile] = useState(null);
-	const [preview, setPrev] = useState(cacheMedia(initialUrl));
+    const [file, setFile] = useState(null);
+    const [preview, setPrev] = useState(null);
 
-	const onChange = (e) => {
-		const f = e.target.files?.[0];
-		if (!f) return;
-		setFile(f);
-		setPrev(URL.createObjectURL(f));
-	};
+    useEffect(() => {
+        let alive = true;
+        cacheMedia(initialUrl).then((u) => {
+            if (alive) setPrev(u);
+        });
+        return () => {
+            alive = false;
+        };
+    }, [initialUrl]);
 
-	const reset = (url) => {
-		setFile(null);
-		setPrev(cacheMedia(url));
-	};
+    const onChange = (e) => {
+        const f = e.target.files?.[0];
+        if (!f) return;
+        setFile(f);
+        setPrev(URL.createObjectURL(f));
+    };
 
-	return { file, preview, onChange, reset };
+    const reset = (url) => {
+        setFile(null);
+        cacheMedia(url).then(setPrev);
+    };
+
+    return { file, preview, onChange, reset };
 }
 
 export default function useProfileCard(user, forceSelf) {
@@ -85,17 +94,17 @@ export default function useProfileCard(user, forceSelf) {
 	useEffect(() => {
 		const socket = socketIoHelper.getSocket();
 		if (!socket) return;
-		const onSaved = ([id, pubData, privData]) => {
-			if (id !== watchId) return;
-			const data = id === auth.userId ? privData : pubData;
-			const av = data?.avatarUrl ? cacheMedia(REQUEST_BASE + data.avatarUrl) : null;
-			const bn = data?.bannerUrl ? cacheMedia(REQUEST_BASE + data.bannerUrl) : null;
-			setProfile((p) => ({ ...p, ...data, avatarUrl: av, bannerUrl: bn }));
-			avatar.reset(av);
-			banner.reset(bn);
-			setName(data.displayName);
-			setBio(data.bio);
-		};
+                const onSaved = async ([id, pubData, privData]) => {
+                        if (id !== watchId) return;
+                        const data = id === auth.userId ? privData : pubData;
+                        const av = data?.avatarUrl ? await cacheMedia(REQUEST_BASE + data.avatarUrl) : null;
+                        const bn = data?.bannerUrl ? await cacheMedia(REQUEST_BASE + data.bannerUrl) : null;
+                        setProfile((p) => ({ ...p, ...data, avatarUrl: av, bannerUrl: bn }));
+                        avatar.reset(av);
+                        banner.reset(bn);
+                        setName(data.displayName);
+                        setBio(data.bio);
+                };
 		socket.on("watched_user_saved", onSaved);
 		return () => {
 			socket.off("watched_user_saved", onSaved);
@@ -131,11 +140,11 @@ export default function useProfileCard(user, forceSelf) {
 
                dispatch(modifyProfile({ formData: fd, authToken: auth.authToken }))
                        .unwrap()
-                       .then(({ profile: u }) => {
+                       .then(async ({ profile: u }) => {
                                const full = {
                                        ...u,
-                                       avatarUrl: u.avatarUrl ? cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
-                                       bannerUrl: u.bannerUrl ? cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
+                                       avatarUrl: u.avatarUrl ? await cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
+                                       bannerUrl: u.bannerUrl ? await cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
                                };
                                dispatch(
                                        setLoggedIn({

--- a/src/components/User/useProfileCard.js
+++ b/src/components/User/useProfileCard.js
@@ -1,9 +1,9 @@
 import { useState, useEffect, useMemo, useRef } from "react";
-import axios from "axios";
 import { useSelector, useDispatch } from "react-redux";
 import socketIoHelper from "../../helpers/socket";
 import { addSnackbar } from "../../slices/snackbarSlice";
 import { setLoggedIn } from "../../slices/authSlice";
+import { friendAction, modifyProfile } from "../../slices/userApiSlice";
 import cacheMedia from "../../helpers/cacheMedia";
 import { getApiBase } from "../../helpers/api";
 
@@ -110,79 +110,64 @@ export default function useProfileCard(user, forceSelf) {
 		return rel.requester === auth.userId ? { status: "sent", friendId: rel._id } : { status: "received", friendId: rel._id };
 	}, [profile.friends, isSelf, auth.userId]);
 
-	const callApi = (ep, data, msg, sev = "success") =>
-		axios
-			.put(`${API_BASE}/${ep}`, data, {
-				headers: { Authorization: `Bearer ${auth.authToken}` },
-			})
-			.then(() =>
-				dispatch(
-					addSnackbar({
-						snackbarMsg: msg,
-						snackbarSeverity: sev,
-						autoHideDuration: 1500,
-					})
-				)
-			)
-			.catch(() =>
-				dispatch(
-					addSnackbar({
-						snackbarMsg: "Error",
-						snackbarSeverity: "error",
-						autoHideDuration: 1500,
-					})
-				)
-			);
+       const callApi = (ep, data, msg, sev = "success") => {
+               dispatch(
+                       friendAction({
+                               ep,
+                               data,
+                               authToken: auth.authToken,
+                               message: msg,
+                               severity: sev,
+                       })
+               );
+       };
 
-	const saveProfile = () => {
-		const fd = new FormData();
-		fd.append("displayName", name);
-		fd.append("bio", bio);
-		if (banner.file) fd.append("banner", banner.file);
-		if (avatar.file) fd.append("avatar", avatar.file);
+       const saveProfile = () => {
+               const fd = new FormData();
+               fd.append("displayName", name);
+               fd.append("bio", bio);
+               if (banner.file) fd.append("banner", banner.file);
+               if (avatar.file) fd.append("avatar", avatar.file);
 
-		axios
-			.put(`${API_BASE}/modify`, fd, {
-				headers: { Authorization: `Bearer ${auth.authToken}` },
-			})
-			.then(({ data }) => {
-				const u = data.user;
-				const full = {
-					...u,
-					avatarUrl: u.avatarUrl ? cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
-					bannerUrl: u.bannerUrl ? cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
-				};
-				dispatch(
-					setLoggedIn({
-						avatarUrl: full.avatarUrl,
-						bannerUrl: full.bannerUrl,
-						displayName: full.displayName,
-						username: full.username,
-						bio: full.bio,
-					})
-				);
-				setProfile((p) => ({ ...p, ...full }));
-				dispatch(
-					addSnackbar({
-						snackbarMsg: "Profile updated",
-						snackbarSeverity: "success",
-						autoHideDuration: 1500,
-					})
-				);
-				setEdit(false);
-				avatar.reset(full.avatarUrl);
-				banner.reset(full.bannerUrl);
-			})
-			.catch(() =>
-				dispatch(
-					addSnackbar({
-						snackbarMsg: "Update failed",
-						snackbarSeverity: "error",
-						autoHideDuration: 1500,
-					})
-				)
-			);
-	};
+               dispatch(modifyProfile({ formData: fd, authToken: auth.authToken }))
+                       .unwrap()
+                       .then(({ profile: u }) => {
+                               const full = {
+                                       ...u,
+                                       avatarUrl: u.avatarUrl ? cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
+                                       bannerUrl: u.bannerUrl ? cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
+                               };
+                               dispatch(
+                                       setLoggedIn({
+                                               avatarUrl: full.avatarUrl,
+                                               bannerUrl: full.bannerUrl,
+                                               displayName: full.displayName,
+                                               username: full.username,
+                                               bio: full.bio,
+                                       })
+                               );
+                               setProfile((p) => ({ ...p, ...full }));
+                               dispatch(
+                                       addSnackbar({
+                                               snackbarMsg: "Profile updated",
+                                               snackbarSeverity: "success",
+                                               autoHideDuration: 1500,
+                                       })
+                               );
+                               setEdit(false);
+                               avatar.reset(full.avatarUrl);
+                               banner.reset(full.bannerUrl);
+                       })
+                       .catch(() =>
+                               dispatch(
+                                       addSnackbar({
+                                               snackbarMsg: "Update failed",
+                                               snackbarSeverity: "error",
+                                               autoHideDuration: 1500,
+                                       })
+                               )
+                       );
+       };
 
 	return {
 		isSelf,

--- a/src/components/User/useProfileCard.js
+++ b/src/components/User/useProfileCard.js
@@ -10,32 +10,32 @@ import { getApiBase } from "../../helpers/api";
 const REQUEST_BASE = getApiBase();
 
 export function useFilePreview(initialUrl) {
-    const [file, setFile] = useState(null);
-    const [preview, setPrev] = useState(null);
+	const [file, setFile] = useState(null);
+	const [preview, setPrev] = useState(null);
 
-    useEffect(() => {
-        let alive = true;
-        cacheMedia(initialUrl).then((u) => {
-            if (alive) setPrev(u);
-        });
-        return () => {
-            alive = false;
-        };
-    }, [initialUrl]);
+	useEffect(() => {
+		let alive = true;
+		cacheMedia(initialUrl).then((u) => {
+			if (alive) setPrev(u);
+		});
+		return () => {
+			alive = false;
+		};
+	}, [initialUrl]);
 
-    const onChange = (e) => {
-        const f = e.target.files?.[0];
-        if (!f) return;
-        setFile(f);
-        setPrev(URL.createObjectURL(f));
-    };
+	const onChange = (e) => {
+		const f = e.target.files?.[0];
+		if (!f) return;
+		setFile(f);
+		setPrev(URL.createObjectURL(f));
+	};
 
-    const reset = (url) => {
-        setFile(null);
-        cacheMedia(url).then(setPrev);
-    };
+	const reset = (url) => {
+		setFile(null);
+		cacheMedia(url).then(setPrev);
+	};
 
-    return { file, preview, onChange, reset };
+	return { file, preview, onChange, reset };
 }
 
 export default function useProfileCard(user, forceSelf) {
@@ -94,17 +94,17 @@ export default function useProfileCard(user, forceSelf) {
 	useEffect(() => {
 		const socket = socketIoHelper.getSocket();
 		if (!socket) return;
-                const onSaved = async ([id, pubData, privData]) => {
-                        if (id !== watchId) return;
-                        const data = id === auth.userId ? privData : pubData;
-                        const av = data?.avatarUrl ? await cacheMedia(REQUEST_BASE + data.avatarUrl) : null;
-                        const bn = data?.bannerUrl ? await cacheMedia(REQUEST_BASE + data.bannerUrl) : null;
-                        setProfile((p) => ({ ...p, ...data, avatarUrl: av, bannerUrl: bn }));
-                        avatar.reset(av);
-                        banner.reset(bn);
-                        setName(data.displayName);
-                        setBio(data.bio);
-                };
+		const onSaved = async ([id, pubData, privData]) => {
+			if (id !== watchId) return;
+			const data = id === auth.userId ? privData : pubData;
+			const av = data?.avatarUrl ? await cacheMedia(REQUEST_BASE + data.avatarUrl) : null;
+			const bn = data?.bannerUrl ? await cacheMedia(REQUEST_BASE + data.bannerUrl) : null;
+			setProfile((p) => ({ ...p, ...data, avatarUrl: av, bannerUrl: bn }));
+			avatar.reset(av);
+			banner.reset(bn);
+			setName(data.displayName);
+			setBio(data.bio);
+		};
 		socket.on("watched_user_saved", onSaved);
 		return () => {
 			socket.off("watched_user_saved", onSaved);
@@ -119,64 +119,64 @@ export default function useProfileCard(user, forceSelf) {
 		return rel.requester === auth.userId ? { status: "sent", friendId: rel._id } : { status: "received", friendId: rel._id };
 	}, [profile.friends, isSelf, auth.userId]);
 
-       const callApi = (ep, data, msg, sev = "success") => {
-               dispatch(
-                       friendAction({
-                               ep,
-                               data,
-                               authToken: auth.authToken,
-                               message: msg,
-                               severity: sev,
-                       })
-               );
-       };
+	const callApi = (ep, data, msg, sev = "success") => {
+		dispatch(
+			friendAction({
+				ep,
+				data,
+				authToken: auth.authToken,
+				message: msg,
+				severity: sev,
+			})
+		);
+	};
 
-       const saveProfile = () => {
-               const fd = new FormData();
-               fd.append("displayName", name);
-               fd.append("bio", bio);
-               if (banner.file) fd.append("banner", banner.file);
-               if (avatar.file) fd.append("avatar", avatar.file);
+	const saveProfile = () => {
+		const fd = new FormData();
+		fd.append("displayName", name);
+		fd.append("bio", bio);
+		if (banner.file) fd.append("banner", banner.file);
+		if (avatar.file) fd.append("avatar", avatar.file);
 
-               dispatch(modifyProfile({ formData: fd, authToken: auth.authToken }))
-                       .unwrap()
-                       .then(async ({ profile: u }) => {
-                               const full = {
-                                       ...u,
-                                       avatarUrl: u.avatarUrl ? await cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
-                                       bannerUrl: u.bannerUrl ? await cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
-                               };
-                               dispatch(
-                                       setLoggedIn({
-                                               avatarUrl: full.avatarUrl,
-                                               bannerUrl: full.bannerUrl,
-                                               displayName: full.displayName,
-                                               username: full.username,
-                                               bio: full.bio,
-                                       })
-                               );
-                               setProfile((p) => ({ ...p, ...full }));
-                               dispatch(
-                                       addSnackbar({
-                                               snackbarMsg: "Profile updated",
-                                               snackbarSeverity: "success",
-                                               autoHideDuration: 1500,
-                                       })
-                               );
-                               setEdit(false);
-                               avatar.reset(full.avatarUrl);
-                               banner.reset(full.bannerUrl);
-                       })
-                       .catch(() =>
-                               dispatch(
-                                       addSnackbar({
-                                               snackbarMsg: "Update failed",
-                                               snackbarSeverity: "error",
-                                               autoHideDuration: 1500,
-                                       })
-                               )
-                       );
-       };
+		dispatch(modifyProfile({ formData: fd, authToken: auth.authToken }))
+			.unwrap()
+			.then(async ({ profile: u }) => {
+				const full = {
+					...u,
+					avatarUrl: u.avatarUrl ? await cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
+					bannerUrl: u.bannerUrl ? await cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
+				};
+				dispatch(
+					setLoggedIn({
+						avatarUrl: full.avatarUrl,
+						bannerUrl: full.bannerUrl,
+						displayName: full.displayName,
+						username: full.username,
+						bio: full.bio,
+					})
+				);
+				setProfile((p) => ({ ...p, ...full }));
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Profile updated",
+						snackbarSeverity: "success",
+						autoHideDuration: 1500,
+					})
+				);
+				setEdit(false);
+				avatar.reset(full.avatarUrl);
+				banner.reset(full.bannerUrl);
+			})
+			.catch(() =>
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Update failed",
+						snackbarSeverity: "error",
+						autoHideDuration: 1500,
+					})
+				)
+			);
+	};
 
 	return {
 		isSelf,

--- a/src/helpers/cacheMedia.js
+++ b/src/helpers/cacheMedia.js
@@ -1,5 +1,23 @@
-export default function cacheMedia(url) {
-	if (!url) return null;
-	const cleaned = url.replace(/([?&])t=\d+(&)?/, (_, sep, trailing) => (trailing ? sep : ""));
-	return `${cleaned}${cleaned.includes("?") ? "&" : "?"}t=${Date.now()}`;
+export default async function cacheMedia(url) {
+    if (!url) return null;
+    if (typeof window === "undefined" || !("caches" in window)) {
+        return url;
+    }
+    try {
+        const cache = await caches.open("media-cache");
+        let response = await cache.match(url);
+        if (!response) {
+            response = await fetch(url, { credentials: "include" });
+            if (response.ok) {
+                cache.put(url, response.clone());
+            } else {
+                return url;
+            }
+        }
+        const blob = await response.blob();
+        return URL.createObjectURL(blob);
+    } catch (err) {
+        console.error("cacheMedia failed", err);
+        return url;
+    }
 }

--- a/src/helpers/cacheMedia.js
+++ b/src/helpers/cacheMedia.js
@@ -1,23 +1,31 @@
 export default async function cacheMedia(url) {
-    if (!url) return null;
-    if (typeof window === "undefined" || !("caches" in window)) {
-        return url;
-    }
-    try {
-        const cache = await caches.open("media-cache");
-        let response = await cache.match(url);
-        if (!response) {
-            response = await fetch(url, { credentials: "include" });
-            if (response.ok) {
-                cache.put(url, response.clone());
-            } else {
-                return url;
-            }
-        }
-        const blob = await response.blob();
-        return URL.createObjectURL(blob);
-    } catch (err) {
-        console.error("cacheMedia failed", err);
-        return url;
-    }
+	if (!url) return null;
+	if (typeof window === "undefined" || !("caches" in window)) {
+		return url;
+	}
+	if (url.includes("blob:") && !url.startsWith("blob:")) {
+		return `blob:${url.split("blob:")[1]}`;
+	} else if (url.startsWith("blob:")) {
+		return url;
+	}
+	if (!url.startsWith("http") && !url.startsWith("https")) {
+		return url; // Not a valid URL, return as is
+	}
+	try {
+		const cache = await caches.open("media-cache");
+		let response = await cache.match(url);
+		if (!response) {
+			response = await fetch(url);
+			if (response.ok) {
+				cache.put(url, response.clone());
+			} else {
+				return url;
+			}
+		}
+		const blob = await response.blob();
+		return URL.createObjectURL(blob);
+	} catch (err) {
+		console.error("cacheMedia failed", err);
+		return url;
+	}
 }

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -30,20 +30,18 @@ export default function useChatPage() {
 	const listRef = useRef(null);
 	const fetchingRef = useRef(false);
 
-       const fetchMessages = useCallback(async () => {
-                if (!authState.socketInfo.currentRoom || fetchingRef.current) return;
-                fetchingRef.current = true;
-                try {
-                        const { messages: msgs } = await dispatch(
-                                fetchRoomMessages({ roomId: authState.socketInfo.currentRoom, authToken: authState.authToken })
-                        ).unwrap();
-                        setMessages(msgs);
-                } catch (err) {
-                        console.error("load messages error", err);
-                } finally {
-                        fetchingRef.current = false;
-                }
-        }, [authState.socketInfo.currentRoom, authState.authToken, dispatch]);
+	const fetchMessages = useCallback(async () => {
+		if (!authState.socketInfo.currentRoom || fetchingRef.current) return;
+		fetchingRef.current = true;
+		try {
+			const { messages: msgs } = await dispatch(fetchRoomMessages({ roomId: authState.socketInfo.currentRoom, authToken: authState.authToken })).unwrap();
+			setMessages(msgs);
+		} catch (err) {
+			console.error("load messages error", err);
+		} finally {
+			fetchingRef.current = false;
+		}
+	}, [authState.socketInfo.currentRoom, authState.authToken, dispatch]);
 
 	useEffect(() => {
 		const socket = socketIoHelper.getSocket();
@@ -59,18 +57,18 @@ export default function useChatPage() {
 					);
 				}
 			});
-                        socket.on("joined_room", async (_id, msgs) => {
-                                setMessages(await mapMessages(msgs));
-                        });
-                        socket.on("message_sent", async (_id, msgs) => {
-                                setMessages(await mapMessages(msgs));
-                        });
-                        socket.on("new_message", async (_id, msgs) => {
-                                setMessages(await mapMessages(msgs));
-                        });
-                        socket.on("messages_updated", async (_id, msgs) => {
-                                setMessages(await mapMessages(msgs));
-                        });
+			socket.on("joined_room", async (_id, msgs) => {
+				setMessages(await mapMessages(msgs));
+			});
+			socket.on("message_sent", async (_id, msgs) => {
+				setMessages(await mapMessages(msgs));
+			});
+			socket.on("new_message", async (_id, msgs) => {
+				setMessages(await mapMessages(msgs));
+			});
+			socket.on("messages_updated", async (_id, msgs) => {
+				setMessages(await mapMessages(msgs));
+			});
 			socket.on("user_list", (_roomId, list, sender, evt) => {
 				if (sender.id !== authState.userId) {
 					dispatch(
@@ -143,25 +141,23 @@ export default function useChatPage() {
 		setRoomAnchorEl(null);
 	};
 
-       const previewUser = async (elRef, u) => {
-                if (!elRef?.current) {
-                        setUserPreviewEl(null);
-                        setUserPreviewUser(null);
-                        return;
-                }
-                if (!u?._id) return;
-                try {
-                        const { profile: info } = await dispatch(
-                                fetchUserProfile({ userId: u._id, authToken: authState.authToken })
-                        ).unwrap();
-                        if (info) {
-                                setUserPreviewEl(elRef.current);
-                                setUserPreviewUser(info);
-                        }
-                } catch (err) {
-                        console.error(err);
-                }
-        };
+	const previewUser = async (elRef, u) => {
+		if (!elRef?.current) {
+			setUserPreviewEl(null);
+			setUserPreviewUser(null);
+			return;
+		}
+		if (!u?._id) return;
+		try {
+			const { profile: info } = await dispatch(fetchUserProfile({ userId: u._id, authToken: authState.authToken })).unwrap();
+			if (info) {
+				setUserPreviewEl(elRef.current);
+				setUserPreviewUser(info);
+			}
+		} catch (err) {
+			console.error(err);
+		}
+	};
 
 	const openMessageMenu = (msg, pos) => {
 		setSelectedMessage(msg);

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -59,18 +59,18 @@ export default function useChatPage() {
 					);
 				}
 			});
-			socket.on("joined_room", (_id, msgs) => {
-				setMessages(mapMessages(msgs));
-			});
-			socket.on("message_sent", (_id, msgs) => {
-				setMessages(mapMessages(msgs));
-			});
-			socket.on("new_message", (_id, msgs) => {
-				setMessages(mapMessages(msgs));
-			});
-			socket.on("messages_updated", (_id, msgs) => {
-				setMessages(mapMessages(msgs));
-			});
+                        socket.on("joined_room", async (_id, msgs) => {
+                                setMessages(await mapMessages(msgs));
+                        });
+                        socket.on("message_sent", async (_id, msgs) => {
+                                setMessages(await mapMessages(msgs));
+                        });
+                        socket.on("new_message", async (_id, msgs) => {
+                                setMessages(await mapMessages(msgs));
+                        });
+                        socket.on("messages_updated", async (_id, msgs) => {
+                                setMessages(await mapMessages(msgs));
+                        });
 			socket.on("user_list", (_roomId, list, sender, evt) => {
 				if (sender.id !== authState.userId) {
 					dispatch(

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -1,46 +1,14 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import useWindowDimensions from "../../helpers/useWindowDimensions";
 import { useDispatch, useSelector } from "react-redux";
-import axios from "axios";
+import { fetchRoomMessages, mapMessages } from "../../slices/chatApiSlice";
+import { fetchUserProfile } from "../../slices/userApiSlice";
 import socketIoHelper from "../../helpers/socket";
 import { setSocketRoom } from "../../slices/authSlice";
 import { addSnackbar } from "../../slices/snackbarSlice";
-import cacheMedia from "../../helpers/cacheMedia";
 import { getApiBase } from "../../helpers/api";
 
 const REQUEST_BASE = getApiBase();
-
-const mapMessages = (msgs) =>
-	msgs.map((m) => ({
-		...m,
-		sender: {
-			...m.sender,
-			avatarUrl: m.sender?.avatarUrl ? cacheMedia(REQUEST_BASE + m.sender.avatarUrl) : null,
-		},
-	}));
-
-async function getUserInfo(userId, authToken) {
-	const url = `${REQUEST_BASE}/users/profile`;
-	try {
-		const { data } = await axios.get(url, {
-			headers: {
-				"Content-Type": "application/json",
-				"Allow-Control-Allow-Origin": "*",
-				Authorization: `Bearer ${authToken}`,
-			},
-			params: { id: userId },
-		});
-		const u = data.user;
-		return {
-			...u,
-			avatarUrl: u.avatarUrl ? cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
-			bannerUrl: u.bannerUrl ? cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
-		};
-	} catch (err) {
-		console.error(err);
-		return null;
-	}
-}
 
 export default function useChatPage() {
 	const authState = useSelector((state) => state.auth);
@@ -62,20 +30,20 @@ export default function useChatPage() {
 	const listRef = useRef(null);
 	const fetchingRef = useRef(false);
 
-	const fetchMessages = useCallback(async () => {
-		if (!authState.socketInfo.currentRoom || fetchingRef.current) return;
-		fetchingRef.current = true;
-		try {
-			const { data } = await axios.get(`${REQUEST_BASE}/rooms/${authState.socketInfo.currentRoom}/messages`, {
-				headers: { Authorization: `Bearer ${authState.authToken}` },
-			});
-			setMessages(mapMessages(data.messages));
-		} catch (err) {
-			console.error("load messages error", err);
-		} finally {
-			fetchingRef.current = false;
-		}
-	}, [authState.socketInfo.currentRoom, authState.authToken]);
+       const fetchMessages = useCallback(async () => {
+                if (!authState.socketInfo.currentRoom || fetchingRef.current) return;
+                fetchingRef.current = true;
+                try {
+                        const { messages: msgs } = await dispatch(
+                                fetchRoomMessages({ roomId: authState.socketInfo.currentRoom, authToken: authState.authToken })
+                        ).unwrap();
+                        setMessages(msgs);
+                } catch (err) {
+                        console.error("load messages error", err);
+                } finally {
+                        fetchingRef.current = false;
+                }
+        }, [authState.socketInfo.currentRoom, authState.authToken, dispatch]);
 
 	useEffect(() => {
 		const socket = socketIoHelper.getSocket();
@@ -175,19 +143,25 @@ export default function useChatPage() {
 		setRoomAnchorEl(null);
 	};
 
-	const previewUser = async (elRef, u) => {
-		if (!elRef?.current) {
-			setUserPreviewEl(null);
-			setUserPreviewUser(null);
-			return;
-		}
-		if (!u?._id) return;
-		const info = await getUserInfo(u._id, authState.authToken);
-		if (info) {
-			setUserPreviewEl(elRef.current);
-			setUserPreviewUser(info);
-		}
-	};
+       const previewUser = async (elRef, u) => {
+                if (!elRef?.current) {
+                        setUserPreviewEl(null);
+                        setUserPreviewUser(null);
+                        return;
+                }
+                if (!u?._id) return;
+                try {
+                        const { profile: info } = await dispatch(
+                                fetchUserProfile({ userId: u._id, authToken: authState.authToken })
+                        ).unwrap();
+                        if (info) {
+                                setUserPreviewEl(elRef.current);
+                                setUserPreviewUser(info);
+                        }
+                } catch (err) {
+                        console.error(err);
+                }
+        };
 
 	const openMessageMenu = (msg, pos) => {
 		setSelectedMessage(msg);

--- a/src/routes/FriendPage/useFriendPage.js
+++ b/src/routes/FriendPage/useFriendPage.js
@@ -2,12 +2,6 @@ import { useState, useEffect, useRef } from "react";
 import { useSelector, useDispatch } from "react-redux";
 import { fetchUserProfile, friendAction } from "../../slices/userApiSlice";
 import socketIoHelper from "../../helpers/socket";
-import cacheMedia from "../../helpers/cacheMedia";
-import { getApiBase } from "../../helpers/api";
-
-const REQUEST_BASE = getApiBase();
-const API_BASE = `${REQUEST_BASE}/users`;
-
 async function getUserInfo(userId, authToken, dispatch) {
         try {
                 const { profile } = await dispatch(

--- a/src/routes/FriendPage/useFriendPage.js
+++ b/src/routes/FriendPage/useFriendPage.js
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from "react";
-import { useSelector } from "react-redux";
-import axios from "axios";
+import { useSelector, useDispatch } from "react-redux";
+import { fetchUserProfile, friendAction } from "../../slices/userApiSlice";
 import socketIoHelper from "../../helpers/socket";
 import cacheMedia from "../../helpers/cacheMedia";
 import { getApiBase } from "../../helpers/api";
@@ -8,31 +8,21 @@ import { getApiBase } from "../../helpers/api";
 const REQUEST_BASE = getApiBase();
 const API_BASE = `${REQUEST_BASE}/users`;
 
-async function getUserInfo(userId, authToken) {
-	const url = `${REQUEST_BASE}/users/profile`;
-	try {
-		const { data } = await axios.get(url, {
-			headers: {
-				"Content-Type": "application/json",
-				"Allow-Control-Allow-Origin": "*",
-				Authorization: `Bearer ${authToken}`,
-			},
-			params: { id: userId },
-		});
-		const u = data.user;
-		return {
-			...u,
-			avatarUrl: u.avatarUrl ? cacheMedia(REQUEST_BASE + u.avatarUrl) : null,
-			bannerUrl: u.bannerUrl ? cacheMedia(REQUEST_BASE + u.bannerUrl) : null,
-		};
-	} catch (err) {
-		console.error(err);
-		return null;
-	}
+async function getUserInfo(userId, authToken, dispatch) {
+        try {
+                const { profile } = await dispatch(
+                        fetchUserProfile({ userId, authToken })
+                ).unwrap();
+                return profile;
+        } catch (err) {
+                console.error(err);
+                return null;
+        }
 }
 
 export default function useFriendPage() {
-	const auth = useSelector((state) => state.auth);
+        const auth = useSelector((state) => state.auth);
+        const dispatch = useDispatch();
 
 	const [friendItems, setFriendItems] = useState([]);
 	const [loading, setLoading] = useState(true);
@@ -48,14 +38,14 @@ export default function useFriendPage() {
 		}
 	}, [friendItems, userPreviewEl]);
 
-	const handleProfilePreview = async (userId, relationId) => {
-		if (!userId) return;
-		const info = await getUserInfo(userId, auth.authToken);
-		if (info && paperRefs.current[relationId]) {
-			setUserPreviewEl(paperRefs.current[relationId]);
-			setUserPreviewUser(info);
-		}
-	};
+       const handleProfilePreview = async (userId, relationId) => {
+                if (!userId) return;
+                const info = await getUserInfo(userId, auth.authToken, dispatch);
+                if (info && paperRefs.current[relationId]) {
+                        setUserPreviewEl(paperRefs.current[relationId]);
+                        setUserPreviewUser(info);
+                }
+        };
 
 	useEffect(() => {
 		if (!auth.loggedIn) {
@@ -65,51 +55,44 @@ export default function useFriendPage() {
 		let isMounted = true;
 		const socket = socketIoHelper.getSocket();
 
-		async function loadRelations() {
-			setLoading(true);
-			try {
-				const res = await axios.get(`${API_BASE}/profile`, {
-					headers: { Authorization: `Bearer ${auth.authToken}` },
-				});
-				const relations = res.data.user.friends;
-				const items = await Promise.all(
-					relations.map(async (rel) => {
-						const myId = auth.userId;
-						let status, otherId;
-						if (rel.confirmed) {
-							status = "friends";
-							otherId = rel.requester === myId ? rel.recipient : rel.requester;
-						} else if (rel.requester === myId) {
-							status = "sent";
-							otherId = rel.recipient;
-						} else {
-							status = "received";
-							otherId = rel.requester;
-						}
-						const profileRes = await axios.get(`${API_BASE}/profile`, {
-							headers: { Authorization: `Bearer ${auth.authToken}` },
-							params: { id: otherId },
-						});
-						return {
-							relation: rel,
-							profile: {
-								...profileRes.data.user,
-								avatarUrl:
-									profileRes.data.user?.avatarUrl && profileRes.data.user.avatarUrl !== "" ? cacheMedia(REQUEST_BASE + profileRes.data.user.avatarUrl) : null,
-								bannerUrl:
-									profileRes.data.user?.bannerUrl && profileRes.data.user.bannerUrl !== "" ? cacheMedia(REQUEST_BASE + profileRes.data.user.bannerUrl) : null,
-							},
-							status,
-						};
-					})
-				);
-				if (isMounted) setFriendItems(items);
-			} catch (err) {
-				console.error("Error loading friend relations:", err);
-			} finally {
-				if (isMounted) setLoading(false);
-			}
-		}
+                async function loadRelations() {
+                        setLoading(true);
+                        try {
+                                const { profile: selfProfile } = await dispatch(
+                                        fetchUserProfile({ authToken: auth.authToken })
+                                ).unwrap();
+                                const relations = selfProfile.friends || [];
+                                const items = await Promise.all(
+                                        relations.map(async (rel) => {
+                                                const myId = auth.userId;
+                                                let status, otherId;
+                                                if (rel.confirmed) {
+                                                        status = "friends";
+                                                        otherId = rel.requester === myId ? rel.recipient : rel.requester;
+                                                } else if (rel.requester === myId) {
+                                                        status = "sent";
+                                                        otherId = rel.recipient;
+                                                } else {
+                                                        status = "received";
+                                                        otherId = rel.requester;
+                                                }
+                                                const { profile: otherProfile } = await dispatch(
+                                                        fetchUserProfile({ userId: otherId, authToken: auth.authToken })
+                                                ).unwrap();
+                                                return {
+                                                        relation: rel,
+                                                        profile: otherProfile,
+                                                        status,
+                                                };
+                                        })
+                                );
+                                if (isMounted) setFriendItems(items);
+                        } catch (err) {
+                                console.error("Error loading friend relations:", err);
+                        } finally {
+                                if (isMounted) setLoading(false);
+                        }
+                }
 
 		loadRelations();
 		if (socket) {
@@ -127,18 +110,18 @@ export default function useFriendPage() {
 		};
 	}, [auth.authToken, auth.userId, auth.loggedIn, auth.socketInfo.connected]);
 
-	const callApi = async (ep, data, onSuccessId) => {
-		try {
-			await axios.put(`${API_BASE}/${ep}`, data, {
-				headers: { Authorization: `Bearer ${auth.authToken}` },
-			});
-			setFriendItems((prev) => prev.filter((item) => item.relation._id !== onSuccessId));
-			setUserPreviewEl(null);
-			setUserPreviewUser(null);
-		} catch (err) {
-			console.error(`${ep} failed`, err);
-		}
-	};
+       const callApi = async (ep, data, onSuccessId) => {
+                try {
+                        await dispatch(
+                                friendAction({ ep, data, authToken: auth.authToken })
+                        ).unwrap();
+                        setFriendItems((prev) => prev.filter((item) => item.relation._id !== onSuccessId));
+                        setUserPreviewEl(null);
+                        setUserPreviewUser(null);
+                } catch (err) {
+                        console.error(`${ep} failed`, err);
+                }
+        };
 
 	return {
 		friendItems,

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -3,6 +3,7 @@ import axios from "axios";
 
 import socketIoHelper from "../helpers/socket";
 import { getApiBase } from "../helpers/api";
+import cacheMedia from "../helpers/cacheMedia";
 
 const initialState = {
 	authToken: window.localStorage.getItem("auth-token"),
@@ -35,6 +36,15 @@ export const verifyUser = createAsyncThunk("auth/verifyUser", async (token, { re
 			}
 		);
 		const u = data.user;
+
+		// build raw URLs
+		const rawBanner = u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp";
+		const rawAvatar = u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp";
+
+		// run through cacheMedia
+		const bannerUrl = await cacheMedia(rawBanner);
+		const avatarUrl = await cacheMedia(rawAvatar);
+
 		return {
 			loggedIn: true,
 			authToken: token,
@@ -43,8 +53,8 @@ export const verifyUser = createAsyncThunk("auth/verifyUser", async (token, { re
 			displayName: u.displayName,
 			bio: u.bio,
 			friends: u.friends,
-			bannerUrl: u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp",
-			avatarUrl: u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp",
+			bannerUrl,
+			avatarUrl,
 		};
 	} catch (err) {
 		return rejectWithValue(err.response?.data || err.message);
@@ -58,6 +68,13 @@ export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, pass
 			user: { email, password },
 		});
 		const u = data.user;
+
+		const rawBanner = u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp";
+		const rawAvatar = u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp";
+
+		const bannerUrl = await cacheMedia(rawBanner);
+		const avatarUrl = await cacheMedia(rawAvatar);
+
 		return {
 			loggedIn: true,
 			authToken: u.token,
@@ -66,8 +83,8 @@ export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, pass
 			displayName: u.displayName,
 			bio: u.bio,
 			friends: u.friends,
-			bannerUrl: u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp",
-			avatarUrl: u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp",
+			bannerUrl,
+			avatarUrl,
 		};
 	} catch (err) {
 		return rejectWithValue(err.response?.data || err.message);
@@ -83,9 +100,17 @@ export const registerUser = createAsyncThunk(
 				user: { username, email, displayName, bio, password },
 			});
 			const u = data.user;
+
 			if (stayLoggedIn) {
 				window.localStorage.setItem("auth-token", u.token);
 			}
+
+			const rawBanner = u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp";
+			const rawAvatar = u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp";
+
+			const bannerUrl = await cacheMedia(rawBanner);
+			const avatarUrl = await cacheMedia(rawAvatar);
+
 			return {
 				loggedIn: true,
 				authToken: u.token,
@@ -94,8 +119,8 @@ export const registerUser = createAsyncThunk(
 				displayName: u.displayName,
 				bio: u.bio,
 				friends: u.friends,
-				bannerUrl: u?.bannerUrl && u.bannerUrl !== "" ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp",
-				avatarUrl: u?.avatarUrl && u.avatarUrl !== "" ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp",
+				bannerUrl,
+				avatarUrl,
 			};
 		} catch (err) {
 			return rejectWithValue(err.response?.data || err.message);

--- a/src/slices/chatApiSlice.js
+++ b/src/slices/chatApiSlice.js
@@ -1,0 +1,51 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+import { getApiBase } from "../helpers/api";
+import cacheMedia from "../helpers/cacheMedia";
+
+const base = getApiBase();
+
+export const mapMessages = (msgs) =>
+    msgs.map((m) => ({
+        ...m,
+        sender: {
+            ...m.sender,
+            avatarUrl: m.sender?.avatarUrl ? cacheMedia(base + m.sender.avatarUrl) : null,
+        },
+    }));
+
+export const fetchRoomMessages = createAsyncThunk(
+    "chatApi/fetchRoomMessages",
+    async ({ roomId, authToken }, { rejectWithValue }) => {
+        try {
+            const { data } = await axios.get(`${base}/rooms/${roomId}/messages`, {
+                headers: { Authorization: `Bearer ${authToken}` },
+            });
+            return { roomId, messages: mapMessages(data.messages) };
+        } catch (err) {
+            return rejectWithValue(err.response?.data || err.message);
+        }
+    }
+);
+
+const chatApiSlice = createSlice({
+    name: "chatApi",
+    initialState: { messages: {} },
+    reducers: {
+        clearMessages(state, action) {
+            if (action.payload?.roomId) {
+                delete state.messages[action.payload.roomId];
+            } else {
+                state.messages = {};
+            }
+        },
+    },
+    extraReducers: (builder) => {
+        builder.addCase(fetchRoomMessages.fulfilled, (state, action) => {
+            state.messages[action.payload.roomId] = action.payload.messages;
+        });
+    },
+});
+
+export const { clearMessages } = chatApiSlice.actions;
+export default chatApiSlice.reducer;

--- a/src/slices/chatApiSlice.js
+++ b/src/slices/chatApiSlice.js
@@ -6,47 +6,44 @@ import cacheMedia from "../helpers/cacheMedia";
 const base = getApiBase();
 
 export const mapMessages = async (msgs) =>
-    Promise.all(
-        msgs.map(async (m) => ({
-            ...m,
-            sender: {
-                ...m.sender,
-                avatarUrl: m.sender?.avatarUrl ? await cacheMedia(base + m.sender.avatarUrl) : null,
-            },
-        }))
-    );
+	Promise.all(
+		msgs.map(async (m) => ({
+			...m,
+			sender: {
+				...m.sender,
+				avatarUrl: m.sender?.avatarUrl ? await cacheMedia(base + m.sender.avatarUrl) : null,
+			},
+		}))
+	);
 
-export const fetchRoomMessages = createAsyncThunk(
-    "chatApi/fetchRoomMessages",
-    async ({ roomId, authToken }, { rejectWithValue }) => {
-        try {
-            const { data } = await axios.get(`${base}/rooms/${roomId}/messages`, {
-                headers: { Authorization: `Bearer ${authToken}` },
-            });
-            return { roomId, messages: await mapMessages(data.messages) };
-        } catch (err) {
-            return rejectWithValue(err.response?.data || err.message);
-        }
-    }
-);
+export const fetchRoomMessages = createAsyncThunk("chatApi/fetchRoomMessages", async ({ roomId, authToken }, { rejectWithValue }) => {
+	try {
+		const { data } = await axios.get(`${base}/rooms/${roomId}/messages`, {
+			headers: { Authorization: `Bearer ${authToken}` },
+		});
+		return { roomId, messages: await mapMessages(data.messages) };
+	} catch (err) {
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
 const chatApiSlice = createSlice({
-    name: "chatApi",
-    initialState: { messages: {} },
-    reducers: {
-        clearMessages(state, action) {
-            if (action.payload?.roomId) {
-                delete state.messages[action.payload.roomId];
-            } else {
-                state.messages = {};
-            }
-        },
-    },
-    extraReducers: (builder) => {
-        builder.addCase(fetchRoomMessages.fulfilled, (state, action) => {
-            state.messages[action.payload.roomId] = action.payload.messages;
-        });
-    },
+	name: "chatApi",
+	initialState: { messages: {} },
+	reducers: {
+		clearMessages(state, action) {
+			if (action.payload?.roomId) {
+				delete state.messages[action.payload.roomId];
+			} else {
+				state.messages = {};
+			}
+		},
+	},
+	extraReducers: (builder) => {
+		builder.addCase(fetchRoomMessages.fulfilled, (state, action) => {
+			state.messages[action.payload.roomId] = action.payload.messages;
+		});
+	},
 });
 
 export const { clearMessages } = chatApiSlice.actions;

--- a/src/slices/chatApiSlice.js
+++ b/src/slices/chatApiSlice.js
@@ -5,14 +5,16 @@ import cacheMedia from "../helpers/cacheMedia";
 
 const base = getApiBase();
 
-export const mapMessages = (msgs) =>
-    msgs.map((m) => ({
-        ...m,
-        sender: {
-            ...m.sender,
-            avatarUrl: m.sender?.avatarUrl ? cacheMedia(base + m.sender.avatarUrl) : null,
-        },
-    }));
+export const mapMessages = async (msgs) =>
+    Promise.all(
+        msgs.map(async (m) => ({
+            ...m,
+            sender: {
+                ...m.sender,
+                avatarUrl: m.sender?.avatarUrl ? await cacheMedia(base + m.sender.avatarUrl) : null,
+            },
+        }))
+    );
 
 export const fetchRoomMessages = createAsyncThunk(
     "chatApi/fetchRoomMessages",
@@ -21,7 +23,7 @@ export const fetchRoomMessages = createAsyncThunk(
             const { data } = await axios.get(`${base}/rooms/${roomId}/messages`, {
                 headers: { Authorization: `Bearer ${authToken}` },
             });
-            return { roomId, messages: mapMessages(data.messages) };
+            return { roomId, messages: await mapMessages(data.messages) };
         } catch (err) {
             return rejectWithValue(err.response?.data || err.message);
         }

--- a/src/slices/index.js
+++ b/src/slices/index.js
@@ -4,12 +4,16 @@ import authReducer from "./authSlice";
 import dialogReducer from "./dialogSlice";
 import settingsReducer from "./settingsSlice";
 import snackbarReducer from "./snackbarSlice";
+import userApiReducer from "./userApiSlice";
+import chatApiReducer from "./chatApiSlice";
 
 const rootReducer = combineReducers({
-	dialogs: dialogReducer,
-	auth: authReducer,
-	snackbars: snackbarReducer,
-	settings: settingsReducer,
+        dialogs: dialogReducer,
+        auth: authReducer,
+        snackbars: snackbarReducer,
+        settings: settingsReducer,
+        userApi: userApiReducer,
+        chatApi: chatApiReducer,
 });
 
 export default rootReducer;

--- a/src/slices/userApiSlice.js
+++ b/src/slices/userApiSlice.js
@@ -5,88 +5,83 @@ import { getApiBase } from "../helpers/api";
 import cacheMedia from "../helpers/cacheMedia";
 
 const initialState = {
-    profiles: {},
+	profiles: {},
 };
 
-export const fetchUserProfile = createAsyncThunk(
-    "userApi/fetchUserProfile",
-    async ({ userId, authToken } = {}, { rejectWithValue }) => {
-        const base = getApiBase();
-        try {
-            const { data } = await axios.get(`${base}/users/profile`, {
-                headers: { Authorization: `Bearer ${authToken}` },
-                params: userId ? { id: userId } : undefined,
-            });
-            const u = data.user;
-            return {
-                id: u.id,
-                profile: {
-                    ...u,
-                    avatarUrl: u.avatarUrl ? await cacheMedia(base + u.avatarUrl) : null,
-                    bannerUrl: u.bannerUrl ? await cacheMedia(base + u.bannerUrl) : null,
-                },
-            };
-        } catch (err) {
-            return rejectWithValue(err.response?.data || err.message);
-        }
-    }
-);
+export const fetchUserProfile = createAsyncThunk("userApi/fetchUserProfile", async ({ userId, authToken } = {}, { rejectWithValue }) => {
+	const base = getApiBase();
+	try {
+		const { data } = await axios.get(`${base}/users/profile`, {
+			headers: { Authorization: `Bearer ${authToken}` },
+			params: userId ? { id: userId } : undefined,
+		});
+		const u = data.user;
+		return {
+			id: u.id,
+			profile: {
+				...u,
+				avatarUrl: u.avatarUrl ? await cacheMedia(base + u.avatarUrl) : null,
+				bannerUrl: u.bannerUrl ? await cacheMedia(base + u.bannerUrl) : null,
+			},
+		};
+	} catch (err) {
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
-export const modifyProfile = createAsyncThunk(
-    "userApi/modifyProfile",
-    async ({ formData, authToken }, { rejectWithValue }) => {
-        const base = getApiBase();
-        try {
-            const { data } = await axios.put(`${base}/users/modify`, formData, {
-                headers: { Authorization: `Bearer ${authToken}` },
-            });
-            const u = data.user;
-            return {
-                id: u.id,
-                profile: {
-                    ...u,
-                    avatarUrl: u.avatarUrl ? await cacheMedia(base + u.avatarUrl) : null,
-                    bannerUrl: u.bannerUrl ? await cacheMedia(base + u.bannerUrl) : null,
-                },
-            };
-        } catch (err) {
-            return rejectWithValue(err.response?.data || err.message);
-        }
-    }
-);
+export const modifyProfile = createAsyncThunk("userApi/modifyProfile", async ({ formData, authToken }, { rejectWithValue }) => {
+	const base = getApiBase();
+	try {
+		const { data } = await axios.put(`${base}/users/modify`, formData, {
+			headers: { Authorization: `Bearer ${authToken}` },
+		});
+		const u = data.user;
+		console.log(u.avatarUrl);
+		return {
+			id: u.id,
+			profile: {
+				...u,
+				avatarUrl: u.avatarUrl ? await cacheMedia(base + u.avatarUrl) : null,
+				bannerUrl: u.bannerUrl ? await cacheMedia(base + u.bannerUrl) : null,
+			},
+		};
+	} catch (err) {
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
 export const friendAction = createAsyncThunk(
-    "userApi/friendAction",
-    async ({ ep, data, authToken, message, severity = "success" }, { dispatch, rejectWithValue }) => {
-        const base = getApiBase();
-        try {
-            await axios.put(`${base}/users/${ep}`, data, {
-                headers: { Authorization: `Bearer ${authToken}` },
-            });
-            if (message) {
-                dispatch(addSnackbar({ snackbarMsg: message, snackbarSeverity: severity, autoHideDuration: 1500 }));
-            }
-            return true;
-        } catch (err) {
-            dispatch(addSnackbar({ snackbarMsg: "Error", snackbarSeverity: "error", autoHideDuration: 1500 }));
-            return rejectWithValue(err.response?.data || err.message);
-        }
-    }
+	"userApi/friendAction",
+	async ({ ep, data, authToken, message, severity = "success" }, { dispatch, rejectWithValue }) => {
+		const base = getApiBase();
+		try {
+			await axios.put(`${base}/users/${ep}`, data, {
+				headers: { Authorization: `Bearer ${authToken}` },
+			});
+			if (message) {
+				dispatch(addSnackbar({ snackbarMsg: message, snackbarSeverity: severity, autoHideDuration: 1500 }));
+			}
+			return true;
+		} catch (err) {
+			dispatch(addSnackbar({ snackbarMsg: "Error", snackbarSeverity: "error", autoHideDuration: 1500 }));
+			return rejectWithValue(err.response?.data || err.message);
+		}
+	}
 );
 
 const userApiSlice = createSlice({
-    name: "userApi",
-    initialState,
-    reducers: {},
-    extraReducers: (builder) => {
-        builder
-            .addCase(fetchUserProfile.fulfilled, (state, action) => {
-                state.profiles[action.payload.id] = action.payload.profile;
-            })
-            .addCase(modifyProfile.fulfilled, (state, action) => {
-                state.profiles[action.payload.id] = action.payload.profile;
-            });
-    },
+	name: "userApi",
+	initialState,
+	reducers: {},
+	extraReducers: (builder) => {
+		builder
+			.addCase(fetchUserProfile.fulfilled, (state, action) => {
+				state.profiles[action.payload.id] = action.payload.profile;
+			})
+			.addCase(modifyProfile.fulfilled, (state, action) => {
+				state.profiles[action.payload.id] = action.payload.profile;
+			});
+	},
 });
 
 export default userApiSlice.reducer;

--- a/src/slices/userApiSlice.js
+++ b/src/slices/userApiSlice.js
@@ -1,0 +1,92 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+import { addSnackbar } from "./snackbarSlice";
+import { getApiBase } from "../helpers/api";
+import cacheMedia from "../helpers/cacheMedia";
+
+const initialState = {
+    profiles: {},
+};
+
+export const fetchUserProfile = createAsyncThunk(
+    "userApi/fetchUserProfile",
+    async ({ userId, authToken } = {}, { rejectWithValue }) => {
+        const base = getApiBase();
+        try {
+            const { data } = await axios.get(`${base}/users/profile`, {
+                headers: { Authorization: `Bearer ${authToken}` },
+                params: userId ? { id: userId } : undefined,
+            });
+            const u = data.user;
+            return {
+                id: u.id,
+                profile: {
+                    ...u,
+                    avatarUrl: u.avatarUrl ? cacheMedia(base + u.avatarUrl) : null,
+                    bannerUrl: u.bannerUrl ? cacheMedia(base + u.bannerUrl) : null,
+                },
+            };
+        } catch (err) {
+            return rejectWithValue(err.response?.data || err.message);
+        }
+    }
+);
+
+export const modifyProfile = createAsyncThunk(
+    "userApi/modifyProfile",
+    async ({ formData, authToken }, { rejectWithValue }) => {
+        const base = getApiBase();
+        try {
+            const { data } = await axios.put(`${base}/users/modify`, formData, {
+                headers: { Authorization: `Bearer ${authToken}` },
+            });
+            const u = data.user;
+            return {
+                id: u.id,
+                profile: {
+                    ...u,
+                    avatarUrl: u.avatarUrl ? cacheMedia(base + u.avatarUrl) : null,
+                    bannerUrl: u.bannerUrl ? cacheMedia(base + u.bannerUrl) : null,
+                },
+            };
+        } catch (err) {
+            return rejectWithValue(err.response?.data || err.message);
+        }
+    }
+);
+
+export const friendAction = createAsyncThunk(
+    "userApi/friendAction",
+    async ({ ep, data, authToken, message, severity = "success" }, { dispatch, rejectWithValue }) => {
+        const base = getApiBase();
+        try {
+            await axios.put(`${base}/users/${ep}`, data, {
+                headers: { Authorization: `Bearer ${authToken}` },
+            });
+            if (message) {
+                dispatch(addSnackbar({ snackbarMsg: message, snackbarSeverity: severity, autoHideDuration: 1500 }));
+            }
+            return true;
+        } catch (err) {
+            dispatch(addSnackbar({ snackbarMsg: "Error", snackbarSeverity: "error", autoHideDuration: 1500 }));
+            return rejectWithValue(err.response?.data || err.message);
+        }
+    }
+);
+
+const userApiSlice = createSlice({
+    name: "userApi",
+    initialState,
+    reducers: {},
+    extraReducers: (builder) => {
+        builder
+            .addCase(fetchUserProfile.fulfilled, (state, action) => {
+                state.profiles[action.payload.id] = action.payload.profile;
+            })
+            .addCase(modifyProfile.fulfilled, (state, action) => {
+                state.profiles[action.payload.id] = action.payload.profile;
+            });
+    },
+});
+
+export default userApiSlice.reducer;

--- a/src/slices/userApiSlice.js
+++ b/src/slices/userApiSlice.js
@@ -22,8 +22,8 @@ export const fetchUserProfile = createAsyncThunk(
                 id: u.id,
                 profile: {
                     ...u,
-                    avatarUrl: u.avatarUrl ? cacheMedia(base + u.avatarUrl) : null,
-                    bannerUrl: u.bannerUrl ? cacheMedia(base + u.bannerUrl) : null,
+                    avatarUrl: u.avatarUrl ? await cacheMedia(base + u.avatarUrl) : null,
+                    bannerUrl: u.bannerUrl ? await cacheMedia(base + u.bannerUrl) : null,
                 },
             };
         } catch (err) {
@@ -45,8 +45,8 @@ export const modifyProfile = createAsyncThunk(
                 id: u.id,
                 profile: {
                     ...u,
-                    avatarUrl: u.avatarUrl ? cacheMedia(base + u.avatarUrl) : null,
-                    bannerUrl: u.bannerUrl ? cacheMedia(base + u.bannerUrl) : null,
+                    avatarUrl: u.avatarUrl ? await cacheMedia(base + u.avatarUrl) : null,
+                    bannerUrl: u.bannerUrl ? await cacheMedia(base + u.bannerUrl) : null,
                 },
             };
         } catch (err) {


### PR DESCRIPTION
## Summary
- move user profile and messaging calls to Redux Toolkit slices
- refactor hooks to dispatch async actions instead of calling axios

## Testing
- `pnpm test`
- `cd server && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6849cde66b648327b0176e3be267ed41