### PR TITLE
Add media caching tests

### DIFF
--- a/src/__tests__/cacheMedia.test.js
+++ b/src/__tests__/cacheMedia.test.js
@@ -1,0 +1,49 @@
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import cacheMedia from "../helpers/cacheMedia.js";
+
+let cacheStore;
+let cacheObj;
+let openSpy;
+
+beforeEach(() => {
+    cacheStore = new Map();
+    cacheObj = {
+        match: vi.fn((url) => Promise.resolve(cacheStore.get(url))),
+        put: vi.fn((url, resp) => {
+            cacheStore.set(url, resp);
+            return Promise.resolve();
+        }),
+    };
+    openSpy = vi.fn(() => Promise.resolve(cacheObj));
+    global.caches = { open: openSpy };
+    const res = { ok: true, blob: () => Promise.resolve(new Blob(["img"])) };
+    res.clone = () => res;
+    global.fetch = vi.fn(() => Promise.resolve(res));
+    global.URL.createObjectURL = vi.fn(() => "blob:url");
+});
+
+afterEach(() => {
+    delete global.caches;
+    vi.restoreAllMocks();
+});
+
+describe("cacheMedia helper", () => {
+    test("fetches and caches when not already cached", async () => {
+        const url = "http://example.com/image.png";
+        const result = await cacheMedia(url);
+        expect(openSpy).toHaveBeenCalledWith("media-cache");
+        expect(global.fetch).toHaveBeenCalledWith(url);
+        expect(cacheObj.put).toHaveBeenCalled();
+        expect(result).toBe("blob:url");
+    });
+
+    test("uses cached response when available", async () => {
+        const url = "http://example.com/cached.png";
+        const response = { ok: true, blob: () => Promise.resolve(new Blob(["img"])) };
+        response.clone = () => response;
+        cacheStore.set(url, response);
+        const result = await cacheMedia(url);
+        expect(global.fetch).not.toHaveBeenCalled();
+        expect(result).toBe("blob:url");
+    });
+});

--- a/src/__tests__/useFilePreview.test.js
+++ b/src/__tests__/useFilePreview.test.js
@@ -1,0 +1,25 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import { useFilePreview } from "../components/User/useProfileCard.js";
+
+vi.mock("../helpers/cacheMedia");
+import cacheMedia from "../helpers/cacheMedia";
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+afterEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("useFilePreview", () => {
+    test("loads and caches media", async () => {
+        cacheMedia.mockResolvedValue("cached-url");
+        const { result } = renderHook(() => useFilePreview("http://example.com/img.png"));
+        await waitFor(() => {
+            expect(cacheMedia).toHaveBeenCalledWith("http://example.com/img.png");
+            expect(result.current.preview).toBe("cached-url");
+        });
+    });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -7,11 +7,12 @@ export default defineConfig(({ mode }) => ({
 	resolve: {
 		alias: {
 			slices: path.resolve(__dirname, "./src/slices"),
-			...(process.env.VITEST
-				? {
-						"@mui/icons-material": path.resolve(__dirname, "./src/muiIconsStub.js"),
-					}
-				: {}),
+                        ...(process.env.VITEST
+                                ? {
+                                                "@mui/icons-material": path.resolve(__dirname, "./src/muiIconsStub.js"),
+                                                "@mui/icons-material/*": path.resolve(__dirname, "./src/muiIconsStub.js"),
+                                        }
+                                : {}),
 		},
 	},
 	plugins: [react()],


### PR DESCRIPTION
## Summary
- add unit tests for media caching helper
- test profile card hook's file preview caching
- support `@mui/icons-material/*` alias during vitest

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684cab343e348327bad642511320954f