### PR TITLE
Persist auth tokens in cookies

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,8 +13,7 @@ import DraggableCallOverlay from "./components/CallOverlay/CallOverlay.comp";
 import SnackbarMapper from "./components/SnackbarMapper";
 import useDarkTheme from "./helpers/darkTheme";
 import socketIoHelper from "./helpers/socket";
-import { setLoggedIn, setLoggingIn, setSocketStatus, verifyUser, setAuthState } from "./slices/authSlice";
-import { addSnackbar } from "./slices/snackbarSlice";
+import { bootstrapAuth, setAuthState, setSocketStatus, verifyUser } from "./slices/authSlice";
 
 import useCustomAppBar from "./components/CustomAppBar/useCustomAppBar";
 import useWindowDimensions from "./helpers/useWindowDimensions";
@@ -45,77 +44,52 @@ const App = () => {
 	const dispatch = useDispatch();
 	const customAppBarProps = useCustomAppBar(useWindowDimensions().width);
 
-	useEffect(() => {
-		const params = new URLSearchParams(window.location.search);
-		const token = params.get("token");
-		if (token) {
-			window.localStorage.setItem("auth-token", token);
-			dispatch(setAuthState({ authToken: token }));
-			params.delete("token");
-			const newSearch = params.toString();
-			const newUrl = window.location.pathname + (newSearch ? "?" + newSearch : "");
-			window.history.replaceState({}, "", newUrl);
-		}
-	}, [dispatch]);
+        useEffect(() => {
+                const params = new URLSearchParams(window.location.search);
+                const token = params.get("token");
+                if (token) {
+                        dispatch(setAuthState({ authToken: token }));
+                        dispatch(verifyUser(token));
+                        params.delete("token");
+                        const newSearch = params.toString();
+                        const newUrl = window.location.pathname + (newSearch ? "?" + newSearch : "");
+                        window.history.replaceState({}, "", newUrl);
+                }
+        }, [dispatch]);
 
-	const useSocketConnection = (authToken, loggedIn) => {
-		useEffect(() => {
-			const connectSocket = async (token) => {
-				const socketClient = socketIoHelper.connectSocket(token);
+        useEffect(() => {
+                if (!authState.initialized && !authState.skipAutoLogin && !authState.authToken) {
+                        dispatch(bootstrapAuth());
+                }
+        }, [authState.initialized, authState.skipAutoLogin, authState.authToken, dispatch]);
 
-				socketClient.on("connected", () => {
-					dispatch(setSocketStatus({ connected: true }));
-				});
+        const useSocketConnection = (authToken, loggedIn) => {
+                useEffect(() => {
+                        const connectSocket = async (token) => {
+                                const socketClient = socketIoHelper.connectSocket(token);
 
-				socketClient.on("disconnect", () => {
-					dispatch(setSocketStatus({ connected: false }));
-				});
-			};
+                                socketClient.on("connected", () => {
+                                        dispatch(setSocketStatus({ connected: true }));
+                                });
 
-			if (!socketIoHelper.getSocket()?.connected && loggedIn) {
-				connectSocket(authToken);
-			}
+                                socketClient.on("disconnect", () => {
+                                        dispatch(setSocketStatus({ connected: false }));
+                                });
+                        };
 
-			return () => {
-				if (socketIoHelper.getSocket()?.connected) {
-					socketIoHelper.disconnectSocket();
-				}
-			};
-		}, [loggedIn, authToken]);
-	};
+                        if (!socketIoHelper.getSocket()?.connected && loggedIn) {
+                                connectSocket(authToken);
+                        }
 
-	const useVerifyUser = (authState) => {
-		useEffect(() => {
-			if (authState.authToken && !authState.loggedIn) {
-				dispatch(setLoggingIn({ loggingIn: true }));
-				dispatch(verifyUser(authState.authToken))
-					.unwrap()
-					.then((user) => {
-						dispatch(
-							addSnackbar({
-								snackbarMsg: `Hello ${user.displayName}!`,
-								snackbarSeverity: "success",
-								autoHideDuration: 1000,
-							})
-						);
-					})
-					.catch(() => {
-						dispatch(
-							addSnackbar({
-								snackbarMsg: "Failed to verify user. Please try logging in again.",
-								snackbarSeverity: "error",
-								autoHideDuration: 5000,
-							})
-						);
-						window.localStorage.removeItem("auth-token");
-						dispatch(setLoggedIn({ loggedIn: false, token: null }));
-					});
-			}
-		}, [authState.authToken, authState.loggedIn, dispatch]);
-	};
+                        return () => {
+                                if (socketIoHelper.getSocket()?.connected) {
+                                        socketIoHelper.disconnectSocket();
+                                }
+                        };
+                }, [loggedIn, authToken]);
+        };
 
-	useSocketConnection(authState.authToken, authState.loggedIn);
-	useVerifyUser(authState);
+        useSocketConnection(authState.authToken, authState.loggedIn);
 
 	return (
 		<ThemeProvider theme={darkTheme}>

--- a/src/components/CustomAppBar/useCustomAppBar.js
+++ b/src/components/CustomAppBar/useCustomAppBar.js
@@ -38,14 +38,13 @@ export default function useCustomAppBar(width) {
 		);
 	};
 
-	const handleLogout = () => {
-		window.localStorage.removeItem("auth-token");
-		const oldDisplayName = displayName;
-		dispatch(setLoggedIn({ loggedIn: false }));
-		const socketClient = socketIoHelper.getSocket();
-		if (socketClient && socketClient.connected) {
-			socketIoHelper.disconnectSocket();
-		}
+        const handleLogout = () => {
+                const oldDisplayName = displayName;
+                dispatch(setLoggedIn({ loggedIn: false, disableAutoLogin: true }));
+                const socketClient = socketIoHelper.getSocket();
+                if (socketClient && socketClient.connected) {
+                        socketIoHelper.disconnectSocket();
+                }
 		dispatch(
 			addSnackbar({
 				snackbarMsg: `Goodbye ${oldDisplayName}`,

--- a/src/components/LoginDialog.comp.jsx
+++ b/src/components/LoginDialog.comp.jsx
@@ -13,24 +13,23 @@ const LoginDialog = () => {
 	const loginDialogState = useSelector((state) => state.dialogs.loginDialogOpen);
 	const dispatch = useDispatch();
 
-	const [email, setEmail] = useState("");
-	const [password, setPassword] = useState("");
+        const [email, setEmail] = useState("");
+        const [password, setPassword] = useState("");
 
-	const handleUserLogin = () => {
-		dispatch(loginUser({ email, password }))
-			.unwrap()
-			.then((user) => {
-				window.localStorage.setItem("auth-token", user.authToken);
-				dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }));
-				dispatch(
-					addSnackbar({
-						snackbarMsg: `Login Successful. Hello ${user.displayName}`,
-						snackbarSeverity: "success",
-						autoHideDuration: 2000,
-					})
-				);
-			})
-			.catch((error) => {
+        const handleUserLogin = () => {
+                dispatch(loginUser({ email, password }))
+                        .unwrap()
+                        .then((user) => {
+                                dispatch(setDialogOpened({ dialogName: "loginDialogOpen", newState: false }));
+                                dispatch(
+                                        addSnackbar({
+                                                snackbarMsg: `Login Successful. Hello ${user.displayName}`,
+                                                snackbarSeverity: "success",
+                                                autoHideDuration: 2000,
+                                        })
+                                );
+                        })
+                        .catch((error) => {
 				console.log(error);
 				const loginErrors = error?.errors;
 				if (!loginErrors) {

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -1,2 +1,61 @@
 export const getApiBase = () =>
-	process.env.NODE_ENV === "development" ? "http://localhost:6001/api" : globalThis.IN_ELECTRON_ENV ? "https://rebound.nexus/api" : "/api";
+        process.env.NODE_ENV === "development"
+                ? "http://localhost:6001/api"
+                : globalThis.IN_ELECTRON_ENV
+                  ? "https://rebound.nexus/api"
+                  : "/api";
+
+const CSRF_COOKIE_NAME = "csrfToken";
+const CSRF_HEADER_NAME = "x-csrf-token";
+const AUTH_COOKIE_NAME = "authToken";
+
+const getCookie = (name) => {
+        if (typeof document === "undefined" || !document.cookie) return null;
+        const match = document.cookie
+                .split(";")
+                .map((entry) => entry.trim())
+                .find((entry) => entry.startsWith(`${name}=`));
+        if (!match) return null;
+        const [, value] = match.split("=");
+        return decodeURIComponent(value || "");
+};
+
+const setCookie = (name, value) => {
+        if (!value || typeof document === "undefined") return;
+        const secureFlag = window.location.protocol === "https:" ? "; Secure" : "";
+        document.cookie = `${name}=${value}; Path=/; SameSite=Strict${secureFlag}`;
+};
+
+export const clearCookie = (name) => {
+        if (typeof document === "undefined") return;
+        document.cookie = `${name}=; Path=/; Expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+};
+
+export const getCsrfToken = () => getCookie(CSRF_COOKIE_NAME);
+
+export const setCsrfTokenCookie = (csrfToken) => setCookie(CSRF_COOKIE_NAME, csrfToken);
+
+export const getAuthToken = () => getCookie(AUTH_COOKIE_NAME);
+
+export const setAuthTokenCookie = (authToken) => setCookie(AUTH_COOKIE_NAME, authToken);
+
+export const clearAuthCookies = () => {
+        clearCookie(AUTH_COOKIE_NAME);
+        clearCookie(CSRF_COOKIE_NAME);
+};
+
+export const buildApiConfig = (authToken, config = {}) => {
+        const csrfToken = getCsrfToken();
+        const token = authToken || getAuthToken();
+        const headers = {
+                ...(csrfToken ? { [CSRF_HEADER_NAME]: csrfToken } : {}),
+                ...(token ? { Authorization: `Bearer ${token}` } : {}),
+                ...(config.headers || {}),
+        };
+
+        return {
+                withCredentials: true,
+                ...config,
+                headers,
+        };
+};

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -2,66 +2,133 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
 
 import socketIoHelper from "../helpers/socket";
-import { getApiBase } from "../helpers/api";
+import {
+        buildApiConfig,
+        clearAuthCookies,
+        getApiBase,
+        setAuthTokenCookie,
+        setCsrfTokenCookie,
+} from "../helpers/api";
 import { profileMediaUrl } from "../helpers/mediaUrl";
 
-const initialState = {
-	authToken: window.localStorage.getItem("auth-token"),
-	friends: [],
-	loggedIn: false,
-	userId: null,
-	username: "",
-	displayName: "",
-        bio: "",
-        createdAt: null,
-        loggingIn: false,
-	socketInfo: {
-		connected: false,
-		currentRoom: null,
-	},
-	bannerUrl: null,
-	avatarUrl: null,
+const AUTO_LOGIN_BLOCK_KEY = "disable-auto-login";
+
+const setAutoLoginBlocked = (blocked) => {
+        if (typeof window === "undefined") return;
+        if (blocked) {
+                window.localStorage.setItem(AUTO_LOGIN_BLOCK_KEY, "true");
+                return;
+        }
+        window.localStorage.removeItem(AUTO_LOGIN_BLOCK_KEY);
 };
 
-export const verifyUser = createAsyncThunk("auth/verifyUser", async (token, { rejectWithValue }) => {
-	const base = getApiBase();
-	try {
-		const { data } = await axios.post(
-			`${base}/users/verify`,
-			{},
-			{
-				headers: {
-					"Content-Type": "application/json",
-					authorization: `Bearer ${token}`,
-				},
-			}
-		);
-		const u = data.user;
+const resetAuthFields = (state) => {
+        state.authToken = null;
+        state.userId = null;
+        state.username = "";
+        state.displayName = "";
+        state.bio = "";
+        state.friends = [];
+        state.createdAt = null;
+        state.bannerUrl = null;
+        state.avatarUrl = null;
+        state.socketInfo.currentRoom = null;
+};
 
-                return {
-                        loggedIn: true,
-                        authToken: token,
-                        userId: u.id,
-                        username: u.username,
-                        displayName: u.displayName,
-                        bio: u.bio,
-                        friends: u.friends,
-                        bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
-                        avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
-                        createdAt: u.createdAt,
-                };
-	} catch (err) {
-		return rejectWithValue(err.response?.data || err.message);
-	}
+const initialState = {
+        authToken: null,
+        friends: [],
+        loggedIn: false,
+        userId: null,
+        username: "",
+        displayName: "",
+        bio: "",
+        createdAt: null,
+        initialized: false,
+        loggingIn: false,
+        refreshing: false,
+        skipAutoLogin: typeof window !== "undefined" && window.localStorage.getItem(AUTO_LOGIN_BLOCK_KEY) === "true",
+        socketInfo: {
+                connected: false,
+                currentRoom: null,
+        },
+        bannerUrl: null,
+        avatarUrl: null,
+};
+
+export const verifyUser = createAsyncThunk(
+        "auth/verifyUser",
+        async (token, { getState, rejectWithValue }) => {
+                const base = getApiBase();
+                const authToken = token || getState().auth.authToken;
+                try {
+                        const { data } = await axios.post(
+                                `${base}/users/verify`,
+                                {},
+                                buildApiConfig(authToken, { headers: { "Content-Type": "application/json" } })
+                        );
+                        const u = data.user;
+
+                        return {
+                                loggedIn: true,
+                                authToken,
+                                userId: u.id,
+                                username: u.username,
+                                displayName: u.displayName,
+                                bio: u.bio,
+                                friends: u.friends,
+                                bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
+                                avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
+                                createdAt: u.createdAt,
+                        };
+                } catch (err) {
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
+
+export const refreshAuthToken = createAsyncThunk("auth/refreshAuthToken", async (_, { rejectWithValue }) => {
+        const base = getApiBase();
+        try {
+                const { data } = await axios.post(
+                        `${base}/users/refresh`,
+                        {},
+                        buildApiConfig(null, { headers: { "Content-Type": "application/json" } })
+                );
+
+                setCsrfTokenCookie(data.csrfToken);
+                setAuthTokenCookie(data.token);
+                return { authToken: data.token };
+        } catch (err) {
+                return rejectWithValue(err.response?.data || err.message);
+        }
 });
+
+export const bootstrapAuth = createAsyncThunk(
+        "auth/bootstrapAuth",
+        async (_, { dispatch, rejectWithValue }) => {
+                try {
+                        const { authToken } = await dispatch(refreshAuthToken()).unwrap();
+                        return await dispatch(verifyUser(authToken)).unwrap();
+                } catch (err) {
+                        return rejectWithValue(err);
+                }
+        }
+);
 
 export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, password }, { rejectWithValue }) => {
 	const base = getApiBase();
-	try {
-		const { data } = await axios.post(`${base}/users/login`, {
-			user: { email, password },
-		});
-		const u = data.user;
+        try {
+                const { data } = await axios.post(
+                        `${base}/users/login`,
+                        {
+                                user: { email, password },
+                        },
+                        buildApiConfig(null, { headers: { "Content-Type": "application/json" } })
+                );
+                const u = data.user;
+                setCsrfTokenCookie(data.csrfToken);
+                setAuthTokenCookie(u.token);
 
                 return {
                         loggedIn: true,
@@ -75,73 +142,77 @@ export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, pass
                         avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
                         createdAt: u.createdAt,
                 };
-	} catch (err) {
-		return rejectWithValue(err.response?.data || err.message);
-	}
+        } catch (err) {
+                return rejectWithValue(err.response?.data || err.message);
+        }
 });
 
 export const registerUser = createAsyncThunk(
-	"auth/registerUser",
-	async ({ username, email, displayName, bio, password, stayLoggedIn }, { rejectWithValue }) => {
-		const base = getApiBase();
-		try {
-			const { data } = await axios.post(`${base}/users/register`, {
-				user: { username, email, displayName, bio, password },
-			});
-			const u = data.user;
+        "auth/registerUser",
+        async ({ username, email, displayName, bio, password }, { rejectWithValue }) => {
+                const base = getApiBase();
+                try {
+                        const { data } = await axios.post(
+                                `${base}/users/register`,
+                                {
+                                        user: { username, email, displayName, bio, password },
+                                },
+                                buildApiConfig(null, { headers: { "Content-Type": "application/json" } })
+                        );
+                        const u = data.user;
+                        setCsrfTokenCookie(data.csrfToken);
+                        setAuthTokenCookie(u.token);
 
-			if (stayLoggedIn) {
-				window.localStorage.setItem("auth-token", u.token);
-			}
-
-                return {
-                        loggedIn: true,
-                        authToken: u.token,
-                        userId: u.id,
-                        username: u.username,
-                        displayName: u.displayName,
-                        bio: u.bio,
-                        friends: u.friends,
-                        bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
-                        avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
-                        createdAt: u.createdAt,
-                };
-		} catch (err) {
-			return rejectWithValue(err.response?.data || err.message);
-		}
-	}
+                        return {
+                                loggedIn: true,
+                                authToken: u.token,
+                                userId: u.id,
+                                username: u.username,
+                                displayName: u.displayName,
+                                bio: u.bio,
+                                friends: u.friends,
+                                bannerUrl: profileMediaUrl(u.bannerUrl, "banner.webp"),
+                                avatarUrl: profileMediaUrl(u.avatarUrl, "defaultpfp.webp"),
+                                createdAt: u.createdAt,
+                        };
+                } catch (err) {
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
 );
 
 const authSlice = createSlice({
 	name: "auth",
 	initialState,
-	reducers: {
-		setAuthState: (state, action) => {
-			if (action.payload.authToken !== undefined) {
-				state.authToken = action.payload.authToken;
-			}
-		},
-		setLoggedIn: (state, action) => {
-			if ("loggedIn" in action.payload) {
-				state.loggingIn = false;
-				state.loggedIn = action.payload.loggedIn;
+        reducers: {
+                setAuthState: (state, action) => {
+                        if (action.payload.authToken !== undefined) {
+                                state.authToken = action.payload.authToken;
+                                setAuthTokenCookie(action.payload.authToken);
+                        }
+                },
+                setLoggedIn: (state, action) => {
+                        if ("loggedIn" in action.payload) {
+                                state.loggingIn = false;
+                                state.loggedIn = action.payload.loggedIn;
 
-				if (action.payload.loggedIn === false) {
-					action.payload.authToken = null;
-					action.payload.userId = null;
-					action.payload.username = "";
-					action.payload.displayName = "";
-					action.payload.bio = "";
-					action.payload.friends = [];
-					state.socketInfo.currentRoom = null;
-					state.bannerUrl = null;
-					state.avatarUrl = null;
-				}
-			}
-			if ("authToken" in action.payload) {
-				state.authToken = action.payload.authToken;
-			}
-			if ("userId" in action.payload) {
+                                if (action.payload.loggedIn === false) {
+                                        clearAuthCookies();
+                                        resetAuthFields(state);
+                                        if (action.payload.disableAutoLogin) {
+                                                state.skipAutoLogin = true;
+                                                setAutoLoginBlocked(true);
+                                        }
+                                }
+                        }
+                        if (action.payload.loggedIn) {
+                                state.skipAutoLogin = false;
+                                setAutoLoginBlocked(false);
+                        }
+                        if ("authToken" in action.payload) {
+                                state.authToken = action.payload.authToken;
+                        }
+                        if ("userId" in action.payload) {
 				state.userId = action.payload.userId;
 			}
 			if ("username" in action.payload) {
@@ -188,70 +259,109 @@ const authSlice = createSlice({
 				state.socketInfo.currentRoom = roomToJoin;
 			}
 		},
-	},
-	extraReducers: (builder) => {
-		builder
-			.addCase(verifyUser.pending, (state) => {
-				state.loggingIn = true;
-			})
-			.addCase(verifyUser.fulfilled, (state, action) => {
-				state.loggingIn = false;
-				state.loggedIn = true;
-				state.authToken = action.payload.authToken;
-				state.userId = action.payload.userId;
-				state.username = action.payload.username;
-				state.displayName = action.payload.displayName;
+        },
+        extraReducers: (builder) => {
+                builder
+                        .addCase(verifyUser.pending, (state) => {
+                                state.loggingIn = true;
+                        })
+                        .addCase(verifyUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
+                                state.skipAutoLogin = false;
+                                setAutoLoginBlocked(false);
+                                state.initialized = true;
+                                state.authToken = action.payload.authToken;
+                                state.userId = action.payload.userId;
+                                state.username = action.payload.username;
+                                state.displayName = action.payload.displayName;
                                 state.bio = action.payload.bio;
                                 state.friends = action.payload.friends;
                                 state.bannerUrl = action.payload.bannerUrl;
                                 state.avatarUrl = action.payload.avatarUrl;
                                 state.createdAt = action.payload.createdAt;
                         })
-			.addCase(verifyUser.rejected, (state) => {
-				state.loggingIn = false;
-				state.loggedIn = false;
-			})
-			.addCase(registerUser.pending, (state) => {
-				state.loggingIn = true;
-			})
-			.addCase(registerUser.fulfilled, (state, action) => {
-				state.loggingIn = false;
-				state.loggedIn = true;
-				state.authToken = action.payload.authToken;
-				state.userId = action.payload.userId;
-				state.username = action.payload.username;
-				state.displayName = action.payload.displayName;
-				state.bio = action.payload.bio;
+                        .addCase(verifyUser.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.loggedIn = false;
+                                state.initialized = true;
+                                clearAuthCookies();
+                        })
+                        .addCase(refreshAuthToken.pending, (state) => {
+                                state.refreshing = true;
+                                state.loggingIn = true;
+                        })
+                        .addCase(refreshAuthToken.fulfilled, (state, action) => {
+                                state.refreshing = false;
+                                state.authToken = action.payload.authToken;
+                        })
+                        .addCase(refreshAuthToken.rejected, (state) => {
+                                state.refreshing = false;
+                                state.loggingIn = false;
+                                clearAuthCookies();
+                                resetAuthFields(state);
+                        })
+                        .addCase(bootstrapAuth.pending, (state) => {
+                                state.loggingIn = true;
+                        })
+                        .addCase(bootstrapAuth.fulfilled, (state) => {
+                                state.loggingIn = false;
+                                state.initialized = true;
+                                state.skipAutoLogin = false;
+                                setAutoLoginBlocked(false);
+                        })
+                        .addCase(bootstrapAuth.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.initialized = true;
+                        })
+                        .addCase(registerUser.pending, (state) => {
+                                state.loggingIn = true;
+                        })
+                        .addCase(registerUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
+                                state.skipAutoLogin = false;
+                                setAutoLoginBlocked(false);
+                                state.initialized = true;
+                                state.authToken = action.payload.authToken;
+                                state.userId = action.payload.userId;
+                                state.username = action.payload.username;
+                                state.displayName = action.payload.displayName;
+                                state.bio = action.payload.bio;
                                 state.friends = action.payload.friends;
                                 state.bannerUrl = action.payload.bannerUrl;
                                 state.avatarUrl = action.payload.avatarUrl;
                                 state.createdAt = action.payload.createdAt;
                         })
-			.addCase(registerUser.rejected, (state) => {
-				state.loggingIn = false;
-				state.loggedIn = false;
-			})
-			.addCase(loginUser.pending, (state) => {
-				state.loggingIn = true;
-			})
-			.addCase(loginUser.fulfilled, (state, action) => {
-				state.loggingIn = false;
-				state.loggedIn = true;
-				state.authToken = action.payload.authToken;
-				state.userId = action.payload.userId;
-				state.username = action.payload.username;
-				state.displayName = action.payload.displayName;
-				state.bio = action.payload.bio;
-				state.friends = action.payload.friends;
+                        .addCase(registerUser.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.loggedIn = false;
+                                state.initialized = true;
+                        })
+                        .addCase(loginUser.pending, (state) => {
+                                state.loggingIn = true;
+                        })
+                        .addCase(loginUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
+                                state.skipAutoLogin = false;
+                                setAutoLoginBlocked(false);
+                                state.initialized = true;
+                                state.authToken = action.payload.authToken;
+                                state.userId = action.payload.userId;
+                                state.username = action.payload.username;
+                                state.displayName = action.payload.displayName;
+                                state.bio = action.payload.bio;
+                                state.friends = action.payload.friends;
                                 state.bannerUrl = action.payload.bannerUrl;
                                 state.avatarUrl = action.payload.avatarUrl;
                                 state.createdAt = action.payload.createdAt;
-                                window.localStorage.setItem("auth-token", action.payload.authToken);
                         })
-			.addCase(loginUser.rejected, (state) => {
-				state.loggingIn = false;
-				state.loggedIn = false;
-			});
+                        .addCase(loginUser.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.loggedIn = false;
+                                state.initialized = true;
+                        });
 	},
 });
 

--- a/src/slices/chatApiSlice.js
+++ b/src/slices/chatApiSlice.js
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
-import { getApiBase } from "../helpers/api";
+import { buildApiConfig, getApiBase } from "../helpers/api";
 import { profileMediaUrl } from "../helpers/mediaUrl";
 
 const base = getApiBase();
@@ -16,9 +16,10 @@ export const mapMessages = (msgs) =>
 
 export const fetchRoomMessages = createAsyncThunk("chatApi/fetchRoomMessages", async ({ roomId, authToken }, { rejectWithValue }) => {
 	try {
-		const { data } = await axios.get(`${base}/rooms/${roomId}/messages`, {
-			headers: { Authorization: `Bearer ${authToken}` },
-		});
+                const { data } = await axios.get(
+                        `${base}/rooms/${roomId}/messages`,
+                        buildApiConfig(authToken)
+                );
 		return { roomId, messages: await mapMessages(data.messages) };
 	} catch (err) {
 		return rejectWithValue(err.response?.data || err.message);

--- a/src/slices/dmApiSlice.js
+++ b/src/slices/dmApiSlice.js
@@ -1,6 +1,6 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
-import { getApiBase } from "../helpers/api";
+import { buildApiConfig, getApiBase } from "../helpers/api";
 import { mapMessages } from "./chatApiSlice";
 
 const base = getApiBase();
@@ -9,9 +9,10 @@ export const fetchDmMessages = createAsyncThunk(
   "dmApi/fetchDmMessages",
   async ({ userId, authToken }, { rejectWithValue }) => {
     try {
-      const { data } = await axios.get(`${base}/dms/${userId}/messages`, {
-        headers: { Authorization: `Bearer ${authToken}` },
-      });
+      const { data } = await axios.get(
+        `${base}/dms/${userId}/messages`,
+        buildApiConfig(authToken)
+      );
       return {
         userId,
         threadId: data.threadId,

--- a/src/slices/userApiSlice.js
+++ b/src/slices/userApiSlice.js
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
 import { addSnackbar } from "./snackbarSlice";
-import { getApiBase } from "../helpers/api";
+import { buildApiConfig, getApiBase } from "../helpers/api";
 import { profileMediaUrl } from "../helpers/mediaUrl";
 
 const initialState = {
@@ -11,10 +11,10 @@ const initialState = {
 export const fetchUserProfile = createAsyncThunk("userApi/fetchUserProfile", async ({ userId, authToken } = {}, { rejectWithValue }) => {
 	const base = getApiBase();
 	try {
-		const { data } = await axios.get(`${base}/users/profile`, {
-			headers: { Authorization: `Bearer ${authToken}` },
-			params: userId ? { id: userId } : undefined,
-		});
+                const { data } = await axios.get(
+                        `${base}/users/profile`,
+                        buildApiConfig(authToken, { params: userId ? { id: userId } : undefined })
+                );
 		const u = data.user;
 
                 return {
@@ -33,9 +33,7 @@ export const fetchUserProfile = createAsyncThunk("userApi/fetchUserProfile", asy
 export const modifyProfile = createAsyncThunk("userApi/modifyProfile", async ({ formData, authToken }, { rejectWithValue }) => {
 	const base = getApiBase();
 	try {
-		const { data } = await axios.put(`${base}/users/modify`, formData, {
-			headers: { Authorization: `Bearer ${authToken}` },
-		});
+                const { data } = await axios.put(`${base}/users/modify`, formData, buildApiConfig(authToken));
 		const u = data.user;
 		return {
 			id: u.id,
@@ -55,9 +53,7 @@ export const friendAction = createAsyncThunk(
 	async ({ ep, data, authToken, message, severity = "success" }, { dispatch, rejectWithValue }) => {
 		const base = getApiBase();
 		try {
-			await axios.put(`${base}/users/${ep}`, data, {
-				headers: { Authorization: `Bearer ${authToken}` },
-			});
+                        await axios.put(`${base}/users/${ep}`, data, buildApiConfig(authToken));
 			if (message) {
 				dispatch(addSnackbar({ snackbarMsg: message, snackbarSeverity: severity, autoHideDuration: 1500 }));
 			}


### PR DESCRIPTION
## Summary
- add helper utilities to store auth tokens in SameSite cookies and reuse them when building API requests
- set auth and CSRF cookies when logging in, registering, refreshing, or receiving tokens from URL parameters
- clear auth-related cookies on logout or when token refresh/verification fails

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921306be6a08327b6819296e835c850)