### PR TITLE
Add voice chat with WebRTC

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
 		"url": "https://github.com/BrandonCasa"
 	},
 	"dependencies": {
-		"dompurify": "^3.2.6",
 		"@emotion/react": "^11.14.0",
 		"@emotion/styled": "^11.14.0",
 		"@fontsource/roboto": "^5.2.5",
@@ -20,6 +19,7 @@
 		"@mui/styled-engine-sc": "^7.1.1",
 		"@reduxjs/toolkit": "^2.8.2",
 		"axios": "^1.9.0",
+		"dompurify": "^3.2.6",
 		"electron-is-dev": "^3.0.1",
 		"electron-log": "^5.4.0",
 		"electron-updater": "^6.6.2",
@@ -30,6 +30,7 @@
 		"react-google-button": "^0.8.0",
 		"react-redux": "^9.2.0",
 		"react-router-dom": "^7.6.2",
+		"simple-peer": "^9.11.1",
 		"socket.io-client": "^4.8.1",
 		"styled-components": "^6.1.18",
 		"validator": "^13.15.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-router-dom:
         specifier: ^7.6.2
         version: 7.6.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      simple-peer:
+        specifier: ^9.11.1
+        version: 9.11.1
       socket.io-client:
         specifier: ^4.8.1
         version: 4.8.1
@@ -1401,6 +1404,9 @@ packages:
   buffer@5.7.1:
     resolution: {integrity: sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==}
 
+  buffer@6.0.3:
+    resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
+
   builder-util-runtime@9.3.1:
     resolution: {integrity: sha512-2/egrNDDnRaxVwK3A+cJq6UOlqOdedGA7JPqCeJjN2Zjk1/QB/6QUi3b714ScIGS7HafFXTyzJEOr5b44I3kvQ==}
     engines: {node: '>=12.0.0'}
@@ -1897,6 +1903,9 @@ packages:
   err-code@2.0.3:
     resolution: {integrity: sha512-2bmlRpNKBxT/CRmPOlyISQpNj+qSeYvcym/uT0Jx2bMOlKLtSy1ZmLuVxSEKKyor/N5yhvp/ZiG1oE3DEYMSFA==}
 
+  err-code@3.0.1:
+    resolution: {integrity: sha512-GiaH0KJUewYok+eeY05IIgjtAe4Yltygk9Wqp1V5yVWLdhf0hYZchRjNIT9bb0mSwRcIusT3cx7PJUf3zEIfUA==}
+
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
 
@@ -2112,6 +2121,9 @@ packages:
   gensync@1.0.0-beta.2:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
+
+  get-browser-rtc@1.1.0:
+    resolution: {integrity: sha512-MghbMJ61EJrRsDe7w1Bvqt3ZsBuqhce5nrn/XAwgwOXhcsz53/ltdxOse1h/8eKXj5slzxdsz56g5rzOFSGwfQ==}
 
   get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
@@ -3123,6 +3135,9 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
   quick-lru@5.1.1:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
@@ -3415,6 +3430,9 @@ packages:
   signal-exit@4.1.0:
     resolution: {integrity: sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==}
     engines: {node: '>=14'}
+
+  simple-peer@9.11.1:
+    resolution: {integrity: sha512-D1SaWpOW8afq1CZGWB8xTfrT3FekjQmPValrqncJMX7QFl8YwhrPTZvMCANLtgBwwdS+7zURyqxDDEmY558tTw==}
 
   simple-swizzle@0.2.2:
     resolution: {integrity: sha512-JA//kQgZtbuY83m+xT+tXJkmJncGMTFT+C+g2h2R9uxkYIrE2yy9sgmcLhCnw57/WSD+Eh3J97FPEDFnbXnDUg==}
@@ -5151,6 +5169,11 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
+  buffer@6.0.3:
+    dependencies:
+      base64-js: 1.5.1
+      ieee754: 1.2.1
+
   builder-util-runtime@9.3.1:
     dependencies:
       debug: 4.4.1(supports-color@8.1.1)
@@ -5754,6 +5777,8 @@ snapshots:
 
   err-code@2.0.3: {}
 
+  err-code@3.0.1: {}
+
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
@@ -6024,6 +6049,8 @@ snapshots:
   generaterr@1.5.0: {}
 
   gensync@1.0.0-beta.2: {}
+
+  get-browser-rtc@1.1.0: {}
 
   get-caller-file@2.0.5: {}
 
@@ -7080,6 +7107,8 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  queue-microtask@1.2.3: {}
+
   quick-lru@5.1.1: {}
 
   random-bytes@1.0.0: {}
@@ -7395,6 +7424,18 @@ snapshots:
   signal-exit@3.0.7: {}
 
   signal-exit@4.1.0: {}
+
+  simple-peer@9.11.1:
+    dependencies:
+      buffer: 6.0.3
+      debug: 4.4.1(supports-color@8.1.1)
+      err-code: 3.0.1
+      get-browser-rtc: 1.1.0
+      queue-microtask: 1.2.3
+      randombytes: 2.1.0
+      readable-stream: 3.6.2
+    transitivePeerDependencies:
+      - supports-color
 
   simple-swizzle@0.2.2:
     dependencies:

--- a/server/src/socketio/voice.js
+++ b/server/src/socketio/voice.js
@@ -37,6 +37,18 @@ class ServerVoice {
         }
     }
 
+    async #relaySignal(socket, callId, signal) {
+        try {
+            const call = this.#calls.get(callId);
+            if (!call) return;
+            const otherId =
+                call.callerId === socket.user.id ? call.calleeId : call.callerId;
+            await this.#emitToUser(otherId, "voice_signal", callId, signal);
+        } catch (err) {
+            logger.error("relay_signal error:", err);
+        }
+    }
+
     async #endCall(socket, callId) {
         try {
             const call = this.#calls.get(callId);
@@ -63,6 +75,9 @@ class ServerVoice {
     startListeners(socket) {
         socket.on("call_user", (otherId) => this.#startCall(socket, otherId));
         socket.on("accept_call", (callId) => this.#acceptCall(socket, callId));
+        socket.on("voice_signal", (callId, signal) =>
+            this.#relaySignal(socket, callId, signal)
+        );
         socket.on("end_call", (callId) => this.#endCall(socket, callId));
         socket.on("disconnect", () => this.#cleanupForSocket(socket));
     }

--- a/server_docs/socketio.md
+++ b/server_docs/socketio.md
@@ -73,6 +73,7 @@ Client‑initiated events:
 | ------------- | ------------ | ------------------------------------- |
 | `call_user`   | `userId`     | Start a voice call with the specified user. The callee receives `incoming_call`. |
 | `accept_call` | `callId`     | Accept an incoming call. Both parties receive `call_accepted`. |
+| `voice_signal` | `callId`, `signal` | Relay WebRTC signalling data to the other participant. |
 | `end_call`    | `callId`     | Terminate an active call. Both parties receive `call_ended`. |
 
 Server‑emitted events:
@@ -81,3 +82,4 @@ Server‑emitted events:
 - `call_started` – confirmation sent back to the caller after issuing `call_user`.
 - `call_accepted` – emitted to both participants when a call is accepted.
 - `call_ended` – emitted to both participants when a call is ended or a participant disconnects.
+- `voice_signal` – WebRTC signalling data forwarded between participants.

--- a/src/helpers/useVoiceChatSocket.js
+++ b/src/helpers/useVoiceChatSocket.js
@@ -1,17 +1,32 @@
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useState } from "react";
+import Peer from "simple-peer";
 import { useDispatch, useSelector } from "react-redux";
 import socketIoHelper from "./socket";
-import { callStarted, incomingCall, callAccepted, callEnded } from "../slices/voiceChatSlice";
+import { callStarted, incomingCall, callAccepted, callEnded, toggleMute } from "../slices/voiceChatSlice";
 
 export default function useVoiceChatSocket() {
-	const dispatch = useDispatch();
-	const token = useSelector((s) => s.auth.token); // adjust selector to your auth slice
-	const myId = useSelector((s) => s.auth.user?.id);
-	const { currentCallId } = useSelector((s) => s.voiceChat);
+        const dispatch = useDispatch();
+        const token = useSelector((s) => s.auth.token);
+        const myId = useSelector((s) => s.auth.user?.id);
+        const { currentCallId, calls } = useSelector((s) => s.voiceChat);
+
+        const [localStream, setLocalStream] = useState(null);
+        const [remoteStream, setRemoteStream] = useState(null);
+        const [peer, setPeer] = useState(null);
+
+        // Acquire microphone once
+        useEffect(() => {
+                navigator.mediaDevices
+                        .getUserMedia({ audio: true })
+                        .then(setLocalStream)
+                        .catch(() => {
+                                /* ignored */
+                        });
+        }, []);
 
 	// --- establish a single shared connection ---
-	useEffect(() => {
-		if (!token) return;
+        useEffect(() => {
+                if (!token) return;
 
 		// get existing or create new socket
 		const socket = socketIoHelper.getSocket() ?? socketIoHelper.connectSocket(token);
@@ -23,21 +38,58 @@ export default function useVoiceChatSocket() {
 		socket.on("call_started", (callId) => {
 			// no state change needed; handled optimistically in startCall()
 		});
-		socket.on("call_accepted", (callId) => {
-			dispatch(callAccepted({ callId }));
-		});
-		socket.on("call_ended", (callId) => {
-			dispatch(callEnded({ callId }));
-		});
+                socket.on("call_accepted", (callId) => {
+                        dispatch(callAccepted({ callId }));
+                });
+                socket.on("voice_signal", (callId, signal) => {
+                        if (callId === currentCallId) peer?.signal(signal);
+                });
+                socket.on("call_ended", (callId) => {
+                        dispatch(callEnded({ callId }));
+                });
 
 		return () => {
 			socket.off("incoming_call");
 			socket.off("call_started");
-			socket.off("call_accepted");
-			socket.off("call_ended");
+                        socket.off("call_accepted");
+                        socket.off("voice_signal");
+                        socket.off("call_ended");
 			// do *not* disconnect; other features may rely on the socket
 		};
-	}, [dispatch, token, myId]);
+        }, [dispatch, token, myId]);
+
+        // create or destroy peer based on call state
+        useEffect(() => {
+                const call = currentCallId ? calls[currentCallId] : null;
+                if (!call || call.status !== "active" || !localStream) return;
+
+                if (peer) return;
+
+                const initiator = call.callerId === myId;
+                const p = new Peer({ initiator, trickle: false, stream: localStream });
+                p.on("signal", (data) => {
+                        socketIoHelper.getSocket()?.emit("voice_signal", currentCallId, data);
+                });
+                p.on("stream", (stream) => {
+                        setRemoteStream(stream);
+                });
+                setPeer(p);
+
+                return () => {
+                        p.destroy();
+                        setPeer(null);
+                        setRemoteStream(null);
+                };
+        }, [currentCallId, calls, localStream, peer, myId]);
+
+        // cleanup peer on call end
+        useEffect(() => {
+                if (!currentCallId && peer) {
+                        peer.destroy();
+                        setPeer(null);
+                        setRemoteStream(null);
+                }
+        }, [currentCallId, peer]);
 
 	// ------- Action Creators (Client-to-Server) -------
 	const startCall = useCallback((otherId) => {
@@ -50,9 +102,17 @@ export default function useVoiceChatSocket() {
 		socketIoHelper.getSocket()?.emit("accept_call", callId);
 	}, []);
 
-	const endCall = useCallback((callId) => {
-		socketIoHelper.getSocket()?.emit("end_call", callId);
-	}, []);
+        const endCall = useCallback((callId) => {
+                socketIoHelper.getSocket()?.emit("end_call", callId);
+        }, []);
 
-	return { startCall, acceptCall, endCall };
+        const toggleMuteLocal = useCallback(() => {
+                if (!localStream || !currentCallId) return;
+                localStream.getAudioTracks().forEach((t) => {
+                        t.enabled = !t.enabled;
+                });
+                dispatch(toggleMute({ callId: currentCallId }));
+        }, [localStream, currentCallId, dispatch]);
+
+        return { startCall, acceptCall, endCall, toggleMute: toggleMuteLocal, remoteStream };
 }

--- a/src/routes/VoiceChatPage/VoiceChatPage.jsx
+++ b/src/routes/VoiceChatPage/VoiceChatPage.jsx
@@ -27,7 +27,7 @@ import useVoiceChatSocket from "../../helpers/useVoiceChatSocket";
 import { callStarted, callEnded } from "../../slices/voiceChatSlice";
 
 export default function VoiceChatPage() {
-	const { startCall, acceptCall, endCall, toggleMute } = useVoiceChatSocket();
+        const { startCall, acceptCall, endCall, toggleMute, remoteStream } = useVoiceChatSocket();
 	const dispatch = useDispatch();
 	const { incoming, currentCallId, calls } = useSelector((s) => s.voiceChat);
 	const myId = useSelector((s) => s.auth.user?.id);
@@ -75,13 +75,13 @@ export default function VoiceChatPage() {
 				</Box>
 			</Grid>
 
-			{/* Call Panel - appears only when in a call */}
-			{currentCallId && currentCall?.status !== "ended" && (
-				<Grid item xs={4} sx={{ borderLeft: 1, borderColor: "divider", p: 2 }}>
-					<Typography variant="h6" gutterBottom>
-						In Call
-					</Typography>
-					<Stack spacing={2}>
+                        {/* Call Panel - appears only when in a call */}
+                        {currentCallId && currentCall?.status !== "ended" && (
+                                <Grid item xs={4} sx={{ borderLeft: 1, borderColor: "divider", p: 2 }}>
+                                        <Typography variant="h6" gutterBottom>
+                                                In Call
+                                        </Typography>
+                                        <Stack spacing={2}>
 						<Stack direction="row" spacing={1} alignItems="center">
 							<Avatar src={`https://api.dicebear.com/8.x/identicon/svg?seed=${otherId}`} />
 							<Typography>{otherId}</Typography>
@@ -89,22 +89,30 @@ export default function VoiceChatPage() {
 						<Divider />
 						{/* Controls */}
 						<Stack direction="row" spacing={2} justifyContent="center">
-							<IconButton onClick={toggleMute}>{currentCall?.muted ? <MicOffIcon /> : <MicIcon />}</IconButton>
-							<IconButton
-								onClick={() => {
-									endCall(currentCallId);
-									dispatch(callEnded({ callId: currentCallId }));
-								}}
+                                                        <IconButton onClick={toggleMute}>{currentCall?.muted ? <MicOffIcon /> : <MicIcon />}</IconButton>
+                                                        <IconButton
+                                                                onClick={() => {
+                                                                        endCall(currentCallId);
+                                                                        dispatch(callEnded({ callId: currentCallId }));
+                                                                }}
 								color="error">
 								<CallEndIcon />
 							</IconButton>
 							<IconButton>
 								<VolumeUpIcon />
 							</IconButton>
-						</Stack>
-					</Stack>
-				</Grid>
-			)}
+                                                </Stack>
+                                                {remoteStream && (
+                                                        <audio
+                                                                autoPlay
+                                                                ref={(el) => {
+                                                                        if (el) el.srcObject = remoteStream;
+                                                                }}
+                                                        />
+                                                )}
+                                        </Stack>
+                                </Grid>
+                        )}
 
 			{/* Incoming Call Dialog */}
 			{incoming && (

--- a/src/slices/voiceChatSlice.js
+++ b/src/slices/voiceChatSlice.js
@@ -1,36 +1,39 @@
 import { createSlice } from "@reduxjs/toolkit";
 
 const initialState = {
-	calls: {}, // callId -> { callerId, calleeId, status: "ringing" | "active" | "ended" }
-	currentCallId: null,
-	incoming: null,
+        calls: {}, // callId -> { callerId, calleeId, status, muted }
+        currentCallId: null,
+        incoming: null,
 };
 
 const voiceChatSlice = createSlice({
 	name: "voiceChat",
 	initialState,
 	reducers: {
-		callStarted(state, { payload: { callId, callerId, calleeId } }) {
-			state.calls[callId] = { callerId, calleeId, status: "ringing" };
-			state.currentCallId = callId;
-		},
-		incomingCall(state, { payload: { callId, callerId, calleeId } }) {
-			state.calls[callId] = { callerId, calleeId, status: "ringing" };
-			state.incoming = { callId, callerId };
-		},
+                callStarted(state, { payload: { callId, callerId, calleeId } }) {
+                        state.calls[callId] = { callerId, calleeId, status: "ringing", muted: false };
+                        state.currentCallId = callId;
+                },
+                incomingCall(state, { payload: { callId, callerId, calleeId } }) {
+                        state.calls[callId] = { callerId, calleeId, status: "ringing", muted: false };
+                        state.incoming = { callId, callerId };
+                },
 		callAccepted(state, { payload: { callId } }) {
 			if (state.calls[callId]) state.calls[callId].status = "active";
 			state.incoming = null;
 			state.currentCallId = callId;
 		},
-		callEnded(state, { payload: { callId } }) {
-			if (state.calls[callId]) state.calls[callId].status = "ended";
-			if (state.currentCallId === callId) state.currentCallId = null;
-			if (state.incoming?.callId === callId) state.incoming = null;
-		},
-		resetVoiceChat: () => initialState,
-	},
+                callEnded(state, { payload: { callId } }) {
+                        if (state.calls[callId]) state.calls[callId].status = "ended";
+                        if (state.currentCallId === callId) state.currentCallId = null;
+                        if (state.incoming?.callId === callId) state.incoming = null;
+                },
+                toggleMute(state, { payload: { callId } }) {
+                        if (state.calls[callId]) state.calls[callId].muted = !state.calls[callId].muted;
+                },
+                resetVoiceChat: () => initialState,
+        },
 });
 
-export const { callStarted, incomingCall, callAccepted, callEnded, resetVoiceChat } = voiceChatSlice.actions;
+export const { callStarted, incomingCall, callAccepted, callEnded, toggleMute, resetVoiceChat } = voiceChatSlice.actions;
 export default voiceChatSlice.reducer;


### PR DESCRIPTION
## Summary
- implement `voice_signal` relay in server and docs
- track mute state in voiceChatSlice
- setup `simple-peer` in `useVoiceChatSocket`
- stream remote audio in `VoiceChatPage`
- add `simple-peer` dependency

## Testing
- `pnpm -r test`

------
https://chatgpt.com/codex/tasks/task_e_6864bb7847cc8327910ebc4192a02aaf