### PR TITLE
Handle CSRF token bootstrap on initial requests

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -72,6 +72,10 @@ class ServerBackend {
                         const cookieToken = req.cookies?.[CSRF_COOKIE_NAME];
                         const headerToken = req.get(CSRF_HEADER_NAME);
 
+                        if (!cookieToken && !headerToken) {
+                                return next();
+                        }
+
                         if (!cookieToken || !headerToken || cookieToken !== headerToken) {
                                 return res.status(403).json({ error: "Invalid CSRF token" });
                         }


### PR DESCRIPTION
## Summary
- allow the CSRF middleware to permit the first protected request when no CSRF tokens are yet present while still setting the cookie
- retain validation for subsequent requests when CSRF tokens are available

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692136552cd883279c654e012f71e35a)