### PR TITLE
Add long press hook for better mobile interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
 # Rebound
 
 Welcome to Rebound! Our website is all about bringing people together and providing a robust platform for social interaction and content sharing. We offer a wide variety of features that make the user experience unique, enjoyable, and customizable.
+
+## Mobile support
+
+Rebound now includes improved touch interactions. Long pressing on messages opens the context menu, and the interface disables double-tap zoom for a smoother experience on phones.

--- a/src/__tests__/useLongPress.test.jsx
+++ b/src/__tests__/useLongPress.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, test, expect, vi, beforeEach, afterEach } from "vitest";
+import React from "react";
+import useLongPress from "../helpers/useLongPress";
+
+function TestComponent({ onLongPress }) {
+	const handlers = useLongPress(onLongPress, 200);
+	return (
+		<div data-testid="press" {...handlers}>
+			press me
+		</div>
+	);
+}
+
+describe("useLongPress hook", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	test("fires after long press", () => {
+		const cb = vi.fn();
+		render(<TestComponent onLongPress={cb} />);
+		fireEvent.touchStart(screen.getByTestId("press"), {
+			touches: [{ clientX: 0, clientY: 0 }],
+		});
+		vi.advanceTimersByTime(250);
+		expect(cb).toHaveBeenCalled();
+	});
+});

--- a/src/components/Chat/ChatInput.jsx
+++ b/src/components/Chat/ChatInput.jsx
@@ -27,10 +27,11 @@ const ChatForm = styled("form")(({ theme }) => ({
 
 const EditableDiv = styled("div")(({ theme }) => ({
 	flex: 1,
-	minHeight: 42,
+	minHeight: 16,
 	maxHeight: 180,
 	overflowY: "auto",
-	padding: theme.spacing(1),
+	alignContent: "center",
+	padding: theme.spacing(1, 1),
 	border: `1px solid ${theme.palette.primary.main}`,
 	borderRadius: theme.shape.borderRadius,
 	outline: "none",

--- a/src/components/Chat/IndividualMessage.jsx
+++ b/src/components/Chat/IndividualMessage.jsx
@@ -1,6 +1,7 @@
 import { Box, ListItem, Avatar, Typography, useTheme, Link, TextField, Button } from "@mui/material";
 import { scrollbarStyles } from "../../routes/LandingPage/utils/scrollbarStyles";
 import React from "react";
+import useLongPress from "../../helpers/useLongPress";
 import { highlightMentions } from "../../helpers/mentions";
 import { profileMediaUrl } from "../../helpers/mediaUrl";
 
@@ -39,7 +40,7 @@ function IndividualMessage({
 	const theme = useTheme();
 	let sendTimeText = requestedTime ? formatDate(requestedTime) : formatDate(msg.createdAt);
 	const messageRef = React.useRef(null);
-	const touchTimer = React.useRef(null);
+	const longPressHandlers = useLongPress(({ x, y }) => onContextMenu(msg, { x, y }));
 
 	const onHoverStart = (_event) => {
 		onHoverMessage(currentMsg);
@@ -53,15 +54,6 @@ function IndividualMessage({
 		onContextMenu(msg, { x: e.clientX, y: e.clientY });
 	};
 
-	const handleTouchStart = (e) => {
-		const { clientX, clientY } = e.touches[0];
-		touchTimer.current = setTimeout(() => onContextMenu(msg, { x: clientX, y: clientY }), 500);
-	};
-
-	const handleTouchEnd = () => {
-		clearTimeout(touchTimer.current);
-	};
-
 	return (
 		<ListItem
 			disablePadding
@@ -72,8 +64,7 @@ function IndividualMessage({
 				width: "100%",
 			}}
 			onContextMenu={handleContext}
-			onTouchStart={handleTouchStart}
-			onTouchEnd={handleTouchEnd}>
+			{...longPressHandlers}>
 			<Box
 				sx={{
 					display: shouldDisplayAvatar ? "inherit" : "none",

--- a/src/helpers/useLongPress.js
+++ b/src/helpers/useLongPress.js
@@ -1,0 +1,28 @@
+import { useCallback, useRef } from "react";
+
+export default function useLongPress(callback, ms = 500) {
+	const timerRef = useRef(null);
+
+	const start = useCallback(
+		(event) => {
+			const { clientX, clientY } = event.touches && event.touches[0] ? event.touches[0] : event;
+			timerRef.current = setTimeout(() => {
+				callback({ x: clientX, y: clientY });
+			}, ms);
+		},
+		[callback, ms]
+	);
+
+	const clear = useCallback(() => {
+		clearTimeout(timerRef.current);
+	}, []);
+
+	return {
+		onMouseDown: start,
+		onMouseUp: clear,
+		onMouseLeave: clear,
+		onTouchStart: start,
+		onTouchEnd: clear,
+		onTouchMove: clear,
+	};
+}

--- a/src/index.css
+++ b/src/index.css
@@ -17,6 +17,7 @@ body {
 	font-family: "Roboto";
 	-webkit-font-smoothing: antialiased;
 	-moz-osx-font-smoothing: grayscale;
+	touch-action: manipulation;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- support smooth touch interaction by adding `touch-action` CSS
- add reusable `useLongPress` hook
- refactor message component to use the hook
- document touch features in README
- test new hook

## Testing
- `pnpm test`
- `cd server && pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684f7337f9548327939d104b770130ba