### PR TITLE
Implement direct messaging

### DIFF
--- a/server/src/models/DmThread.js
+++ b/server/src/models/DmThread.js
@@ -1,0 +1,11 @@
+import mongoose, { Schema } from "mongoose";
+
+const DmThreadSchema = new mongoose.Schema(
+  {
+    participants: [{ type: Schema.Types.ObjectId, ref: "User" }],
+    messages: [{ type: Schema.Types.ObjectId, ref: "Message" }],
+  },
+  { timestamps: true }
+);
+
+export default mongoose.model("DmThread", DmThreadSchema);

--- a/server/src/routes/api/dms.js
+++ b/server/src/routes/api/dms.js
@@ -1,0 +1,74 @@
+import { Router } from "express";
+import jwt from "jsonwebtoken";
+import { auth, getTokenFromHeader } from "../auth.js";
+import DmThreadModel from "../../models/DmThread.js";
+import MessageModel from "../../models/Message.js";
+import UserModel from "../../models/User.js";
+import logger from "../../logger.js";
+import rateLimit from "express-rate-limit";
+
+const router = Router();
+
+const messagesLimiter = rateLimit({
+  windowMs: 60 * 1000,
+  max: 3000,
+  standardHeaders: true,
+  legacyHeaders: false,
+  message: { error: "Too many requests, please try again later." },
+});
+
+async function getThread(userId, otherId) {
+  let thread = await DmThreadModel.findOne({
+    participants: { $all: [userId, otherId], $size: 2 },
+  }).populate({
+    path: "messages",
+    options: { sort: { createdAt: 1 } },
+    populate: { path: "sender", select: "displayName avatarUrl" },
+  });
+  if (!thread) {
+    thread = new DmThreadModel({ participants: [userId, otherId], messages: [] });
+    await thread.save();
+  }
+  return thread;
+}
+
+router.get("/dms/:userId/messages", messagesLimiter, auth.required, async (req, res, next) => {
+  const token = getTokenFromHeader(req);
+  try {
+    const decoded = jwt.verify(token, process.env.SECRET);
+    const otherId = req.params.userId;
+    if (!(await UserModel.exists({ _id: otherId }))) return res.sendStatus(404);
+    const thread = await getThread(decoded.id, otherId);
+    return res.json({ threadId: thread._id, messages: thread.messages });
+  } catch (err) {
+    logger.error("Error fetching DM messages:", err);
+    return next(err);
+  }
+});
+
+router.post("/dms/:userId/messages", auth.required, async (req, res, next) => {
+  const token = getTokenFromHeader(req);
+  try {
+    const decoded = jwt.verify(token, process.env.SECRET);
+    const otherId = req.params.userId;
+    const { content } = req.body;
+    if (!content) return res.status(400).json({ error: "Content required" });
+    if (!(await UserModel.exists({ _id: otherId }))) return res.sendStatus(404);
+    const thread = await getThread(decoded.id, otherId);
+    const msg = new MessageModel({ sender: decoded.id, content });
+    await msg.save();
+    thread.messages.push(msg);
+    await thread.save();
+    await thread.populate({
+      path: "messages",
+      options: { sort: { createdAt: 1 } },
+      populate: { path: "sender", select: "displayName avatarUrl" },
+    });
+    return res.json({ threadId: thread._id, messages: thread.messages });
+  } catch (err) {
+    logger.error("Error sending DM:", err);
+    return next(err);
+  }
+});
+
+export default router;

--- a/server/src/routes/api/dms.js
+++ b/server/src/routes/api/dms.js
@@ -10,65 +10,68 @@ import rateLimit from "express-rate-limit";
 const router = Router();
 
 const messagesLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 3000,
-  standardHeaders: true,
-  legacyHeaders: false,
-  message: { error: "Too many requests, please try again later." },
+	windowMs: 60 * 1000,
+	max: 3000,
+	standardHeaders: true,
+	legacyHeaders: false,
+	message: { error: "Too many requests, please try again later." },
 });
 
 async function getThread(userId, otherId) {
-  let thread = await DmThreadModel.findOne({
-    participants: { $all: [userId, otherId], $size: 2 },
-  }).populate({
-    path: "messages",
-    options: { sort: { createdAt: 1 } },
-    populate: { path: "sender", select: "displayName avatarUrl" },
-  });
-  if (!thread) {
-    thread = new DmThreadModel({ participants: [userId, otherId], messages: [] });
-    await thread.save();
-  }
-  return thread;
+	if (userId === otherId) return;
+	let thread = await DmThreadModel.findOne({
+		participants: { $all: [userId, otherId], $size: 2 },
+	}).populate({
+		path: "messages",
+		options: { sort: { createdAt: 1 } },
+		populate: { path: "sender", select: "displayName avatarUrl" },
+	});
+	if (!thread) {
+		thread = new DmThreadModel({ participants: [userId, otherId], messages: [] });
+		await thread.save();
+	}
+	return thread;
 }
 
 router.get("/dms/:userId/messages", messagesLimiter, auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  try {
-    const decoded = jwt.verify(token, process.env.SECRET);
-    const otherId = req.params.userId;
-    if (!(await UserModel.exists({ _id: otherId }))) return res.sendStatus(404);
-    const thread = await getThread(decoded.id, otherId);
-    return res.json({ threadId: thread._id, messages: thread.messages });
-  } catch (err) {
-    logger.error("Error fetching DM messages:", err);
-    return next(err);
-  }
+	const token = getTokenFromHeader(req);
+	try {
+		const decoded = jwt.verify(token, process.env.SECRET);
+		const otherId = req.params.userId;
+		if (decoded.id === otherId) return res.status(400).json({ error: "Cannot message yourself" });
+		if (!(await UserModel.exists({ _id: otherId }))) return res.sendStatus(404);
+		const thread = await getThread(decoded.id, otherId);
+		return res.json({ threadId: thread._id, messages: thread.messages });
+	} catch (err) {
+		logger.error("Error fetching DM messages:", err);
+		return next(err);
+	}
 });
 
 router.post("/dms/:userId/messages", auth.required, async (req, res, next) => {
-  const token = getTokenFromHeader(req);
-  try {
-    const decoded = jwt.verify(token, process.env.SECRET);
-    const otherId = req.params.userId;
-    const { content } = req.body;
-    if (!content) return res.status(400).json({ error: "Content required" });
-    if (!(await UserModel.exists({ _id: otherId }))) return res.sendStatus(404);
-    const thread = await getThread(decoded.id, otherId);
-    const msg = new MessageModel({ sender: decoded.id, content });
-    await msg.save();
-    thread.messages.push(msg);
-    await thread.save();
-    await thread.populate({
-      path: "messages",
-      options: { sort: { createdAt: 1 } },
-      populate: { path: "sender", select: "displayName avatarUrl" },
-    });
-    return res.json({ threadId: thread._id, messages: thread.messages });
-  } catch (err) {
-    logger.error("Error sending DM:", err);
-    return next(err);
-  }
+	const token = getTokenFromHeader(req);
+	try {
+		const decoded = jwt.verify(token, process.env.SECRET);
+		const otherId = req.params.userId;
+		if (decoded.id === otherId) return res.status(400).json({ error: "Cannot message yourself" });
+		const { content } = req.body;
+		if (!content) return res.status(400).json({ error: "Content required" });
+		if (!(await UserModel.exists({ _id: otherId }))) return res.sendStatus(404);
+		const thread = await getThread(decoded.id, otherId);
+		const msg = new MessageModel({ sender: decoded.id, content });
+		await msg.save();
+		thread.messages.push(msg);
+		await thread.save();
+		await thread.populate({
+			path: "messages",
+			options: { sort: { createdAt: 1 } },
+			populate: { path: "sender", select: "displayName avatarUrl" },
+		});
+		return res.json({ threadId: thread._id, messages: thread.messages });
+	} catch (err) {
+		logger.error("Error sending DM:", err);
+		return next(err);
+	}
 });
 
 export default router;

--- a/server/src/routes/api/index.js
+++ b/server/src/routes/api/index.js
@@ -4,6 +4,7 @@ import adminApi from "./admin.js";
 import devApi from "./dev.js";
 import usersApi from "./users.js";
 import chatApi from "./chat.js";
+import dmApi from "./dms.js";
 import contentRoutes from "../content.js";
 
 const router = Router();
@@ -15,6 +16,7 @@ router.use("/", devApi);
 router.use("/", adminApi);
 
 router.use("/", chatApi);
+router.use("/", dmApi);
 
 router.use("/", contentRoutes);
 

--- a/server/src/socketio/dms.js
+++ b/server/src/socketio/dms.js
@@ -5,65 +5,116 @@ import UserModel from "../models/User.js";
 import socketio from "./index.js";
 
 class ServerDMs {
-  async #getThread(id1, id2) {
-    let thread = await DmThreadModel.findOne({
-      participants: { $all: [id1, id2], $size: 2 },
-    }).populate({
-      path: "messages",
-      options: { sort: { createdAt: 1 } },
-      populate: { path: "sender", select: "displayName avatarUrl" },
-    });
-    if (!thread) {
-      thread = new DmThreadModel({ participants: [id1, id2], messages: [] });
-      await thread.save();
-    }
-    return thread;
-  }
+	async #getThread(id1, id2) {
+		let thread = await DmThreadModel.findOne({
+			participants: { $all: [id1, id2], $size: 2 },
+		}).populate({
+			path: "messages",
+			options: { sort: { createdAt: 1 } },
+			populate: { path: "sender", select: "displayName avatarUrl" },
+		});
+		if (!thread) {
+			thread = new DmThreadModel({ participants: [id1, id2], messages: [] });
+			await thread.save();
+		}
+		return thread;
+	}
 
-  async joinThread(socket, otherId) {
-    const thread = await this.#getThread(socket.user.id, otherId);
-    socket.join(thread._id.toString());
-    socket.emit("dm_joined", thread._id.toString(), thread.messages);
-  }
+	async joinThread(socket, otherId) {
+		const thread = await this.#getThread(socket.user.id, otherId);
+		socket.join(thread._id.toString());
+		socket.emit("dm_joined", thread._id.toString(), thread.messages);
+	}
 
-  startListeners(socket) {
-    socket.on("join_dm", async (otherId) => {
-      try {
-        const other = await UserModel.findById(otherId);
-        if (!other) return;
-        await this.joinThread(socket, otherId);
-      } catch (err) {
-        logger.error("join_dm error:", err);
-      }
-    });
+	startListeners(socket) {
+		socket.on("join_dm", async (otherId) => {
+			try {
+				const other = await UserModel.findById(otherId);
+				if (!other) return;
+				await this.joinThread(socket, otherId);
+			} catch (err) {
+				logger.error("join_dm error:", err);
+			}
+		});
 
-    socket.on("message_dm", async (threadId, content) => {
-      try {
-        const thread = await DmThreadModel.findById(threadId);
-        if (!thread) return;
-        if (!thread.participants.some((p) => p.toString() === socket.user.id)) return;
-        const msg = new MessageModel({ sender: socket.user.id, content });
-        await msg.save();
-        thread.messages.push(msg);
-        await thread.save();
-        await thread.populate({
-          path: "messages",
-          options: { sort: { createdAt: 1 } },
-          populate: { path: "sender", select: "displayName avatarUrl" },
-        });
-        const sockets = await socketio.io.in(threadId).fetchSockets();
-        sockets.forEach((s) => {
-          if (s.id === socket.id) {
-            s.emit("dm_sent", threadId, thread.messages);
-          } else {
-            s.emit("dm_new_message", threadId, thread.messages);
-          }
-        });
-      } catch (err) {
-        logger.error("message_dm error:", err);
-      }
-    });
-  }
+		socket.on("message_dm", async (threadId, content) => {
+			try {
+				const thread = await DmThreadModel.findById(threadId);
+				if (!thread) return;
+				if (!thread.participants.some((p) => p.toString() === socket.user.id)) return;
+				const msg = new MessageModel({ sender: socket.user.id, content });
+				await msg.save();
+				thread.messages.push(msg);
+				await thread.save();
+				await thread.populate({
+					path: "messages",
+					options: { sort: { createdAt: 1 } },
+					populate: { path: "sender", select: "displayName avatarUrl" },
+				});
+				const sockets = await socketio.io.in(threadId).fetchSockets();
+				sockets.forEach((s) => {
+					if (s.id === socket.id) {
+						s.emit("dm_sent", threadId, thread.messages);
+					} else {
+						s.emit("dm_new_message", threadId, thread.messages);
+					}
+				});
+			} catch (err) {
+				logger.error("message_dm error:", err);
+			}
+		});
+
+		socket.on("dm_edit_message", async (threadId, messageId, content) => {
+			try {
+				const thread = await DmThreadModel.findById(threadId);
+				if (!thread) return;
+				if (!thread.participants.some((p) => p.toString() === socket.user.id)) return;
+
+				const msg = await MessageModel.findById(messageId);
+				if (!msg) return;
+				if (msg.sender.toString() !== socket.user.id) return;
+
+				msg.content = content;
+				await msg.save();
+
+				const msgDoc = await msg.populate({
+					path: "sender",
+					select: "displayName avatarUrl",
+				});
+
+				const sockets = await socketio.io.in(threadId).fetchSockets();
+				sockets.forEach((s) => {
+					s.emit("dm_message_edited", threadId, messageId, msgDoc);
+				});
+			} catch (err) {
+				logger.error("Error handling edit_message:", err);
+			}
+		});
+
+		socket.on("dm_delete_message", async (threadId, messageId) => {
+			try {
+				const thread = await DmThreadModel.findById(threadId);
+				if (!thread) return;
+				if (!thread.participants.some((p) => p.toString() === socket.user.id)) return;
+
+				const msg = await MessageModel.findById(messageId);
+				if (!msg) return;
+				if (msg.sender.toString() !== socket.user.id) return;
+
+				await MessageModel.deleteOne({ _id: messageId });
+				await DmThreadModel.findByIdAndUpdate(threadId, {
+					$pull: { messages: messageId },
+				});
+
+				const sockets = await socketio.io.in(threadId).fetchSockets();
+				sockets.forEach((s) => {
+					s.emit("dm_delete_message", threadId, messageId);
+				});
+			} catch (err) {
+				logger.error("Error handling edit_message:", err);
+			}
+		});
+	}
 }
 
 export default new ServerDMs();

--- a/server/src/socketio/dms.js
+++ b/server/src/socketio/dms.js
@@ -1,0 +1,69 @@
+import logger from "../logger.js";
+import DmThreadModel from "../models/DmThread.js";
+import MessageModel from "../models/Message.js";
+import UserModel from "../models/User.js";
+import socketio from "./index.js";
+
+class ServerDMs {
+  async #getThread(id1, id2) {
+    let thread = await DmThreadModel.findOne({
+      participants: { $all: [id1, id2], $size: 2 },
+    }).populate({
+      path: "messages",
+      options: { sort: { createdAt: 1 } },
+      populate: { path: "sender", select: "displayName avatarUrl" },
+    });
+    if (!thread) {
+      thread = new DmThreadModel({ participants: [id1, id2], messages: [] });
+      await thread.save();
+    }
+    return thread;
+  }
+
+  async joinThread(socket, otherId) {
+    const thread = await this.#getThread(socket.user.id, otherId);
+    socket.join(thread._id.toString());
+    socket.emit("dm_joined", thread._id.toString(), thread.messages);
+  }
+
+  startListeners(socket) {
+    socket.on("join_dm", async (otherId) => {
+      try {
+        const other = await UserModel.findById(otherId);
+        if (!other) return;
+        await this.joinThread(socket, otherId);
+      } catch (err) {
+        logger.error("join_dm error:", err);
+      }
+    });
+
+    socket.on("message_dm", async (threadId, content) => {
+      try {
+        const thread = await DmThreadModel.findById(threadId);
+        if (!thread) return;
+        if (!thread.participants.some((p) => p.toString() === socket.user.id)) return;
+        const msg = new MessageModel({ sender: socket.user.id, content });
+        await msg.save();
+        thread.messages.push(msg);
+        await thread.save();
+        await thread.populate({
+          path: "messages",
+          options: { sort: { createdAt: 1 } },
+          populate: { path: "sender", select: "displayName avatarUrl" },
+        });
+        const sockets = await socketio.io.in(threadId).fetchSockets();
+        sockets.forEach((s) => {
+          if (s.id === socket.id) {
+            s.emit("dm_sent", threadId, thread.messages);
+          } else {
+            s.emit("dm_new_message", threadId, thread.messages);
+          }
+        });
+      } catch (err) {
+        logger.error("message_dm error:", err);
+      }
+    });
+  }
+}
+
+export default new ServerDMs();

--- a/server/src/socketio/index.js
+++ b/server/src/socketio/index.js
@@ -5,6 +5,7 @@ import "dotenv/config";
 
 import logger from "../logger.js";
 import serverRooms from "./rooms.js";
+import serverDMs from "./dms.js";
 import serverWatchers from "./watchers.js";
 import UserModel from "../models/User.js";
 
@@ -53,8 +54,11 @@ class SocketBackend {
 		logger.info(`User connected: '${socket.user.username}'`);
 		socket.emit("connected");
 
-		// start handling room events
-		serverRooms.startListeners(socket);
+                // start handling room events
+                serverRooms.startListeners(socket);
+
+                // start handling direct message events
+                serverDMs.startListeners(socket);
 
 		// start handling watcher events
 		serverWatchers.init(socket);

--- a/server_docs/endpoints/dms_userId_messages.md
+++ b/server_docs/endpoints/dms_userId_messages.md
@@ -1,0 +1,24 @@
+# GET `/dms/:userId/messages`
+
+Return direct messages between the authenticated user and `userId`. Creates a new conversation if one does not exist.
+
+- **Authentication**: required JWT.
+- **Rate Limit**: 3000 requests per minute per IP (`messagesLimiter`).
+- **Path Parameters**:
+  - `userId` – ID of the other participant.
+- **Responses**:
+  - `200` – JSON `{ threadId: <id>, messages: [...] }` sorted by creation time.
+  - `404` – other user not found.
+
+# POST `/dms/:userId/messages`
+
+Send a direct message to `userId`.
+
+- **Authentication**: required JWT.
+- **Request Body**:
+  ```json
+  { "content": "Hello" }
+  ```
+- **Responses**:
+  - `200` – JSON `{ threadId: <id>, messages: [...] }` updated list.
+  - `404` – other user not found.

--- a/server_docs/socketio.md
+++ b/server_docs/socketio.md
@@ -31,6 +31,21 @@ Server‑emitted events related to rooms:
 - `new_message` – updated messages broadcast to others in the room.
 - `messages_updated` – emitted after edits or deletions.
 
+## Direct Messages
+
+Client‑initiated events handled in `server/src/socketio/dms.js`:
+
+| Event        | Arguments               | Description                                        |
+| ------------ | ----------------------- | -------------------------------------------------- |
+| `join_dm`    | `userId`                | Join or create a DM thread with the given user. The server replies with `dm_joined`. |
+| `message_dm` | `threadId`, `content`   | Post a message in the DM thread. Sender receives `dm_sent`; the other participant gets `dm_new_message`. |
+
+Server‑emitted events related to direct messages:
+
+- `dm_joined` – thread id and existing messages when a socket joins a DM.
+- `dm_sent` – updated message list sent back to the sender after posting.
+- `dm_new_message` – updated messages broadcast to the other participant.
+
 ## Watchers
 
 Handlers in `server/src/socketio/watchers.js` let sockets watch user profiles for changes.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -26,6 +26,7 @@ const ServersPage = lazy(() => import("./routes/ServersPage/ServersPage.route"))
 const TestingPage = lazy(() => import("./routes/TestingPage/TestingPage.route"));
 const SettingsPage = lazy(() => import("./routes/SettingsPage/SettingsPage.route"));
 const FriendPage = lazy(() => import("./routes/FriendPage/FriendPage.route"));
+const DirectMessagePage = lazy(() => import("./routes/DirectMessagePage/DirectMessagePage"));
 
 const PageNotFoundContainer = styled("div")({
 	maxWidth: "100%",
@@ -117,7 +118,8 @@ const App = () => {
 								<Route path="/" element={<LandingPage />} />
 								<Route path="/friends" element={<FriendPage />} />
 								<Route path="/profile" element={<ProfilePage />} />
-								<Route path="/chat" element={<ChatPage />} />
+                                                                <Route path="/chat" element={<ChatPage />} />
+                                                                <Route path="/dm/:userId" element={<DirectMessagePage />} />
 								<Route path="/servers" element={<ServersPage />} />
 								<Route path="/testing" element={<TestingPage />} />
 								<Route path="/settings" element={<SettingsPage />} />

--- a/src/components/User/ProfileCard.jsx
+++ b/src/components/User/ProfileCard.jsx
@@ -3,8 +3,9 @@ import CameraAlt from "@mui/icons-material/CameraAlt";
 import PersonAdd from "@mui/icons-material/PersonAdd";
 import PersonOff from "@mui/icons-material/PersonOff";
 import PersonRemove from "@mui/icons-material/PersonRemove";
-import { Avatar, Box, Button, ButtonGroup, IconButton, Paper, Stack, TextField, Typography } from "@mui/material";
+import { Avatar, Box, Button, ButtonGroup, Divider, Fab, IconButton, Paper, Stack, TextField, Typography } from "@mui/material";
 import useProfileCard from "./useProfileCard";
+import { useNavigate, useLocation } from "react-router-dom";
 
 /* -------------------------------------------------- */
 
@@ -84,6 +85,9 @@ export default function ProfileCard({ user, self: forceSelf = false, type = "ful
 		user,
 		forceSelf
 	);
+
+	const navigate = useNavigate();
+	const location = useLocation();
 
 	/* ---------- placeholder when no user ---------- */
 	if (!user && !forceSelf) {
@@ -176,7 +180,7 @@ export default function ProfileCard({ user, self: forceSelf = false, type = "ful
 				</Paper>
 
 				{/* Actions */}
-				<Box sx={{ pt: 1 }}>
+				<Box>
 					{isSelf ? (
 						editMode ? (
 							<Stack direction="row" spacing={1}>
@@ -193,7 +197,14 @@ export default function ProfileCard({ user, self: forceSelf = false, type = "ful
 							</Button>
 						)
 					) : (
-						<FriendButtons status={status} friendId={friendId} profile={profile} onAction={callApi} />
+						<Stack direction="row" spacing={1} sx={{ width: "100%" }}>
+							<FriendButtons status={status} friendId={friendId} profile={profile} onAction={callApi} />
+							{location.pathname !== `/dm/${profile.id}` && (
+								<Button variant="outlined" size="small" color="info" onClick={() => navigate(`/dm/${profile.id}`)}>
+									Chat
+								</Button>
+							)}
+						</Stack>
 					)}
 				</Box>
 			</Stack>

--- a/src/routes/DirectMessagePage/DirectMessagePage.jsx
+++ b/src/routes/DirectMessagePage/DirectMessagePage.jsx
@@ -1,63 +1,103 @@
 import React from "react";
 import { useParams } from "react-router-dom";
-import { Box, Divider, Paper, Typography } from "@mui/material";
+import { Box, Divider, IconButton, Paper, Popover, Typography } from "@mui/material";
 import ChatArea from "../../components/Chat/ChatArea";
 import ChatInput from "../../components/Chat/ChatInput";
 import MessageContextMenu from "../../components/Chat/MessageContextMenu";
 import useDirectMessagePage from "./useDirectMessagePage";
+import AccountCircleRounded from "@mui/icons-material/AccountCircleRounded";
+import Avatar from "@mui/material/Avatar";
+import ProfileCard from "../../components/User/ProfileCard";
 
 export default function DirectMessagePage() {
-  const { userId } = useParams();
-  const {
-    auth,
-    otherUser,
-    message,
-    setMessage,
-    messages,
-    editingMessageId,
-    editingText,
-    setEditingText,
-    sendMessage,
-    msgMenuPos,
-    openMessageMenu,
-    closeMessageMenu,
-    startEditSelectedMessage,
-    commitEditMessage,
-    cancelEditMessage,
-    listRef,
-  } = useDirectMessagePage(userId);
+	const { userId } = useParams();
+	const {
+		auth,
+		otherUser,
+		message,
+		setMessage,
+		messages,
+		editingMessageId,
+		editingText,
+		setEditingText,
+		sendMessage,
+		msgMenuPos,
+		openMessageMenu,
+		closeMessageMenu,
+		selectedMessage,
+		startEditSelectedMessage,
+		confirmDeleteSelectedMessage,
+		commitEditMessage,
+		cancelEditMessage,
+		listRef,
+		userPreviewEl,
+		setUserPreviewEl,
+		previewMe,
+		setPreviewMe,
+		previewUser,
+	} = useDirectMessagePage(userId);
 
-  if (!auth.loggedIn) return <Typography>Please login.</Typography>;
+	const pfpRef = React.useRef(null);
 
-  return (
-    <Box sx={{ display: "flex", flexGrow: 1, flexDirection: "column", overflow: "hidden" }}>
-      <MessageContextMenu
-        anchorPosition={msgMenuPos}
-        setAnchorPosition={closeMessageMenu}
-        onEdit={startEditSelectedMessage}
-        onDelete={() => {}}
-        allowEdit={true}
-      />
-      <Paper sx={{ position: "relative", display: "flex", flexDirection: "column", width: "100%", flexGrow: 1 }}>
-        <Box sx={{ p: 1 }}>
-          <Typography variant="h6">{otherUser?.displayName || "DM"}</Typography>
-        </Box>
-        <Divider />
-        <Box sx={{ flexGrow: 1, position: "relative", width: "100%" }}>
-          <ChatArea
-            messages={messages}
-            previewUser={() => {}}
-            onContextMenu={openMessageMenu}
-            editingMessageId={editingMessageId}
-            editingText={editingText}
-            setEditingText={setEditingText}
-            commitEdit={commitEditMessage}
-            cancelEdit={cancelEditMessage}
-            listRef={listRef}
-          />
-        </Box>
-        <ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} />
-      </Paper>
-    </Box>
-  );
+	if (!auth.loggedIn) return <Typography>Please login.</Typography>;
+
+	return (
+		<Box sx={{ display: "flex", flexGrow: 1, flexDirection: "column", overflow: "hidden" }}>
+			<MessageContextMenu
+				anchorPosition={msgMenuPos}
+				setAnchorPosition={closeMessageMenu}
+				onEdit={startEditSelectedMessage}
+				onDelete={confirmDeleteSelectedMessage}
+				allowEdit={selectedMessage?.sender?._id === auth.userId}
+			/>
+			<Popover
+				anchorOrigin={{ vertical: "top", horizontal: "right" }}
+				transformOrigin={{ vertical: "bottom", horizontal: "left" }}
+				anchorEl={userPreviewEl}
+				open={Boolean(userPreviewEl)}
+				onClose={() => {
+					setUserPreviewEl(null);
+				}}
+				sx={{ mb: 2 }}>
+				<ProfileCard self={previewMe} user={otherUser} width="300px" passStyle={{ maxWidth: "300px" }} />
+			</Popover>
+			<Paper sx={{ position: "relative", display: "flex", flexDirection: "column", width: "100%", flexGrow: 1 }}>
+				<Box sx={{ p: 1, display: "flex", alignItems: "center", gap: 2 }}>
+					<IconButton
+						color="secondary"
+						onClick={() => {
+							previewUser(pfpRef);
+						}}
+						sx={{ p: 0 }}>
+						<Avatar
+							alt="User"
+							src={otherUser?.avatarUrl}
+							sx={{
+								height: "40px",
+								width: "40px",
+							}}
+						/>
+					</IconButton>
+					<Typography variant="h6" ref={pfpRef}>
+						{otherUser?.displayName || "DM"}
+					</Typography>
+				</Box>
+				<Divider />
+				<Box sx={{ flexGrow: 1, position: "relative", width: "100%" }}>
+					<ChatArea
+						messages={messages}
+						previewUser={previewUser}
+						onContextMenu={openMessageMenu}
+						editingMessageId={editingMessageId}
+						editingText={editingText}
+						setEditingText={setEditingText}
+						commitEdit={commitEditMessage}
+						cancelEdit={cancelEditMessage}
+						listRef={listRef}
+					/>
+				</Box>
+				<ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} />
+			</Paper>
+		</Box>
+	);
 }

--- a/src/routes/DirectMessagePage/DirectMessagePage.jsx
+++ b/src/routes/DirectMessagePage/DirectMessagePage.jsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { useParams } from "react-router-dom";
+import { Box, Divider, Paper, Typography } from "@mui/material";
+import ChatArea from "../../components/Chat/ChatArea";
+import ChatInput from "../../components/Chat/ChatInput";
+import MessageContextMenu from "../../components/Chat/MessageContextMenu";
+import useDirectMessagePage from "./useDirectMessagePage";
+
+export default function DirectMessagePage() {
+  const { userId } = useParams();
+  const {
+    auth,
+    otherUser,
+    message,
+    setMessage,
+    messages,
+    editingMessageId,
+    editingText,
+    setEditingText,
+    sendMessage,
+    msgMenuPos,
+    openMessageMenu,
+    closeMessageMenu,
+    startEditSelectedMessage,
+    commitEditMessage,
+    cancelEditMessage,
+    listRef,
+  } = useDirectMessagePage(userId);
+
+  if (!auth.loggedIn) return <Typography>Please login.</Typography>;
+
+  return (
+    <Box sx={{ display: "flex", flexGrow: 1, flexDirection: "column", overflow: "hidden" }}>
+      <MessageContextMenu
+        anchorPosition={msgMenuPos}
+        setAnchorPosition={closeMessageMenu}
+        onEdit={startEditSelectedMessage}
+        onDelete={() => {}}
+        allowEdit={true}
+      />
+      <Paper sx={{ position: "relative", display: "flex", flexDirection: "column", width: "100%", flexGrow: 1 }}>
+        <Box sx={{ p: 1 }}>
+          <Typography variant="h6">{otherUser?.displayName || "DM"}</Typography>
+        </Box>
+        <Divider />
+        <Box sx={{ flexGrow: 1, position: "relative", width: "100%" }}>
+          <ChatArea
+            messages={messages}
+            previewUser={() => {}}
+            onContextMenu={openMessageMenu}
+            editingMessageId={editingMessageId}
+            editingText={editingText}
+            setEditingText={setEditingText}
+            commitEdit={commitEditMessage}
+            cancelEdit={cancelEditMessage}
+            listRef={listRef}
+          />
+        </Box>
+        <ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} />
+      </Paper>
+    </Box>
+  );
+}

--- a/src/routes/DirectMessagePage/useDirectMessagePage.js
+++ b/src/routes/DirectMessagePage/useDirectMessagePage.js
@@ -1,0 +1,118 @@
+import { useState, useEffect, useRef } from "react";
+import { useDispatch, useSelector } from "react-redux";
+import { fetchDmMessages } from "../../slices/dmApiSlice";
+import { fetchUserProfile } from "../../slices/userApiSlice";
+import socketIoHelper from "../../helpers/socket";
+
+export default function useDirectMessagePage(otherId) {
+  const auth = useSelector((state) => state.auth);
+  const dispatch = useDispatch();
+
+  const [threadId, setThreadId] = useState(null);
+  const [messages, setMessages] = useState([]);
+  const [message, setMessage] = useState("");
+  const [otherUser, setOtherUser] = useState(null);
+  const [editingMessageId, setEditingMessageId] = useState(null);
+  const [editingText, setEditingText] = useState("");
+  const [msgMenuPos, setMsgMenuPos] = useState(null);
+  const [selectedMessage, setSelectedMessage] = useState(null);
+  const listRef = useRef(null);
+
+  useEffect(() => {
+    if (!auth.loggedIn || !otherId) return;
+    dispatch(fetchUserProfile({ userId: otherId, authToken: auth.authToken }))
+      .unwrap()
+      .then(({ profile }) => setOtherUser(profile))
+      .catch(() => {});
+  }, [otherId, auth.loggedIn, auth.authToken, dispatch]);
+
+  useEffect(() => {
+    if (!auth.loggedIn || !otherId) return;
+    const socket = socketIoHelper.getSocket();
+    if (socket) {
+      socket.emit("join_dm", otherId);
+      socket.on("dm_joined", (tId, msgs) => {
+        setThreadId(tId);
+        setMessages(msgs);
+      });
+      socket.on("dm_sent", (_tId, msgs) => {
+        if (_tId === threadId) setMessages(msgs);
+      });
+      socket.on("dm_new_message", (_tId, msgs) => {
+        if (_tId === threadId) setMessages(msgs);
+      });
+    }
+    return () => {
+      if (socket) {
+        socket.off("dm_joined");
+        socket.off("dm_sent");
+        socket.off("dm_new_message");
+      }
+    };
+  }, [otherId, auth.loggedIn, threadId]);
+
+  useEffect(() => {
+    if (!auth.loggedIn || !otherId) return;
+    dispatch(fetchDmMessages({ userId: otherId, authToken: auth.authToken }))
+      .unwrap()
+      .then(({ threadId: tId, messages: msgs }) => {
+        setThreadId(tId);
+        setMessages(msgs);
+      })
+      .catch(() => {});
+  }, [otherId, auth.loggedIn, auth.authToken, dispatch]);
+
+  const sendMessage = (e) => {
+    e?.preventDefault();
+    if (!message || !threadId) return;
+    const s = socketIoHelper.getSocket();
+    s.emit("message_dm", threadId, message);
+    setMessage("");
+  };
+
+  const openMessageMenu = (msg, pos) => {
+    setSelectedMessage(msg);
+    setMsgMenuPos(pos);
+  };
+
+  const closeMessageMenu = () => {
+    setMsgMenuPos(null);
+    setSelectedMessage(null);
+  };
+
+  const startEditSelectedMessage = () => {
+    if (!selectedMessage) return;
+    setEditingMessageId(selectedMessage._id);
+    setEditingText(selectedMessage.content);
+    closeMessageMenu();
+  };
+
+  const commitEditMessage = () => {
+    setEditingMessageId(null);
+    setEditingText("");
+  };
+
+  const cancelEditMessage = () => {
+    setEditingMessageId(null);
+    setEditingText("");
+  };
+
+  return {
+    auth,
+    otherUser,
+    message,
+    setMessage,
+    messages,
+    editingMessageId,
+    editingText,
+    setEditingText,
+    sendMessage,
+    msgMenuPos,
+    openMessageMenu,
+    closeMessageMenu,
+    startEditSelectedMessage,
+    commitEditMessage,
+    cancelEditMessage,
+    listRef,
+  };
+}

--- a/src/routes/DirectMessagePage/useDirectMessagePage.js
+++ b/src/routes/DirectMessagePage/useDirectMessagePage.js
@@ -3,116 +3,163 @@ import { useDispatch, useSelector } from "react-redux";
 import { fetchDmMessages } from "../../slices/dmApiSlice";
 import { fetchUserProfile } from "../../slices/userApiSlice";
 import socketIoHelper from "../../helpers/socket";
+import { mapMessages } from "../../slices/chatApiSlice";
 
 export default function useDirectMessagePage(otherId) {
-  const auth = useSelector((state) => state.auth);
-  const dispatch = useDispatch();
+	const auth = useSelector((state) => state.auth);
+	const dispatch = useDispatch();
 
-  const [threadId, setThreadId] = useState(null);
-  const [messages, setMessages] = useState([]);
-  const [message, setMessage] = useState("");
-  const [otherUser, setOtherUser] = useState(null);
-  const [editingMessageId, setEditingMessageId] = useState(null);
-  const [editingText, setEditingText] = useState("");
-  const [msgMenuPos, setMsgMenuPos] = useState(null);
-  const [selectedMessage, setSelectedMessage] = useState(null);
-  const listRef = useRef(null);
+	const [threadId, setThreadId] = useState(null);
+	const [messages, setMessages] = useState([]);
+	const [message, setMessage] = useState("");
+	const [otherUser, setOtherUser] = useState(null);
+	const [editingMessageId, setEditingMessageId] = useState(null);
+	const [editingText, setEditingText] = useState("");
+	const [msgMenuPos, setMsgMenuPos] = useState(null);
+	const [selectedMessage, setSelectedMessage] = useState(null);
+	const listRef = useRef(null);
+	const [userPreviewEl, setUserPreviewEl] = useState(null);
+	const [previewMe, setPreviewMe] = useState(true);
 
-  useEffect(() => {
-    if (!auth.loggedIn || !otherId) return;
-    dispatch(fetchUserProfile({ userId: otherId, authToken: auth.authToken }))
-      .unwrap()
-      .then(({ profile }) => setOtherUser(profile))
-      .catch(() => {});
-  }, [otherId, auth.loggedIn, auth.authToken, dispatch]);
+	useEffect(() => {
+		if (!auth.loggedIn || !otherId) return;
+		dispatch(fetchUserProfile({ userId: otherId, authToken: auth.authToken }))
+			.unwrap()
+			.then(({ profile }) => setOtherUser(profile))
+			.catch(() => {});
+	}, [otherId, auth.loggedIn, auth.authToken, dispatch]);
 
-  useEffect(() => {
-    if (!auth.loggedIn || !otherId) return;
-    const socket = socketIoHelper.getSocket();
-    if (socket) {
-      socket.emit("join_dm", otherId);
-      socket.on("dm_joined", (tId, msgs) => {
-        setThreadId(tId);
-        setMessages(msgs);
-      });
-      socket.on("dm_sent", (_tId, msgs) => {
-        if (_tId === threadId) setMessages(msgs);
-      });
-      socket.on("dm_new_message", (_tId, msgs) => {
-        if (_tId === threadId) setMessages(msgs);
-      });
-    }
-    return () => {
-      if (socket) {
-        socket.off("dm_joined");
-        socket.off("dm_sent");
-        socket.off("dm_new_message");
-      }
-    };
-  }, [otherId, auth.loggedIn, threadId]);
+	useEffect(() => {
+		if (!auth.loggedIn || !otherId) return;
+		const socket = socketIoHelper.getSocket();
+		if (socket) {
+			socket.emit("join_dm", otherId);
+			socket.on("dm_joined", (tId, msgs) => {
+				setThreadId(tId);
+				setMessages(mapMessages(msgs));
+			});
+			socket.on("dm_sent", (_tId, msgs) => {
+				if (_tId === threadId) setMessages(mapMessages(msgs));
+			});
+			socket.on("dm_new_message", (_tId, msgs) => {
+				if (_tId === threadId) setMessages(mapMessages(msgs));
+			});
+			socket.on("dm_message_edited", (_tId, msgId, msgData) => {
+				if (_tId === threadId) {
+					setMessages((prevMessages) => prevMessages.map((msg) => (msg._id === msgId ? { ...msg, ...mapMessages([msgData])[0] } : msg)));
+				}
+			});
+			socket.on("dm_delete_message", (_tId, msgId) => {
+				if (_tId === threadId) {
+					setMessages((prevMessages) => prevMessages.filter((msg) => msg._id !== msgId));
+				}
+			});
+		}
+		return () => {
+			if (socket) {
+				socket.off("dm_joined");
+				socket.off("dm_sent");
+				socket.off("dm_new_message");
+				socket.off("dm_message_edited");
+				socket.off("dm_delete_message");
+			}
+		};
+	}, [otherId, auth.loggedIn, threadId]);
 
-  useEffect(() => {
-    if (!auth.loggedIn || !otherId) return;
-    dispatch(fetchDmMessages({ userId: otherId, authToken: auth.authToken }))
-      .unwrap()
-      .then(({ threadId: tId, messages: msgs }) => {
-        setThreadId(tId);
-        setMessages(msgs);
-      })
-      .catch(() => {});
-  }, [otherId, auth.loggedIn, auth.authToken, dispatch]);
+	useEffect(() => {
+		if (!auth.loggedIn || !otherId) return;
+		dispatch(fetchDmMessages({ userId: otherId, authToken: auth.authToken }))
+			.unwrap()
+			.then(({ threadId: tId, messages: msgs }) => {
+				setThreadId(tId);
+				setMessages(msgs);
+			})
+			.catch(() => {});
+	}, [otherId, auth.loggedIn, auth.authToken, dispatch]);
 
-  const sendMessage = (e) => {
-    e?.preventDefault();
-    if (!message || !threadId) return;
-    const s = socketIoHelper.getSocket();
-    s.emit("message_dm", threadId, message);
-    setMessage("");
-  };
+	const sendMessage = (e) => {
+		e?.preventDefault();
+		if (!message || !threadId) return;
+		const s = socketIoHelper.getSocket();
+		s.emit("message_dm", threadId, message);
+		setMessage("");
+	};
 
-  const openMessageMenu = (msg, pos) => {
-    setSelectedMessage(msg);
-    setMsgMenuPos(pos);
-  };
+	const openMessageMenu = (msg, pos) => {
+		setSelectedMessage(msg);
+		setMsgMenuPos(pos);
+	};
 
-  const closeMessageMenu = () => {
-    setMsgMenuPos(null);
-    setSelectedMessage(null);
-  };
+	const closeMessageMenu = () => {
+		setMsgMenuPos(null);
+		setSelectedMessage(null);
+	};
 
-  const startEditSelectedMessage = () => {
-    if (!selectedMessage) return;
-    setEditingMessageId(selectedMessage._id);
-    setEditingText(selectedMessage.content);
-    closeMessageMenu();
-  };
+	const startEditSelectedMessage = () => {
+		if (!selectedMessage) return;
+		setEditingMessageId(selectedMessage._id);
+		setEditingText(selectedMessage.content);
+		closeMessageMenu();
+	};
 
-  const commitEditMessage = () => {
-    setEditingMessageId(null);
-    setEditingText("");
-  };
+	const commitEditMessage = () => {
+		if (!editingMessageId) return;
+		const s = socketIoHelper.getSocket();
+		s.emit("dm_edit_message", threadId, editingMessageId, editingText);
+		setEditingMessageId(null);
+		setEditingText("");
+	};
 
-  const cancelEditMessage = () => {
-    setEditingMessageId(null);
-    setEditingText("");
-  };
+	const cancelEditMessage = () => {
+		setEditingMessageId(null);
+		setEditingText("");
+	};
 
-  return {
-    auth,
-    otherUser,
-    message,
-    setMessage,
-    messages,
-    editingMessageId,
-    editingText,
-    setEditingText,
-    sendMessage,
-    msgMenuPos,
-    openMessageMenu,
-    closeMessageMenu,
-    startEditSelectedMessage,
-    commitEditMessage,
-    cancelEditMessage,
-    listRef,
-  };
+	const confirmDeleteSelectedMessage = () => {
+		if (!selectedMessage) return;
+		const s = socketIoHelper.getSocket();
+		s.emit("dm_delete_message", threadId, selectedMessage._id);
+		closeMessageMenu();
+	};
+
+	const previewUser = (elRef, u) => {
+		if (!elRef?.current) {
+			setUserPreviewEl(null);
+			setPreviewMe(false);
+			return;
+		} else {
+			setUserPreviewEl(elRef.current);
+			if (u?._id && u._id === auth.userId) {
+				setPreviewMe(true);
+			} else {
+				setPreviewMe(false);
+			}
+		}
+	};
+
+	return {
+		auth,
+		otherUser,
+		message,
+		setMessage,
+		messages,
+		editingMessageId,
+		editingText,
+		setEditingText,
+		sendMessage,
+		msgMenuPos,
+		openMessageMenu,
+		closeMessageMenu,
+		selectedMessage,
+		startEditSelectedMessage,
+		confirmDeleteSelectedMessage,
+		commitEditMessage,
+		cancelEditMessage,
+		listRef,
+		userPreviewEl,
+		setUserPreviewEl,
+		previewMe,
+		setPreviewMe,
+		previewUser,
+	};
 }

--- a/src/slices/dmApiSlice.js
+++ b/src/slices/dmApiSlice.js
@@ -1,0 +1,44 @@
+import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import axios from "axios";
+import { getApiBase } from "../helpers/api";
+import { mapMessages } from "./chatApiSlice";
+
+const base = getApiBase();
+
+export const fetchDmMessages = createAsyncThunk(
+  "dmApi/fetchDmMessages",
+  async ({ userId, authToken }, { rejectWithValue }) => {
+    try {
+      const { data } = await axios.get(`${base}/dms/${userId}/messages`, {
+        headers: { Authorization: `Bearer ${authToken}` },
+      });
+      return {
+        userId,
+        threadId: data.threadId,
+        messages: await mapMessages(data.messages),
+      };
+    } catch (err) {
+      return rejectWithValue(err.response?.data || err.message);
+    }
+  }
+);
+
+const dmApiSlice = createSlice({
+  name: "dmApi",
+  initialState: { messages: {}, threads: {} },
+  reducers: {
+    clearDmMessages(state, action) {
+      if (action.payload?.userId) delete state.messages[action.payload.userId];
+      else state.messages = {};
+    },
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchDmMessages.fulfilled, (state, action) => {
+      state.messages[action.payload.userId] = action.payload.messages;
+      state.threads[action.payload.userId] = action.payload.threadId;
+    });
+  },
+});
+
+export const { clearDmMessages } = dmApiSlice.actions;
+export default dmApiSlice.reducer;

--- a/src/slices/index.js
+++ b/src/slices/index.js
@@ -6,14 +6,16 @@ import settingsReducer from "./settingsSlice";
 import snackbarReducer from "./snackbarSlice";
 import userApiReducer from "./userApiSlice";
 import chatApiReducer from "./chatApiSlice";
+import dmApiReducer from "./dmApiSlice";
 
 const rootReducer = combineReducers({
 	dialogs: dialogReducer,
 	auth: authReducer,
 	snackbars: snackbarReducer,
 	settings: settingsReducer,
-	userApi: userApiReducer,
-	chatApi: chatApiReducer,
+        userApi: userApiReducer,
+        chatApi: chatApiReducer,
+        dmApi: dmApiReducer,
 });
 
 export default rootReducer;

--- a/src/slices/userApiSlice.js
+++ b/src/slices/userApiSlice.js
@@ -15,12 +15,14 @@ export const fetchUserProfile = createAsyncThunk("userApi/fetchUserProfile", asy
 			params: userId ? { id: userId } : undefined,
 		});
 		const u = data.user;
+		const bannerUrl = u.bannerUrl ? base + u.bannerUrl : globalThis.IN_ELECTRON_ENV ? "banner.webp" : "/banner.webp";
+		const avatarUrl = u.avatarUrl ? base + u.avatarUrl : globalThis.IN_ELECTRON_ENV ? "defaultpfp.webp" : "/defaultpfp.webp";
 		return {
 			id: u.id,
 			profile: {
 				...u,
-				avatarUrl: u.avatarUrl ? base + u.avatarUrl : null,
-				bannerUrl: u.bannerUrl ? base + u.bannerUrl : null,
+				avatarUrl: avatarUrl,
+				bannerUrl: bannerUrl,
 			},
 		};
 	} catch (err) {


### PR DESCRIPTION
## Summary
- add DM mongoose model and API routes
- implement socket.io events for direct messages
- document DM endpoints and websocket events
- create DirectMessagePage with new Redux slice
- wire the page and slice into the app

## Testing
- `pnpm test`
- `cd server && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684d7587fcc48327ad425a3fa737b49d