### PR TITLE
Fix build script comment

### DIFF
--- a/projectscripts/clean-build.js
+++ b/projectscripts/clean-build.js
@@ -11,7 +11,7 @@ const buildDir = path.join(__dirname, "..", "build");
 const appDir = path.join(__dirname, "..", "app");
 
 try {
-	// 1) ensure/clear appDir
+        // 1) ensure/clear appDir
 	if (!fs.existsSync(appDir)) {
 		fs.mkdirSync(appDir);
 	} else {
@@ -20,12 +20,12 @@ try {
 		}
 	}
 
-	// 2) copy build → app/build
+        // 2) copy build → app/build
 	if (fs.existsSync(buildDir)) {
 		fs.cpSync(buildDir, path.join(appDir, "build"), { recursive: true });
 	}
 
-	// 4) write new package.json
+        // 3) write new package.json
 	const { version, author, dependencies } = packageJson;
 	const newPkg = {
 		name: "rebound-desktop",


### PR DESCRIPTION
## Summary
- fix out-of-order numbering in the `clean-build.js` script

## Testing
- `pnpm test`
- `(cd server && pnpm test)`

------
https://chatgpt.com/codex/tasks/task_e_684cbc551c688327a2c2ef3b52c335a4