### PR TITLE
Add placeholder VoiceChat page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,6 +27,7 @@ const TestingPage = lazy(() => import("./routes/TestingPage/TestingPage.route"))
 const SettingsPage = lazy(() => import("./routes/SettingsPage/SettingsPage.route"));
 const FriendPage = lazy(() => import("./routes/FriendPage/FriendPage.route"));
 const DirectMessagePage = lazy(() => import("./routes/DirectMessagePage/DirectMessagePage"));
+const VoiceChatPage = lazy(() => import("./routes/VoiceChatPage/VoiceChatPage"));
 
 const PageNotFoundContainer = styled("div")({
 	maxWidth: "100%",
@@ -131,9 +132,10 @@ const App = () => {
 								<Route path="/" element={<LandingPage />} />
 								<Route path="/friends" element={<FriendPage />} />
 								<Route path="/profile" element={<ProfilePage />} />
-								<Route path="/chat" element={<ChatPage />} />
-								<Route path="/dm/:userId" element={<DirectMessagePage />} />
-								<Route path="/servers" element={<ServersPage />} />
+                                                               <Route path="/chat" element={<ChatPage />} />
+                                                               <Route path="/voicechat" element={<VoiceChatPage />} />
+                                                               <Route path="/dm/:userId" element={<DirectMessagePage />} />
+                                                               <Route path="/servers" element={<ServersPage />} />
 								<Route path="/testing" element={<TestingPage />} />
 								<Route path="/settings" element={<SettingsPage />} />
 								<Route path="*" element={<PageNotFoundContainer>PAGE NOT FOUND</PageNotFoundContainer>} />

--- a/src/components/CustomAppBar/DrawerMenu.jsx
+++ b/src/components/CustomAppBar/DrawerMenu.jsx
@@ -1,6 +1,7 @@
 import HomeRounded from "@mui/icons-material/HomeRounded";
 import PeopleAltRounded from "@mui/icons-material/PeopleAltRounded";
 import MessageRounded from "@mui/icons-material/MessageRounded";
+import RecordVoiceOverRounded from "@mui/icons-material/RecordVoiceOverRounded";
 import DnsRounded from "@mui/icons-material/DnsRounded";
 import PersonRounded from "@mui/icons-material/PersonRounded";
 import ScienceTwoTone from "@mui/icons-material/ScienceTwoTone";
@@ -61,17 +62,23 @@ function DrawerMenu({ drawerWidth, iconWidth, drawerOpen, setDrawerOpen, theme }
 						path: "/friends",
 						Icon: PeopleAltRounded,
 					},
-					{
-						key: "chat",
-						title: "Chat",
-						path: "/chat",
-						Icon: MessageRounded,
-					},
-					{
-						key: "servers",
-						title: "Servers",
-						path: "/servers",
-						Icon: DnsRounded,
+                                        {
+                                                key: "chat",
+                                                title: "Chat",
+                                                path: "/chat",
+                                                Icon: MessageRounded,
+                                        },
+                                        {
+                                                key: "voicechat",
+                                                title: "Voice Chat",
+                                                path: "/voicechat",
+                                                Icon: RecordVoiceOverRounded,
+                                        },
+                                        {
+                                                key: "servers",
+                                                title: "Servers",
+                                                path: "/servers",
+                                                Icon: DnsRounded,
 					},
 					{
 						key: "profile",

--- a/src/routes/VoiceChatPage/VoiceChatPage.jsx
+++ b/src/routes/VoiceChatPage/VoiceChatPage.jsx
@@ -1,0 +1,19 @@
+import React from "react";
+import { Box, Typography } from "@mui/material";
+import useVoiceChatPage from "./useVoiceChatPage";
+
+export default function VoiceChatPage() {
+    // Initialize placeholder hook
+    useVoiceChatPage();
+
+    return (
+        <Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center" }}>
+            <Typography variant="h4" gutterBottom>
+                Voice Chat
+            </Typography>
+            <Typography variant="body1" color="text.secondary">
+                Voice chat features will live here soon.
+            </Typography>
+        </Box>
+    );
+}

--- a/src/routes/VoiceChatPage/useVoiceChatPage.js
+++ b/src/routes/VoiceChatPage/useVoiceChatPage.js
@@ -1,0 +1,5 @@
+export default function useVoiceChatPage() {
+    // Placeholder hook for VoiceChatPage state management.
+    // Actual logic will be handled via Redux in the future.
+    return {};
+}


### PR DESCRIPTION
## Summary
- create a new `VoiceChatPage` with placeholder content
- hook up a minimal `useVoiceChatPage` stub
- register the new route in `App.jsx`
- add "Voice Chat" entry to the drawer navigation

## Testing
- `pnpm run lint` *(fails: Missing script)*
- `pnpm test` *(no tests found)*

------
https://chatgpt.com/codex/tasks/task_e_6864aea3ac748327be57ef303e6cea23