### PR TITLE
Add profile creation date field

### DIFF
--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -97,19 +97,20 @@ UserSchema.methods.generateJWT = function () {
  * @returns {Object}
  */
 UserSchema.methods.toAuthJSON = function () {
-	return {
-		id: this._id,
-		username: this.username,
-		email: this.email,
-		displayName: this.displayName,
-		bio: this.bio,
-		bannerUrl: this.bannerUrl,
-		avatarUrl: this.avatarUrl,
-		token: this.generateJWT(),
-		friends: this.friends,
-		blocked: this.blocked,
-		serverInvites: this.serverInvites,
-	};
+        return {
+                id: this._id,
+                username: this.username,
+                email: this.email,
+                displayName: this.displayName,
+                bio: this.bio,
+                bannerUrl: this.bannerUrl,
+                avatarUrl: this.avatarUrl,
+                createdAt: this.createdAt,
+                token: this.generateJWT(),
+                friends: this.friends,
+                blocked: this.blocked,
+                serverInvites: this.serverInvites,
+        };
 };
 
 /**
@@ -125,19 +126,20 @@ UserSchema.methods.toProfilePrivJSON = async function (requestingUser, session =
 	await this.populate({ path: "friends", options: { session } });
 	await this.populate({ path: "serverInvites", options: { session } });
 
-	return {
-		id: this._id,
-		username: this.username,
-		email: this.email,
-		displayName: this.displayName,
-		bio: this.bio,
-		bannerUrl: this.bannerUrl,
-		avatarUrl: this.avatarUrl,
-		friends: this.friends,
-		blocked: this.blocked,
-		serverInvites: this.serverInvites,
-		servers: this.servers,
-	};
+        return {
+                id: this._id,
+                username: this.username,
+                email: this.email,
+                displayName: this.displayName,
+                bio: this.bio,
+                bannerUrl: this.bannerUrl,
+                avatarUrl: this.avatarUrl,
+                createdAt: this.createdAt,
+                friends: this.friends,
+                blocked: this.blocked,
+                serverInvites: this.serverInvites,
+                servers: this.servers,
+        };
 };
 
 /**
@@ -150,17 +152,18 @@ UserSchema.methods.toProfilePrivJSON = async function (requestingUser, session =
  */
 UserSchema.methods.toProfilePubJSON = async function (queryingUser, session = null) {
 	if (!queryingUser) {
-		return {
-			id: this._id,
-			username: this.username,
-			displayName: this.displayName,
-			bio: this.bio,
-			bannerUrl: this.bannerUrl,
-			avatarUrl: this.avatarUrl,
-			friends: [],
-			blocked: [],
-			servers: [],
-		};
+                return {
+                        id: this._id,
+                        username: this.username,
+                        displayName: this.displayName,
+                        bio: this.bio,
+                        bannerUrl: this.bannerUrl,
+                        avatarUrl: this.avatarUrl,
+                        createdAt: this.createdAt,
+                        friends: [],
+                        blocked: [],
+                        servers: [],
+                };
 	}
 
 	await this.populate({ path: "friends", options: { session } });
@@ -188,17 +191,18 @@ UserSchema.methods.toProfilePubJSON = async function (queryingUser, session = nu
 	const theirServers = queryingUser.servers.map((s) => s.toString());
 	const mutualServers = this.servers.filter((s) => theirServers.includes(s.toString()));
 
-	return {
-		id: this._id,
-		username: this.username,
-		displayName: this.displayName,
-		bio: this.bio,
-		bannerUrl: this.bannerUrl,
-		avatarUrl: this.avatarUrl,
-		friends: [friendInvite, ...mutualFriendIds].filter((x) => x != null),
-		blocked: blockedList,
-		servers: mutualServers,
-	};
+        return {
+                id: this._id,
+                username: this.username,
+                displayName: this.displayName,
+                bio: this.bio,
+                bannerUrl: this.bannerUrl,
+                avatarUrl: this.avatarUrl,
+                createdAt: this.createdAt,
+                friends: [friendInvite, ...mutualFriendIds].filter((x) => x != null),
+                blocked: blockedList,
+                servers: mutualServers,
+        };
 };
 
 /**

--- a/server_docs/endpoints/users_profile.md
+++ b/server_docs/endpoints/users_profile.md
@@ -11,4 +11,7 @@ Returns a user's profile. The behaviour depends on the authenticated user and op
   - `404` – user not found.
   - `401` – invalid token.
 
+Both public and private profile objects now include a `createdAt` timestamp
+representing when the account was created.
+
 Profiles are generated via `toProfilePrivJSON` or `toProfilePubJSON` which include mutual friends and servers when applicable.

--- a/src/components/User/ProfileCard.jsx
+++ b/src/components/User/ProfileCard.jsx
@@ -143,16 +143,21 @@ export default function ProfileCard({ user, self: forceSelf = false, type = "ful
 					</Stack>
 
 					{/* Bio */}
-					<Paper variant="outlined" sx={{ p: 1, flex: 1, minHeight: 80 }}>
-						<Typography variant="subtitle2">About Me</Typography>
-						<Typography variant="body2" color="text.secondary">
-							{profile.bio || "This user hasn’t written a bio yet."}
-						</Typography>
-					</Paper>
-				</Stack>
-			</Paper>
-		);
-	}
+                                        <Paper variant="outlined" sx={{ p: 1, flex: 1, minHeight: 80 }}>
+                                                <Typography variant="subtitle2">About Me</Typography>
+                                                <Typography variant="body2" color="text.secondary">
+                                                        {profile.bio || "This user hasn’t written a bio yet."}
+                                                </Typography>
+                                        </Paper>
+                                        {profile.createdAt && (
+                                                <Typography variant="caption" color="text.secondary">
+                                                        Joined {new Date(profile.createdAt).toLocaleDateString()}
+                                                </Typography>
+                                        )}
+                                </Stack>
+                        </Paper>
+                );
+        }
 
 	/* ---------- main render ---------- */
 	return (
@@ -225,16 +230,21 @@ export default function ProfileCard({ user, self: forceSelf = false, type = "ful
 				</Stack>
 
 				{/* Bio */}
-				<Paper variant="outlined" sx={{ p: 1, flex: 1, minHeight: 80 }}>
-					<Typography variant="subtitle2">About Me</Typography>
-					{editMode ? (
-						<TextField fullWidth multiline rows={4} label="Bio" value={bio} onChange={(e) => setBio(e.target.value)} />
-					) : (
-						<Typography variant="body2" color="text.secondary">
-							{profile.bio || "This user hasn’t written a bio yet."}
-						</Typography>
-					)}
-				</Paper>
+                                <Paper variant="outlined" sx={{ p: 1, flex: 1, minHeight: 80 }}>
+                                        <Typography variant="subtitle2">About Me</Typography>
+                                        {editMode ? (
+                                                <TextField fullWidth multiline rows={4} label="Bio" value={bio} onChange={(e) => setBio(e.target.value)} />
+                                        ) : (
+                                                <Typography variant="body2" color="text.secondary">
+                                                        {profile.bio || "This user hasn’t written a bio yet."}
+                                                </Typography>
+                                        )}
+                                </Paper>
+                                {profile.createdAt && !editMode && (
+                                        <Typography variant="caption" color="text.secondary">
+                                                Joined {new Date(profile.createdAt).toLocaleDateString()}
+                                        </Typography>
+                                )}
 
 				{/* Actions */}
 				<Box>

--- a/src/components/User/useProfileCard.js
+++ b/src/components/User/useProfileCard.js
@@ -39,15 +39,16 @@ export default function useProfileCard(user, forceSelf) {
 	const isSelf = forceSelf || user?.id === auth.userId;
 	const rawData = isSelf
 		? auth
-		: (user ?? {
-				id: null,
-				displayName: "",
-				username: "",
-				bio: "",
-				avatarUrl: null,
-				bannerUrl: null,
-				friends: [],
-			});
+                : (user ?? {
+                                id: null,
+                                displayName: "",
+                                username: "",
+                                bio: "",
+                                avatarUrl: null,
+                                bannerUrl: null,
+                                friends: [],
+                                createdAt: null,
+                        });
 
 	const [profile, setProfile] = useState(rawData);
 	const [editMode, setEdit] = useState(false);

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -12,8 +12,9 @@ const initialState = {
 	userId: null,
 	username: "",
 	displayName: "",
-	bio: "",
-	loggingIn: false,
+        bio: "",
+        createdAt: null,
+        loggingIn: false,
 	socketInfo: {
 		connected: false,
 		currentRoom: null,
@@ -37,17 +38,18 @@ export const verifyUser = createAsyncThunk("auth/verifyUser", async (token, { re
 		);
 		const u = data.user;
 
-		return {
-			loggedIn: true,
-			authToken: token,
-			userId: u.id,
-			username: u.username,
-			displayName: u.displayName,
-			bio: u.bio,
-			friends: u.friends,
-			bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
-			avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
-		};
+                return {
+                        loggedIn: true,
+                        authToken: token,
+                        userId: u.id,
+                        username: u.username,
+                        displayName: u.displayName,
+                        bio: u.bio,
+                        friends: u.friends,
+                        bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
+                        avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
+                        createdAt: u.createdAt,
+                };
 	} catch (err) {
 		return rejectWithValue(err.response?.data || err.message);
 	}
@@ -61,17 +63,18 @@ export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, pass
 		});
 		const u = data.user;
 
-		return {
-			loggedIn: true,
-			authToken: u.token,
-			userId: u.id,
-			username: u.username,
-			displayName: u.displayName,
-			bio: u.bio,
-			friends: u.friends,
-			bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
-			avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
-		};
+                return {
+                        loggedIn: true,
+                        authToken: u.token,
+                        userId: u.id,
+                        username: u.username,
+                        displayName: u.displayName,
+                        bio: u.bio,
+                        friends: u.friends,
+                        bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
+                        avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
+                        createdAt: u.createdAt,
+                };
 	} catch (err) {
 		return rejectWithValue(err.response?.data || err.message);
 	}
@@ -91,17 +94,18 @@ export const registerUser = createAsyncThunk(
 				window.localStorage.setItem("auth-token", u.token);
 			}
 
-			return {
-				loggedIn: true,
-				authToken: u.token,
-				userId: u.id,
-				username: u.username,
-				displayName: u.displayName,
-				bio: u.bio,
-				friends: u.friends,
-				bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
-				avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
-			};
+                return {
+                        loggedIn: true,
+                        authToken: u.token,
+                        userId: u.id,
+                        username: u.username,
+                        displayName: u.displayName,
+                        bio: u.bio,
+                        friends: u.friends,
+                        bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
+                        avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
+                        createdAt: u.createdAt,
+                };
 		} catch (err) {
 			return rejectWithValue(err.response?.data || err.message);
 		}
@@ -149,12 +153,15 @@ const authSlice = createSlice({
 			if ("bio" in action.payload) {
 				state.bio = action.payload.bio;
 			}
-			if ("friends" in action.payload) {
-				state.friends = action.payload.friends;
-			}
-			if ("bannerUrl" in action.payload) {
-				state.bannerUrl = action.payload.bannerUrl;
-			}
+                        if ("friends" in action.payload) {
+                                state.friends = action.payload.friends;
+                        }
+                        if ("createdAt" in action.payload) {
+                                state.createdAt = action.payload.createdAt;
+                        }
+                        if ("bannerUrl" in action.payload) {
+                                state.bannerUrl = action.payload.bannerUrl;
+                        }
 			if ("avatarUrl" in action.payload) {
 				state.avatarUrl = action.payload.avatarUrl;
 			}
@@ -194,11 +201,12 @@ const authSlice = createSlice({
 				state.userId = action.payload.userId;
 				state.username = action.payload.username;
 				state.displayName = action.payload.displayName;
-				state.bio = action.payload.bio;
-				state.friends = action.payload.friends;
-				state.bannerUrl = action.payload.bannerUrl;
-				state.avatarUrl = action.payload.avatarUrl;
-			})
+                                state.bio = action.payload.bio;
+                                state.friends = action.payload.friends;
+                                state.bannerUrl = action.payload.bannerUrl;
+                                state.avatarUrl = action.payload.avatarUrl;
+                                state.createdAt = action.payload.createdAt;
+                        })
 			.addCase(verifyUser.rejected, (state) => {
 				state.loggingIn = false;
 				state.loggedIn = false;
@@ -214,10 +222,11 @@ const authSlice = createSlice({
 				state.username = action.payload.username;
 				state.displayName = action.payload.displayName;
 				state.bio = action.payload.bio;
-				state.friends = action.payload.friends;
-				state.bannerUrl = action.payload.bannerUrl;
-				state.avatarUrl = action.payload.avatarUrl;
-			})
+                                state.friends = action.payload.friends;
+                                state.bannerUrl = action.payload.bannerUrl;
+                                state.avatarUrl = action.payload.avatarUrl;
+                                state.createdAt = action.payload.createdAt;
+                        })
 			.addCase(registerUser.rejected, (state) => {
 				state.loggingIn = false;
 				state.loggedIn = false;
@@ -234,10 +243,11 @@ const authSlice = createSlice({
 				state.displayName = action.payload.displayName;
 				state.bio = action.payload.bio;
 				state.friends = action.payload.friends;
-				state.bannerUrl = action.payload.bannerUrl;
-				state.avatarUrl = action.payload.avatarUrl;
-				window.localStorage.setItem("auth-token", action.payload.authToken);
-			})
+                                state.bannerUrl = action.payload.bannerUrl;
+                                state.avatarUrl = action.payload.avatarUrl;
+                                state.createdAt = action.payload.createdAt;
+                                window.localStorage.setItem("auth-token", action.payload.authToken);
+                        })
 			.addCase(loginUser.rejected, (state) => {
 				state.loggingIn = false;
 				state.loggedIn = false;

--- a/src/slices/userApiSlice.js
+++ b/src/slices/userApiSlice.js
@@ -17,14 +17,14 @@ export const fetchUserProfile = createAsyncThunk("userApi/fetchUserProfile", asy
 		});
 		const u = data.user;
 
-		return {
-			id: u.id,
-			profile: {
-				...u,
-				bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
-				avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
-			},
-		};
+                return {
+                        id: u.id,
+                        profile: {
+                                ...u,
+                                bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
+                                avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
+                        },
+                };
 	} catch (err) {
 		return rejectWithValue(err.response?.data || err.message);
 	}


### PR DESCRIPTION
## Summary
- include `createdAt` in authentication and profile JSON
- document new `createdAt` field
- expose creation date in Redux stores
- show join date in `ProfileCard`

## Testing
- `pnpm run build`

------
https://chatgpt.com/codex/tasks/task_e_6864d41b170883278fcc3efe57178346