### PR TITLE
Add MUI title bar for Electron app

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -27,15 +27,17 @@ function sendStatus(channel, payload = {}) {
 async function createWindow() {
 	const preloadPath = join(__dirname, "preload.js");
 
-	mainWindow = new BrowserWindow({
-		width: 1280,
-		height: 720,
-		webPreferences: {
-			nodeIntegration: false,
-			contextIsolation: true,
-			preload: preloadPath,
-		},
-	});
+        mainWindow = new BrowserWindow({
+                width: 1280,
+                height: 720,
+                frame: false,
+                titleBarStyle: "hidden",
+                webPreferences: {
+                        nodeIntegration: false,
+                        contextIsolation: true,
+                        preload: preloadPath,
+                },
+        });
 
 	if (isDev) {
 		mainWindow.loadURL("http://localhost:3000");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,7 @@ import { BrowserRouter, HashRouter, Route, Routes } from "react-router-dom";
 import "./App.css";
 
 import CustomAppBar from "./components/CustomAppBar/CustomAppBar";
+import TitleBar from "./components/TitleBar";
 import LoginDialog from "./components/LoginDialog.comp";
 import RegisterDialog from "./components/RegisterDialog";
 import SnackbarMapper from "./components/SnackbarMapper";
@@ -106,9 +107,10 @@ const App = () => {
 		<ThemeProvider theme={darkTheme}>
 			{window.isElectron && <AutoUpdate />}
 			<CssBaseline />
-			<SnackbarMapper drawerWidth={customAppBarProps.drawerWidth} drawerOpen={customAppBarProps.drawerOpen} />
-			<AppRouter>
-				<RegisterDialog />
+                        <SnackbarMapper drawerWidth={customAppBarProps.drawerWidth} drawerOpen={customAppBarProps.drawerOpen} />
+                        <AppRouter>
+                                {window.isElectron && <TitleBar />}
+                                <RegisterDialog />
 				<LoginDialog />
 				<CustomAppBar {...customAppBarProps}>
 					{!authState.loggingIn ? (

--- a/src/__tests__/TitleBar.test.jsx
+++ b/src/__tests__/TitleBar.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from "@testing-library/react";
+import { Provider } from "react-redux";
+import { configureStore } from "@reduxjs/toolkit";
+import { describe, test, expect } from "vitest";
+import rootReducer from "../slices";
+import TitleBar from "../components/TitleBar.jsx";
+
+describe("TitleBar", () => {
+    test("displays notification count", () => {
+        const store = configureStore({
+            reducer: rootReducer,
+            preloadedState: { snackbars: { snackbarList: { 1: {} } } },
+        });
+        render(
+            <Provider store={store}>
+                <TitleBar />
+            </Provider>
+        );
+        expect(screen.getByText("1")).toBeInTheDocument();
+    });
+});

--- a/src/components/CustomAppBar/AppBarContent.jsx
+++ b/src/components/CustomAppBar/AppBarContent.jsx
@@ -2,13 +2,14 @@ import AccountCircleRounded from "@mui/icons-material/AccountCircleRounded";
 import { AppBar, Toolbar, Typography, IconButton, Avatar } from "@mui/material";
 
 const AppBarContent = ({ handleIconClick, drawerWidth, loggedInState, avatarUrl, theme }) => (
-	<AppBar
-		position="fixed"
-		sx={{
-			width: `calc(100% - ${drawerWidth}px)`,
-			ml: `${drawerWidth}px`,
-			boxShadow: "none",
-		}}>
+        <AppBar
+                position="fixed"
+                sx={{
+                        width: `calc(100% - ${drawerWidth}px)`,
+                        ml: `${drawerWidth}px`,
+                        boxShadow: "none",
+                        top: `${window.isElectron ? 32 : 0}px`,
+                }}>
 		<Toolbar
 			variant="dense"
 			sx={{

--- a/src/components/CustomAppBar/CustomAppBar.jsx
+++ b/src/components/CustomAppBar/CustomAppBar.jsx
@@ -23,15 +23,17 @@ function CustomAppBar({
 	const theme = useTheme();
 	const auth = useSelector((s) => s.auth);
 
-	return (
-		<Box
-			sx={{
-				display: "flex",
-				height: "100%",
-				width: "100%",
-				position: "fixed",
-				top: 0,
-			}}>
+        const titleOffset = window.isElectron ? 32 : 0;
+
+        return (
+                <Box
+                        sx={{
+                                display: "flex",
+                                height: "100%",
+                                width: "100%",
+                                position: "fixed",
+                                top: `${titleOffset}px`,
+                        }}>
 			<AppBarContent
 				handleIconClick={handleIconClick}
 				iconWidth={iconWidth}

--- a/src/components/CustomAppBar/DrawerMenu.jsx
+++ b/src/components/CustomAppBar/DrawerMenu.jsx
@@ -10,17 +10,19 @@ import { Toolbar, List, Divider, Drawer, Tooltip, ListItem, ListItemButton, List
 import { useNavigate, useLocation } from "react-router-dom";
 
 const drawerStyles = (drawerWidth, iconWidth) => ({
-	width: drawerWidth,
-	flexShrink: 0,
-	"& .MuiDrawer-paper": {
-		width: `${drawerWidth}px`,
-		boxSizing: "border-box",
-	},
-	".MuiSvgIcon-root": {
-		width: `${iconWidth}px`,
-		height: `${iconWidth}px`,
-		margin: `${(drawerWidth - iconWidth) / 2}px`,
-	},
+        width: drawerWidth,
+        flexShrink: 0,
+        top: `${window.isElectron ? 32 : 0}px`,
+        "& .MuiDrawer-paper": {
+                width: `${drawerWidth}px`,
+                boxSizing: "border-box",
+                top: `${window.isElectron ? 32 : 0}px`,
+        },
+        ".MuiSvgIcon-root": {
+                width: `${iconWidth}px`,
+                height: `${iconWidth}px`,
+                margin: `${(drawerWidth - iconWidth) / 2}px`,
+        },
 });
 
 const ListItemWithTooltip = ({ title, placement, children }) => (

--- a/src/components/CustomAppBar/MainContent.jsx
+++ b/src/components/CustomAppBar/MainContent.jsx
@@ -2,21 +2,24 @@ import ChevronRightRounded from "@mui/icons-material/ChevronRightRounded";
 import { Toolbar, Box, IconButton, Tooltip } from "@mui/material";
 import { styled, useTheme } from "@mui/material/styles";
 
+const offset = typeof window !== "undefined" && window.isElectron ? 32 : 0;
+
 const MainBox = styled(Box)(({ theme }) => ({
-	position: "absolute",
-	flexGrow: 1,
-	padding: 2,
-	height: "100%",
-	display: "flex",
-	flexDirection: "column",
+        position: "absolute",
+        flexGrow: 1,
+        padding: 2,
+        height: `calc(100% - ${offset}px)`,
+        display: "flex",
+        flexDirection: "column",
+        top: `${offset}px`,
 }));
 
 const IconBox = styled(Box)(({ theme }) => ({
-	backgroundColor: theme.palette.primary.main,
-	position: "fixed",
-	left: 0,
-	p: 0,
-	top: 0,
+        backgroundColor: theme.palette.primary.main,
+        position: "fixed",
+        left: 0,
+        p: 0,
+        top: offset,
 }));
 
 function MainContent({ drawerWidth, drawerOpen, iconWidth, setDrawerOpen, children }) {

--- a/src/components/TitleBar.jsx
+++ b/src/components/TitleBar.jsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { AppBar, Toolbar, Typography, Badge, Box, useTheme, useMediaQuery } from "@mui/material";
+import { useSelector } from "react-redux";
+
+export default function TitleBar() {
+    const theme = useTheme();
+    const small = useMediaQuery(theme.breakpoints.down("sm"));
+    const notifications = useSelector((s) => Object.keys(s.snackbars.snackbarList).length);
+    const barHeight = small ? 28 : 32;
+
+    return (
+        <AppBar
+            position="fixed"
+            color="primary"
+            sx={{
+                top: 0,
+                left: 0,
+                right: 0,
+                height: `${barHeight}px`,
+                WebkitAppRegion: "drag",
+                zIndex: theme.zIndex.appBar + 2,
+            }}
+            elevation={0}
+        >
+            <Toolbar variant="dense" sx={{ minHeight: barHeight, height: barHeight, px: 1 }}>
+                <Typography variant="body2" sx={{ flexGrow: 1 }}>
+                    Rebound
+                </Typography>
+                <Badge color="secondary" badgeContent={notifications}>
+                    <Box sx={{ width: 8, height: 8 }} />
+                </Badge>
+            </Toolbar>
+        </AppBar>
+    );
+}


### PR DESCRIPTION
## Summary
- implement a custom MUI `TitleBar` component
- integrate the title bar in the Electron build
- offset app layout when running in Electron
- expose a frameless window for use with the new bar
- test the new title bar notification badge

## Testing
- `pnpm test`
- `cd server && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ceaad79988327b06c75cc31a303b7