### PR TITLE
Fix Google OAuth callback in production

### DIFF
--- a/.github/workflows/deploy-new.yml
+++ b/.github/workflows/deploy-new.yml
@@ -141,7 +141,7 @@ jobs:
 
             cd "${{ github.event.inputs.serverSubdirectory }}"
 
-            echo -e "SECRET=${{ secrets.SECRET }}\nDB_USER=${{ secrets.DB_USER }}\nDB_PASS=${{ secrets.DB_PASS }}\nDB_AUTH=${{ secrets.DB_AUTH }}\nDB_NAME=${{ secrets.DB_NAME }}\nPORT=${{ secrets.PORT }}" > .env
+            echo -e "SECRET=${{ secrets.SECRET }}\nDB_USER=${{ secrets.DB_USER }}\nDB_PASS=${{ secrets.DB_PASS }}\nDB_AUTH=${{ secrets.DB_AUTH }}\nDB_NAME=${{ secrets.DB_NAME }}\nPORT=${{ secrets.PORT }}\nGOOGLE_CLIENT_ID=${{ secrets.GOOGLE_CLIENT_ID }}\nGOOGLE_CLIENT_SECRET=${{ secrets.GOOGLE_CLIENT_SECRET }}" > .env
 
             pnpm install --frozen-lockfile --ignore-scripts
 

--- a/server/nginx/default
+++ b/server/nginx/default
@@ -13,6 +13,7 @@ server {
         proxy_pass         http://127.0.0.1:6001;
         proxy_http_version 1.1;
         proxy_set_header   Host              $host;
+        proxy_set_header   X-Forwarded-Proto $scheme;
         proxy_set_header   X-Real-IP         $remote_addr;
         proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_cache_bypass $http_upgrade;
@@ -27,6 +28,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
@@ -39,6 +41,7 @@ server {
 
         proxy_pass http://localhost:6001;
         proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -48,6 +51,7 @@ server {
     location ~* \.io { # Socket.io
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy false;
 
@@ -107,6 +111,7 @@ server {
 
         proxy_pass http://localhost:6001;
         proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
@@ -116,6 +121,7 @@ server {
     location ~* \.io { # Socket.io
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $http_host;
         proxy_set_header X-NginX-Proxy false;
 

--- a/server/src/app.js
+++ b/server/src/app.js
@@ -24,9 +24,13 @@ class ServerBackend {
 		this.server = http.createServer(this.app);
 	}
 
-	_initMiddleware() {
-		// CORS
-		this.app.use(cors({ optionsSuccessStatus: 200 }));
+        _initMiddleware() {
+                // Trust the reverse proxy (e.g. Nginx) when determining
+                // protocol and other forwarding headers
+                this.app.set("trust proxy", true);
+
+                // CORS
+                this.app.use(cors({ optionsSuccessStatus: 200 }));
 		// ─── GLOBAL RATE LIMITER ───────────────────────────────────────────────────
 		// limit each IP to 150 requests per 5 minutes
 		const globalLimiter = rateLimit({


### PR DESCRIPTION
## Summary
- trust reverse proxy headers so `req.protocol` is correct
- forward `X-Forwarded-Proto` from nginx
- include Google OAuth credentials in deployment `.env`

## Testing
- `pnpm test`
- `cd server && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684e019e17e48327adefb166b6bf4402