### PR TITLE
Add global voice chat overlay

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,9 @@ import CustomAppBar from "./components/CustomAppBar/CustomAppBar";
 import LoginDialog from "./components/LoginDialog.comp";
 import RegisterDialog from "./components/RegisterDialog";
 import SnackbarMapper from "./components/SnackbarMapper";
+import VoiceChatOverlay from "./components/VoiceChatOverlay";
+import VoiceChatContext from "./context/VoiceChatContext";
+import useVoiceChatSocket from "./helpers/useVoiceChatSocket";
 import useDarkTheme from "./helpers/darkTheme";
 import socketIoHelper from "./helpers/socket";
 import { setLoggedIn, setLoggingIn, setSocketStatus, verifyUser, setAuthState } from "./slices/authSlice";
@@ -40,10 +43,11 @@ const AppRouter = ({ children }) => {
 };
 
 const App = () => {
-	const authState = useSelector((state) => state.auth);
-	const darkTheme = useDarkTheme();
-	const dispatch = useDispatch();
-	const customAppBarProps = useCustomAppBar(useWindowDimensions().width);
+        const authState = useSelector((state) => state.auth);
+        const darkTheme = useDarkTheme();
+        const dispatch = useDispatch();
+        const customAppBarProps = useCustomAppBar(useWindowDimensions().width);
+        const voiceChatValue = useVoiceChatSocket();
 
 	useEffect(() => {
 		const params = new URLSearchParams(window.location.search);
@@ -117,15 +121,17 @@ const App = () => {
 	useSocketConnection(authState.authToken, authState.loggedIn);
 	useVerifyUser(authState);
 
-	return (
-		<ThemeProvider theme={darkTheme}>
-			{window.isElectron && <AutoUpdate />}
-			<CssBaseline />
-			<SnackbarMapper drawerWidth={customAppBarProps.drawerWidth} drawerOpen={customAppBarProps.drawerOpen} />
-			<AppRouter>
-				<RegisterDialog />
-				<LoginDialog />
-				<CustomAppBar {...customAppBarProps}>
+        return (
+                <ThemeProvider theme={darkTheme}>
+                        {window.isElectron && <AutoUpdate />}
+                        <CssBaseline />
+                        <VoiceChatContext.Provider value={voiceChatValue}>
+                                <SnackbarMapper drawerWidth={customAppBarProps.drawerWidth} drawerOpen={customAppBarProps.drawerOpen} />
+                                <VoiceChatOverlay />
+                                <AppRouter>
+                                        <RegisterDialog />
+                                        <LoginDialog />
+                                        <CustomAppBar {...customAppBarProps}>
 					{!authState.loggingIn ? (
 						<Suspense fallback={<div>Loading...</div>}>
 							<Routes>
@@ -142,10 +148,11 @@ const App = () => {
 							</Routes>
 						</Suspense>
 					) : null}
-				</CustomAppBar>
-			</AppRouter>
-		</ThemeProvider>
-	);
+                                        </CustomAppBar>
+                                </AppRouter>
+                        </VoiceChatContext.Provider>
+                </ThemeProvider>
+        );
 };
 
 export default App;

--- a/src/components/VoiceChatOverlay.jsx
+++ b/src/components/VoiceChatOverlay.jsx
@@ -1,0 +1,88 @@
+import React, { useContext, useState, useRef } from "react";
+import { Box, Avatar, IconButton, Typography, Paper, Dialog, DialogTitle, DialogContent, DialogActions, Button } from "@mui/material";
+import CallEndIcon from "@mui/icons-material/CallEnd";
+import CallIcon from "@mui/icons-material/Call";
+import MicIcon from "@mui/icons-material/Mic";
+import MicOffIcon from "@mui/icons-material/MicOff";
+import VoiceChatContext from "../context/VoiceChatContext";
+import { useSelector, useDispatch } from "react-redux";
+import { callEnded } from "../slices/voiceChatSlice";
+import { useLocation } from "react-router-dom";
+
+export default function VoiceChatOverlay() {
+  const location = useLocation();
+  const dispatch = useDispatch();
+  const voiceChat = useContext(VoiceChatContext);
+  const { incoming, currentCallId, calls } = useSelector((s) => s.voiceChat);
+  const myId = useSelector((s) => s.auth.user?.id);
+  const friends = useSelector((s) => s.auth.friends) || [];
+
+  const [pos, setPos] = useState({ x: window.innerWidth - 220, y: window.innerHeight - 140 });
+  const dragRef = useRef(null);
+
+  const handlePointerDown = (e) => {
+    dragRef.current = { x: e.clientX - pos.x, y: e.clientY - pos.y };
+    window.addEventListener("pointermove", handlePointerMove);
+    window.addEventListener("pointerup", handlePointerUp);
+  };
+  const handlePointerMove = (e) => {
+    setPos({ x: e.clientX - dragRef.current.x, y: e.clientY - dragRef.current.y });
+  };
+  const handlePointerUp = () => {
+    window.removeEventListener("pointermove", handlePointerMove);
+    window.removeEventListener("pointerup", handlePointerUp);
+  };
+
+  const currentCall = currentCallId ? calls[currentCallId] : null;
+  const otherId = currentCall && (currentCall.callerId === myId ? currentCall.calleeId : currentCall.callerId);
+  const other = friends.find((f) => f.id === otherId);
+
+  if (location.pathname === "/voicechat") return null;
+
+  if (incoming) {
+    return (
+      <Dialog open>
+        <DialogTitle>Incoming Call</DialogTitle>
+        <DialogContent>
+          <Typography>{incoming.callerId} is calling...</Typography>
+        </DialogContent>
+        <DialogActions>
+          <Button color="error" onClick={() => voiceChat.endCall(incoming.callId)} startIcon={<CallEndIcon />}>Decline</Button>
+          <Button onClick={() => voiceChat.acceptCall(incoming.callId)} startIcon={<CallIcon />}>Accept</Button>
+        </DialogActions>
+      </Dialog>
+    );
+  }
+
+  if (!currentCall || currentCall.status === "ended") return null;
+
+  return (
+    <Box style={{ position: "fixed", top: pos.y, left: pos.x, zIndex: 1301 }}>
+      <Paper elevation={8} sx={{ p: 1, width: 200 }} onPointerDown={handlePointerDown}>
+        <Box sx={{ display: "flex", alignItems: "center" }}>
+          <Avatar src={`https://api.dicebear.com/8.x/identicon/svg?seed=${otherId}`} />
+          <Typography sx={{ ml: 1, flexGrow: 1 }} noWrap>
+            {(other && (other.name || other.displayName)) || otherId}
+          </Typography>
+          <IconButton
+            onClick={() => {
+              voiceChat.endCall(currentCallId);
+              dispatch(callEnded({ callId: currentCallId }));
+            }}
+            size="small"
+          >
+            <CallEndIcon color="error" />
+          </IconButton>
+        </Box>
+        <Box sx={{ display: "flex", justifyContent: "center", mt: 1 }}>
+          <IconButton onClick={voiceChat.toggleMute}>
+            {currentCall.muted ? <MicOffIcon /> : <MicIcon />}
+          </IconButton>
+        </Box>
+        {voiceChat.remoteStream && (
+          <audio autoPlay ref={(el) => el && (el.srcObject = voiceChat.remoteStream)} />
+        )}
+      </Paper>
+    </Box>
+  );
+}

--- a/src/context/VoiceChatContext.jsx
+++ b/src/context/VoiceChatContext.jsx
@@ -1,0 +1,11 @@
+import { createContext } from "react";
+
+const VoiceChatContext = createContext({
+  startCall: () => {},
+  acceptCall: () => {},
+  endCall: () => {},
+  toggleMute: () => {},
+  remoteStream: null,
+});
+
+export default VoiceChatContext;

--- a/src/helpers/useVoiceChatSocket.js
+++ b/src/helpers/useVoiceChatSocket.js
@@ -3,6 +3,7 @@ import Peer from "simple-peer";
 import { useDispatch, useSelector } from "react-redux";
 import socketIoHelper from "./socket";
 import { callStarted, incomingCall, callAccepted, callEnded, toggleMute } from "../slices/voiceChatSlice";
+import { addSnackbar } from "../slices/snackbarSlice";
 
 export default function useVoiceChatSocket() {
         const dispatch = useDispatch();
@@ -32,20 +33,47 @@ export default function useVoiceChatSocket() {
 		const socket = socketIoHelper.getSocket() ?? socketIoHelper.connectSocket(token);
 
 		// attach per‑feature listeners once
-		socket.on("incoming_call", (callId, callerId) => {
-			dispatch(incomingCall({ callId, callerId, calleeId: myId }));
-		});
-		socket.on("call_started", (callId) => {
-			// no state change needed; handled optimistically in startCall()
-		});
+                socket.on("incoming_call", (callId, callerId) => {
+                        dispatch(incomingCall({ callId, callerId, calleeId: myId }));
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Incoming call",
+                                        snackbarSeverity: "info",
+                                        autoHideDuration: 2000,
+                                })
+                        );
+                });
+                socket.on("call_started", () => {
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Calling...",
+                                        snackbarSeverity: "info",
+                                        autoHideDuration: 1000,
+                                })
+                        );
+                });
                 socket.on("call_accepted", (callId) => {
                         dispatch(callAccepted({ callId }));
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Call connected",
+                                        snackbarSeverity: "success",
+                                        autoHideDuration: 1500,
+                                })
+                        );
                 });
                 socket.on("voice_signal", (callId, signal) => {
                         if (callId === currentCallId) peer?.signal(signal);
                 });
                 socket.on("call_ended", (callId) => {
                         dispatch(callEnded({ callId }));
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Call ended",
+                                        snackbarSeverity: "warning",
+                                        autoHideDuration: 1500,
+                                })
+                        );
                 });
 
 		return () => {

--- a/src/routes/VoiceChatPage/VoiceChatPage.jsx
+++ b/src/routes/VoiceChatPage/VoiceChatPage.jsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useContext } from "react";
 import {
 	Box,
 	Typography,
@@ -23,11 +23,11 @@ import MicOffIcon from "@mui/icons-material/MicOff";
 import MicIcon from "@mui/icons-material/Mic";
 import VolumeUpIcon from "@mui/icons-material/VolumeUp";
 import { useSelector, useDispatch } from "react-redux";
-import useVoiceChatSocket from "../../helpers/useVoiceChatSocket";
+import VoiceChatContext from "../../context/VoiceChatContext";
 import { callStarted, callEnded } from "../../slices/voiceChatSlice";
 
 export default function VoiceChatPage() {
-        const { startCall, acceptCall, endCall, toggleMute, remoteStream } = useVoiceChatSocket();
+        const { startCall, acceptCall, endCall, toggleMute, remoteStream } = useContext(VoiceChatContext);
 	const dispatch = useDispatch();
 	const { incoming, currentCallId, calls } = useSelector((s) => s.voiceChat);
 	const myId = useSelector((s) => s.auth.user?.id);


### PR DESCRIPTION
## Summary
- implement `VoiceChatContext` for global call controls
- add draggable `VoiceChatOverlay` visible outside the voice chat page
- show snackbar notifications for call events
- expose voice chat context through `App` and update voice chat page

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864bf8794048327b23cced9ad327f18