### PR TITLE
Add users module scaffold and lint config for new Nest backend

### DIFF
--- a/server_new_impl/eslint.config.js
+++ b/server_new_impl/eslint.config.js
@@ -1,0 +1,43 @@
+const js = require('@eslint/js');
+const tsPlugin = require('@typescript-eslint/eslint-plugin');
+const tsParser = require('@typescript-eslint/parser');
+const importPlugin = require('eslint-plugin-import');
+const globals = require('globals');
+
+module.exports = [
+  {
+    ignores: ['dist/**']
+  },
+  js.configs.recommended,
+  {
+    files: ['**/*.{ts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        project: './tsconfig.json',
+        tsconfigRootDir: __dirname
+      },
+      globals: {
+        ...globals.node,
+        ...globals.commonjs
+      }
+    },
+    plugins: {
+      '@typescript-eslint': tsPlugin,
+      import: importPlugin
+    },
+    rules: {
+      ...tsPlugin.configs['recommended-type-checked'].rules,
+      ...tsPlugin.configs['stylistic-type-checked'].rules,
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      'import/order': [
+        'warn',
+        {
+          alphabetize: { order: 'asc', caseInsensitive: true },
+          'newlines-between': 'always'
+        }
+      ]
+    }
+  }
+];

--- a/server_new_impl/src/app.module.ts
+++ b/server_new_impl/src/app.module.ts
@@ -1,11 +1,12 @@
+import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { Module, Logger } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
 import { GraphQLModule } from '@nestjs/graphql';
-import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 
 import { appConfig, validationSchema } from './config/app.config';
 import { GraphqlConfigService } from './config/graphql-config.service';
 import { HealthModule } from './health/health.module';
+import { UsersModule } from './users/users.module';
 
 @Module({
   imports: [
@@ -20,7 +21,8 @@ import { HealthModule } from './health/health.module';
       imports: [ConfigModule],
       useClass: GraphqlConfigService
     }),
-    HealthModule
+    HealthModule,
+    UsersModule
   ],
   providers: [GraphqlConfigService, Logger]
 })

--- a/server_new_impl/src/config/graphql-config.service.ts
+++ b/server_new_impl/src/config/graphql-config.service.ts
@@ -1,9 +1,10 @@
+import { join } from 'node:path';
+
+import { ApolloDriverConfig } from '@nestjs/apollo';
 import { Injectable } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import { ApolloDriverConfig } from '@nestjs/apollo';
 import { GqlOptionsFactory } from '@nestjs/graphql';
 import { Request, Response } from 'express';
-import { join } from 'node:path';
 
 import { AppConfig } from './app.config';
 

--- a/server_new_impl/src/main.ts
+++ b/server_new_impl/src/main.ts
@@ -31,4 +31,4 @@ async function bootstrap() {
   logger.log(`🚀 GraphQL server ready at http://localhost:${port}/graphql`);
 }
 
-bootstrap();
+void bootstrap();

--- a/server_new_impl/src/users/dto/get-user.args.ts
+++ b/server_new_impl/src/users/dto/get-user.args.ts
@@ -1,0 +1,11 @@
+import { ArgsType, Field } from '@nestjs/graphql';
+import { IsAlphanumeric, IsLowercase, Length } from 'class-validator';
+
+@ArgsType()
+export class GetUserArgs {
+  @Field({ description: 'Username to locate the target user profile.' })
+  @IsAlphanumeric()
+  @IsLowercase()
+  @Length(3, 32)
+  username!: string;
+}

--- a/server_new_impl/src/users/user.model.ts
+++ b/server_new_impl/src/users/user.model.ts
@@ -1,0 +1,19 @@
+import { Field, ID, ObjectType } from '@nestjs/graphql';
+
+@ObjectType({ description: 'User profile summary exposed to clients.' })
+export class User {
+  @Field(() => ID)
+  id!: string;
+
+  @Field({ description: 'Unique username/handle used for mentions and lookups.' })
+  username!: string;
+
+  @Field({ description: 'User-facing display name.' })
+  displayName!: string;
+
+  @Field({ nullable: true, description: 'Avatar image URL (to be swapped for signed S3 URLs later).' })
+  avatarUrl?: string;
+
+  @Field({ description: 'Creation timestamp for the user account.' })
+  createdAt!: Date;
+}

--- a/server_new_impl/src/users/users.module.ts
+++ b/server_new_impl/src/users/users.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+
+import { UsersResolver } from './users.resolver';
+import { UsersService } from './users.service';
+
+@Module({
+  providers: [UsersResolver, UsersService],
+  exports: [UsersService]
+})
+export class UsersModule {}

--- a/server_new_impl/src/users/users.resolver.ts
+++ b/server_new_impl/src/users/users.resolver.ts
@@ -1,0 +1,19 @@
+import { Args, Query, Resolver } from '@nestjs/graphql';
+
+import { GetUserArgs } from './dto/get-user.args';
+import { User } from './user.model';
+import { UsersService } from './users.service';
+
+@Resolver(() => User)
+export class UsersResolver {
+  constructor(private readonly usersService: UsersService) {}
+
+  @Query(() => User, {
+    name: 'user',
+    nullable: true,
+    description: 'Lookup a user by username. Will connect to PostgreSQL once the data layer lands.'
+  })
+  user(@Args() args: GetUserArgs): User | null {
+    return this.usersService.findByUsername(args.username);
+  }
+}

--- a/server_new_impl/src/users/users.service.ts
+++ b/server_new_impl/src/users/users.service.ts
@@ -1,0 +1,27 @@
+import { Injectable } from '@nestjs/common';
+
+import { User } from './user.model';
+
+type UserRecord = User & { email?: string };
+
+@Injectable()
+export class UsersService {
+  // Temporary in-memory store to unblock GraphQL schema consumers until Prisma is wired up.
+  private readonly users: UserRecord[] = [
+    {
+      id: '1',
+      username: 'reboundbot',
+      displayName: 'Rebound Bot',
+      avatarUrl: undefined,
+      createdAt: new Date('2024-01-01T00:00:00Z'),
+      email: 'bot@example.com'
+    }
+  ];
+
+  findByUsername(username: string): User | null {
+    const normalized = username.trim().toLowerCase();
+    const match = this.users.find((user) => user.username === normalized);
+
+    return match ?? null;
+  }
+}

--- a/server_new_plan/README.md
+++ b/server_new_plan/README.md
@@ -11,10 +11,10 @@ This folder captures the high-level migration strategy for moving the Rebound ba
 
 ## Migration Phases (broad scope)
 1. **Foundation (NestJS bootstrap)**
-   - [ ] Create Nest workspace with pnpm; set up ESLint/Prettier aligned with repo style.
-   - [ ] Add GraphQL (Apollo driver) with code-first schema generation and automatic schema artifact publishing.
+   - [x] Create Nest workspace with pnpm; set up ESLint/Prettier aligned with repo style.
+   - [x] Add GraphQL (Apollo driver) with code-first schema generation and automatic schema artifact publishing.
    - [ ] Establish shared `@rebound/types` package for DTOs/entities used by frontend (exported via pnpm workspace).
-   - [ ] Wire configuration module (env validation, per-environment files) and logging (Nest Logger + Winston bridge).
+   - [x] Wire configuration module (env validation, per-environment files) and logging (Nest Logger + Winston bridge).
 
 2. **Auth & User Domain parity**
    - [ ] Rebuild authentication/authorization (JWT access/refresh, optional OAuth providers) mirroring current `auth.js` behavior (cookie + bearer token handling).
@@ -40,6 +40,17 @@ This folder captures the high-level migration strategy for moving the Rebound ba
    - [ ] Update GitHub Actions to build/test Nest apps, run GraphQL schema diffing, lint, and publish packages to npm registry or GitHub Packages.
    - [ ] Add e2e test harness (Jest + Supertest/GraphQL testing) and contract tests for Socket/WebSocket flows.
    - [ ] Provide local dev scripts (pnpm) and mocks for S3/Cloudflare (e.g., LocalStack/MinIO) plus database seeders.
+
+## Progress (this iteration)
+
+- Bootstrapped `server_new_impl` Nest app with GraphQL, validated configuration, and security middleware (helmet/CORS/validation pipe).
+- Added `Health` GraphQL resolver for liveness checks and initial `Users` module with a schema-level lookup stub to unblock frontend contracts.
+
+## Next considerations
+
+- Replace the in-memory `UsersService` placeholder with Prisma-backed PostgreSQL access and add dataloaders for relation-heavy queries.
+- Introduce authentication/authorization guards around user lookups before exposing broader profile fields.
+- Stand up the shared `@rebound/types` package so the frontend can adopt generated types without coupling to Nest internals.
 
 ## Notes & Considerations
 - **API surface:** Go fully GraphQL-first (plus WebSockets for realtime) and deprecate the legacy REST surface as the frontend is modernized.

--- a/server_new_plan/architecture.md
+++ b/server_new_plan/architecture.md
@@ -54,3 +54,13 @@
 - OpenTelemetry tracing with HTTP/WebSocket instrumentation; exporters for Jaeger/OTLP.
 - Metrics via Prometheus + NestJS meters; dashboards for request rates, resolver latency, pub/sub throughput.
 - Log correlation with Cloudflare request IDs.
+
+## Current implementation snapshot
+- Nest GraphQL bootstrap is live with code-first schema generation and schema sorting.
+- Health resolver returns liveness metadata for quick smoke tests.
+- Users module scaffolded with a validated `user` query backed by an in-memory store until Prisma + PostgreSQL land.
+
+## Near-term adjustments
+- Add `@ResolveField` patterns and dataloaders around `User` relations (friends, presence) as soon as persistence is in place.
+- Wire Nest Guards/interceptors to enforce auth/context on user lookups once JWT/CSRF flows are implemented.
+- Capture schema artifacts in CI for diffing against future iterations and to feed frontend codegen.


### PR DESCRIPTION
## Summary
- add flat ESLint configuration for the new NestJS service
- scaffold the Users GraphQL module with validated lookup query and wire it into the app
- document current backend progress and upcoming considerations in the design docs

## Testing
- pnpm --filter @rebound/server-new lint

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921312a57108327b39e7ae3ce640d01)