### PR TITLE
Add refresh token descriptors from request metadata

### DIFF
--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -52,14 +52,17 @@ const UserSchema = new Schema(
 		passwordChangedAt: {
 			type: Date,
 		},
-		refreshTokens: [
-			{
-				tokenHash: { type: String, required: true },
-				expiresAt: { type: Date, required: true },
-			},
-		],
-	},
-	{ timestamps: true }
+                refreshTokens: [
+                        {
+                                tokenHash: { type: String, required: true },
+                                expiresAt: { type: Date, required: true },
+                                userAgent: { type: String },
+                                ipAddress: { type: String },
+                                location: { type: String },
+                        },
+                ],
+        },
+        { timestamps: true }
 );
 
 UserSchema.plugin(mongooseUniqueValidator, { message: "is already taken" });
@@ -98,23 +101,30 @@ UserSchema.methods.generateAccessToken = function () {
 	});
 };
 
-UserSchema.methods.generateRefreshToken = async function () {
-	const payload = {
-		id: this._id,
-		tokenVersion: this.tokenVersion,
-	};
+UserSchema.methods.generateRefreshToken = async function (descriptor = {}) {
+        const payload = {
+                id: this._id,
+                tokenVersion: this.tokenVersion,
+        };
 
 	const token = jwt.sign(payload, process.env.REFRESH_TOKEN_SECRET, {
 		expiresIn: `${REFRESH_TOKEN_LIFETIME_DAYS}d`,
 	});
 
-	this.pruneExpiredRefreshTokens();
+        this.pruneExpiredRefreshTokens();
 
-	const expiresAt = new Date(Date.now() + REFRESH_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000);
+        const expiresAt = new Date(Date.now() + REFRESH_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000);
 
-	const tokenHash = hashRefreshToken(token);
-	this.refreshTokens.push({ tokenHash, expiresAt });
-	await this.save();
+        const tokenHash = hashRefreshToken(token);
+        const { userAgent, ipAddress, location } = descriptor;
+        this.refreshTokens.push({
+                tokenHash,
+                expiresAt,
+                userAgent: userAgent || "unknown",
+                ipAddress: ipAddress || "unknown",
+                location: location || ipAddress || "unknown",
+        });
+        await this.save();
 
 	return token;
 };

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -59,6 +59,7 @@ const UserSchema = new Schema(
                                 userAgent: { type: String },
                                 ipAddress: { type: String },
                                 location: { type: String },
+                                lastUsed: { type: Date },
                         },
                 ],
         },
@@ -101,7 +102,7 @@ UserSchema.methods.generateAccessToken = function () {
 	});
 };
 
-UserSchema.methods.generateRefreshToken = async function (descriptor = {}) {
+UserSchema.methods.generateRefreshToken = async function (descriptor = {}, existingTokenHash = null) {
         const payload = {
                 id: this._id,
                 tokenVersion: this.tokenVersion,
@@ -113,20 +114,32 @@ UserSchema.methods.generateRefreshToken = async function (descriptor = {}) {
 
         this.pruneExpiredRefreshTokens();
 
+        const targetIndex = existingTokenHash
+                ? this.refreshTokens.findIndex((t) => t.tokenHash === existingTokenHash)
+                : null;
+
         const expiresAt = new Date(Date.now() + REFRESH_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000);
+        const lastUsed = new Date();
 
         const tokenHash = hashRefreshToken(token);
         const { userAgent, ipAddress, location } = descriptor;
-        this.refreshTokens.push({
+        const tokenRecord = {
                 tokenHash,
                 expiresAt,
                 userAgent: userAgent || "unknown",
                 ipAddress: ipAddress || "unknown",
                 location: location || ipAddress || "unknown",
-        });
+                lastUsed,
+        };
+
+        if (targetIndex === null || targetIndex < 0 || targetIndex >= this.refreshTokens.length) {
+                this.refreshTokens.push(tokenRecord);
+        } else {
+                this.refreshTokens[targetIndex] = tokenRecord;
+        }
         await this.save();
 
-	return token;
+        return token;
 };
 
 UserSchema.methods.revokeRefreshToken = async function (rawToken) {

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -18,7 +18,7 @@ import serverWatchers from "../../socketio/watchers.js";
 import mongoose from "mongoose";
 import rateLimit from "express-rate-limit";
 
-import { createAuthContextMiddleware } from "../../utils/auth.js";
+import { buildRequestTokenDescriptor, createAuthContextMiddleware } from "../../utils/auth.js";
 
 import "dotenv/config";
 
@@ -164,7 +164,7 @@ router.post("/users/refresh", async (req, res, next) => {
 		await user.save();
 
 		const newAccessToken = user.generateAccessToken();
-		const newRefreshToken = await user.generateRefreshToken();
+                const newRefreshToken = await user.generateRefreshToken(buildRequestTokenDescriptor(req));
 
 		const csrfToken = setAuthCookies(res, newAccessToken, newRefreshToken);
 
@@ -199,7 +199,7 @@ router.get("/users/google/callback", passport.authenticate("google", { session: 
 	try {
 		console.log(req.user);
 		const accessToken = req.user.generateAccessToken();
-		const refreshToken = await req.user.generateRefreshToken();
+                const refreshToken = await req.user.generateRefreshToken(buildRequestTokenDescriptor(req));
 
 		setAuthCookies(res, accessToken, refreshToken);
 
@@ -227,11 +227,11 @@ router.post("/users/login", authLimiter, (req, res, next) => {
 			return res.status(422).json(info);
 		}
 
-		try {
-			const accessToken = user.generateAccessToken();
-			const refreshToken = await user.generateRefreshToken();
+                try {
+                        const accessToken = user.generateAccessToken();
+                        const refreshToken = await user.generateRefreshToken(buildRequestTokenDescriptor(req));
 
-			const csrfToken = setAuthCookies(res, accessToken, refreshToken);
+                        const csrfToken = setAuthCookies(res, accessToken, refreshToken);
 
 			res.json({ user: user.toAuthJSON(accessToken), csrfToken });
 		} catch (e) {
@@ -253,7 +253,7 @@ router.post("/users/register", authLimiter, async (req, res, next) => {
 		await user.save();
 
 		const accessToken = user.generateAccessToken();
-		const refreshToken = await user.generateRefreshToken();
+                const refreshToken = await user.generateRefreshToken(buildRequestTokenDescriptor(req));
 
 		const csrfToken = setAuthCookies(res, accessToken, refreshToken);
 

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -153,18 +153,21 @@ router.post("/users/refresh", async (req, res, next) => {
 			return res.status(401).json({ error: "Token no longer valid" });
 		}
 
-		const tokenHash = hashRefreshToken(rawToken);
-		const stored = user.refreshTokens.find((t) => t.tokenHash === tokenHash && t.expiresAt > new Date());
+                const tokenHash = hashRefreshToken(rawToken);
+                const now = new Date();
+                const storedIndex = user.refreshTokens.findIndex(
+                        (t) => t.tokenHash === tokenHash && t.expiresAt > now
+                );
 
-		if (!stored) {
-			return res.status(401).json({ error: "Refresh token revoked or expired" });
-		}
+                if (storedIndex === -1) {
+                        return res.status(401).json({ error: "Refresh token revoked or expired" });
+                }
 
-		user.refreshTokens = user.refreshTokens.filter((t) => t.tokenHash !== tokenHash);
-		await user.save();
-
-		const newAccessToken = user.generateAccessToken();
-                const newRefreshToken = await user.generateRefreshToken(buildRequestTokenDescriptor(req));
+                const newAccessToken = user.generateAccessToken();
+                const newRefreshToken = await user.generateRefreshToken(
+                        buildRequestTokenDescriptor(req),
+                        tokenHash
+                );
 
 		const csrfToken = setAuthCookies(res, newAccessToken, newRefreshToken);
 

--- a/server/src/socketio/index.js
+++ b/server/src/socketio/index.js
@@ -8,6 +8,7 @@ import serverDMs from "./dms.js";
 import serverWatchers from "./watchers.js";
 import UserModel from "../models/User.js";
 import { getAccessToken } from "../routes/auth.js";
+import { hasPasswordChangedAfterTokenIssue } from "../utils/auth.js";
 
 class SocketBackend {
 	constructor() {
@@ -44,7 +45,7 @@ class SocketBackend {
                                 throw new Error("Token version mismatch");
                         }
 
-                        if (user.passwordChangedAt && decoded.iat * 1000 < user.passwordChangedAt.getTime()) {
+                        if (hasPasswordChangedAfterTokenIssue(user, decoded)) {
                                 throw new Error("Stale access token");
                         }
 

--- a/server/src/utils/auth.js
+++ b/server/src/utils/auth.js
@@ -37,6 +37,17 @@ const buildAuthError = (message, status = 401) => {
         return err;
 };
 
+const hasPasswordChangedAfterTokenIssue = (user, decoded) => {
+        const passwordChangedAt =
+                user?.passwordChangedAt instanceof Date ? user.passwordChangedAt.getTime() : null;
+        const issuedAtMs = decoded?.iat ? decoded.iat * 1000 : null;
+
+        if (!passwordChangedAt || !issuedAtMs) return false;
+
+        // Allow a small grace window to avoid race conditions during initial account creation/login
+        return issuedAtMs + 1000 < passwordChangedAt;
+};
+
 const validateAccessToken = async (token) => {
         if (!token) throw buildAuthError("Missing access token.");
 
@@ -56,7 +67,7 @@ const validateAccessToken = async (token) => {
                 throw buildAuthError("Token no longer valid.");
         }
 
-        if (user.passwordChangedAt && decoded.iat * 1000 < user.passwordChangedAt.getTime()) {
+        if (hasPasswordChangedAfterTokenIssue(user, decoded)) {
                 throw buildAuthError("Token issued before password change.");
         }
 
@@ -109,4 +120,5 @@ export {
         validateAccessToken,
         validateAccessTokenFromRequest,
         buildRequestTokenDescriptor,
+        hasPasswordChangedAfterTokenIssue,
 };

--- a/server/src/utils/auth.js
+++ b/server/src/utils/auth.js
@@ -76,6 +76,18 @@ const handleAuthFailure = (err, res, context, logger) => {
         return res.status(err.status || 401).json({ error: err.message });
 };
 
+const buildRequestTokenDescriptor = (req) => {
+        const connectionAddress = req?.socket?.remoteAddress || req?.connection?.remoteAddress;
+        const forwardedIps = Array.isArray(req?.ips) && req.ips.length ? req.ips : [];
+        const ipAddress = forwardedIps[0] || connectionAddress || req?.ip || "unknown";
+
+        return {
+                userAgent: req?.get?.("user-agent") || "unknown",
+                ipAddress,
+                location: forwardedIps[0] || connectionAddress || "unknown",
+        };
+};
+
 const createAuthContextMiddleware = (context, logger) => {
         return async (req, res, next) => {
                 try {
@@ -96,4 +108,5 @@ export {
         parseCookieHeader,
         validateAccessToken,
         validateAccessTokenFromRequest,
+        buildRequestTokenDescriptor,
 };

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -24,6 +24,7 @@ const ProfilePage = lazy(() => import("./routes/ProfilePage/ProfilePage.route"))
 const ChatPage = lazy(() => import("./routes/ChatPage/ChatPage"));
 const ServersPage = lazy(() => import("./routes/ServersPage/ServersPage.route"));
 const TestingPage = lazy(() => import("./routes/TestingPage/TestingPage.route"));
+const SecurityPage = lazy(() => import("./routes/SecurityPage/SecurityPage.route"));
 const SettingsPage = lazy(() => import("./routes/SettingsPage/SettingsPage.route"));
 const FriendPage = lazy(() => import("./routes/FriendPage/FriendPage.route"));
 const DirectMessagePage = lazy(() => import("./routes/DirectMessagePage/DirectMessagePage"));
@@ -34,7 +35,7 @@ const PageNotFoundContainer = styled("div")({
 });
 
 const AppRouter = ({ children }) => {
-	const Router = window.isElectron ? HashRouter : BrowserRouter;
+	const Router = window?.isElectron ? HashRouter : BrowserRouter;
 	return <Router>{children}</Router>;
 };
 
@@ -108,6 +109,7 @@ const App = () => {
 								<Route path="/dm/:userId" element={<DirectMessagePage />} />
 								<Route path="/servers" element={<ServersPage />} />
 								<Route path="/testing" element={<TestingPage />} />
+								<Route path="/security" element={<SecurityPage />} />
 								<Route path="/settings" element={<SettingsPage />} />
 								<Route path="*" element={<PageNotFoundContainer>PAGE NOT FOUND</PageNotFoundContainer>} />
 							</Routes>

--- a/src/components/CustomAppBar/DrawerMenu.jsx
+++ b/src/components/CustomAppBar/DrawerMenu.jsx
@@ -4,6 +4,7 @@ import MessageRounded from "@mui/icons-material/MessageRounded";
 import DnsRounded from "@mui/icons-material/DnsRounded";
 import PersonRounded from "@mui/icons-material/PersonRounded";
 import ScienceTwoTone from "@mui/icons-material/ScienceTwoTone";
+import ShieldOutlined from "@mui/icons-material/ShieldOutlined";
 import SettingsRounded from "@mui/icons-material/SettingsRounded";
 import ChevronLeftRounded from "@mui/icons-material/ChevronLeftRounded";
 import { Toolbar, List, Divider, Drawer, Tooltip, ListItem, ListItemButton, ListItemIcon } from "@mui/material";
@@ -89,6 +90,13 @@ function DrawerMenu({ drawerWidth, iconWidth, drawerOpen, setDrawerOpen, theme }
 						path: "/testing",
 						Icon: ScienceTwoTone,
 						devOnly: true,
+					},
+					{
+						key: "security",
+						title: "Security",
+						path: "/security",
+						Icon: ShieldOutlined,
+						devOnly: false,
 					},
 					{
 						key: "settings",

--- a/src/components/DeviceSessionManager/DeviceSessionManager.jsx
+++ b/src/components/DeviceSessionManager/DeviceSessionManager.jsx
@@ -1,0 +1,287 @@
+import React from "react";
+import {
+	Box,
+	Card,
+	CardContent,
+	CardHeader,
+	Divider,
+	IconButton,
+	Stack,
+	Tooltip,
+	Typography,
+	Button,
+	Chip,
+	useTheme,
+	useMediaQuery,
+	Skeleton,
+} from "@mui/material";
+
+import DevicesOtherRoundedIcon from "@mui/icons-material/DevicesOtherRounded";
+import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
+import SecurityRoundedIcon from "@mui/icons-material/SecurityRounded";
+import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
+import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+
+import useDeviceSessions from "./useDeviceSessions";
+
+const MASK = "••••••••••";
+
+function formatLastActive(dateString) {
+	const date = new Date(dateString);
+	if (Number.isNaN(date.getTime())) return dateString;
+
+	return date.toLocaleString(undefined, {
+		month: "short",
+		day: "numeric",
+		hour: "numeric",
+		minute: "2-digit",
+	});
+}
+
+export default function DeviceSessionsPanel(props) {
+	const { sx, ...rest } = props;
+	const theme = useTheme();
+	const isSmUp = useMediaQuery(theme.breakpoints.up("sm"));
+
+	const { currentSession, otherSessions, hasOtherSessions, loading, error, handleRevokeSession, handleRevokeAllExceptCurrent } = useDeviceSessions();
+
+	return (
+		<Card
+			elevation={0}
+			sx={{
+				width: "100%",
+				borderRadius: 2,
+				border: `1px solid ${theme.palette.divider}`,
+				backgroundColor: theme.palette.background.paper,
+				...sx,
+			}}
+			{...rest}>
+			<CardHeader
+				avatar={
+					<Box
+						sx={{
+							width: 40,
+							height: 40,
+							borderRadius: 1,
+							display: "flex",
+							alignItems: "center",
+							justifyContent: "center",
+							bgcolor: theme.palette.primary.main,
+							color: theme.palette.primary.contrastText,
+						}}>
+						<DevicesOtherRoundedIcon fontSize="small" />
+					</Box>
+				}
+				title={
+					<Typography variant="h6" sx={{ fontWeight: 600 }}>
+						Logged-in devices
+					</Typography>
+				}
+				subheader={
+					<Typography variant="body2" color="text.secondary">
+						Manage where your account is signed in and revoke their login.
+					</Typography>
+				}
+				sx={{ pb: 0 }}
+			/>
+
+			<Divider flexItem />
+
+			{/* Current device */}
+			<Box sx={{ mt: 1 }}>
+				<Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mx: 1 }}>
+					<Stack direction="row" spacing={3} alignItems="center">
+						<Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
+							Current device
+						</Typography>
+						<Chip
+							size="small"
+							icon={<SecurityRoundedIcon color="#12a4ff" sx={{ fontSize: 16, color: "#12a4ff" }} />}
+							label="Protected"
+							sx={{
+								fontSize: 11,
+								borderRadius: 999,
+							}}
+						/>
+					</Stack>
+				</Stack>
+
+				<Box sx={{ padding: 1 }}>
+					{loading && !currentSession ? (
+						<DeviceRowSkeleton />
+					) : currentSession ? (
+						<DeviceRow
+							session={currentSession}
+							isCurrent
+							compact={!isSmUp}
+							// no revoke for current device
+						/>
+					) : (
+						<Typography variant="body2" color="text.secondary">
+							No active current device detected.
+						</Typography>
+					)}
+				</Box>
+			</Box>
+
+			<Divider flexItem />
+
+			{/* Other devices */}
+			<Box sx={{ mt: 1 }}>
+				<Stack direction={isSmUp ? "row" : "column"} alignItems={isSmUp ? "center" : "flex-start"} justifyContent="space-between" spacing={2} sx={{ mx: 1 }}>
+					<Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
+						Other devices
+					</Typography>
+
+					<Button
+						variant="contained"
+						sx={{ background: "#c94b4b" }}
+						size="small"
+						startIcon={<LogoutRoundedIcon />}
+						onClick={handleRevokeAllExceptCurrent}
+						disabled={!hasOtherSessions || loading}>
+						Logout All
+					</Button>
+				</Stack>
+
+				<Box sx={{ padding: 1 }}>
+					{loading && otherSessions.length === 0 ? (
+						<Stack spacing={1.5}>
+							<DeviceRowSkeleton />
+							<DeviceRowSkeleton />
+						</Stack>
+					) : otherSessions.length === 0 ? (
+						<Typography variant="body2" color="text.secondary">
+							You’re only signed in on this device.
+						</Typography>
+					) : (
+						<Stack spacing={1.5}>
+							{otherSessions.map((session) => (
+								<DeviceRow
+									key={session.id}
+									session={session}
+									isCurrent={false}
+									compact={!isSmUp}
+									disabled={loading}
+									onRevoke={() => handleRevokeSession(session.id)}
+								/>
+							))}
+						</Stack>
+					)}
+				</Box>
+			</Box>
+		</Card>
+	);
+}
+
+/**
+ * Subcomponents
+ */
+
+function DeviceRow({ session, isCurrent, onRevoke, compact = false, disabled = false }) {
+	const theme = useTheme();
+
+	return (
+		<Box
+			sx={{
+				px: 2,
+				py: 1.25,
+				borderRadius: 2,
+				border: `1px solid ${theme.palette.divider}`,
+				display: "flex",
+				flexDirection: compact ? "column" : "row",
+				alignItems: compact ? "flex-start" : "center",
+				justifyContent: "space-between",
+				gap: 1.5,
+				bgcolor: (t) => (isCurrent ? t.palette.action.disabledBackground : t.palette.action.hover),
+			}}>
+			<Stack spacing={0.75}>
+				<Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+					{session.deviceName}
+				</Typography>
+
+				<Typography variant="caption" color="text.secondary">
+					{session.userAgent}
+				</Typography>
+
+				<Stack direction="row" flexWrap="wrap" spacing={1.5} rowGap={0.5} sx={{ mt: 0.5 }}>
+					<Stack direction="row" spacing={0.5} alignItems="center">
+						<LocationOnOutlinedIcon sx={{ fontSize: 16 }} />
+						<Typography variant="body2" color="text.secondary">
+							{session.location}
+						</Typography>
+					</Stack>
+
+					<Stack direction="row" spacing={0.5} alignItems="center">
+						<AccessTimeRoundedIcon sx={{ fontSize: 16 }} />
+						<Typography variant="body2" color="text.secondary">
+							Last active {formatLastActive(session.lastActive)}
+						</Typography>
+					</Stack>
+
+					<Tooltip title={session.ipAddress} arrow placement="top" describeChild>
+						<Typography
+							variant="body2"
+							color="text.secondary"
+							sx={{
+								fontFamily: "monospace",
+								cursor: "help",
+								borderRadius: 1,
+								px: 0.75,
+								py: 0.25,
+								border: `1px dashed ${theme.palette.divider}`,
+							}}>
+							IP: {MASK}
+						</Typography>
+					</Tooltip>
+				</Stack>
+			</Stack>
+
+			<Stack direction="row" alignItems="center" justifyContent={compact ? "flex-start" : "flex-end"} spacing={1}>
+				{isCurrent && (
+					<Chip
+						size="small"
+						label="This device"
+						sx={{
+							fontSize: 11,
+							borderRadius: 999,
+						}}
+					/>
+				)}
+
+				{!isCurrent && onRevoke && (
+					<Tooltip title="Log out from this device" arrow>
+						<span>
+							<Button variant="contained" size="small" onClick={onRevoke} disabled={disabled} sx={{ padding: 1.5, minWidth: 0, background: "#a62929" }}>
+								<LogoutRoundedIcon fontSize="small" />
+							</Button>
+						</span>
+					</Tooltip>
+				)}
+			</Stack>
+		</Box>
+	);
+}
+
+function DeviceRowSkeleton() {
+	const theme = useTheme();
+	return (
+		<Box
+			sx={{
+				px: 2,
+				py: 1.25,
+				borderRadius: 2,
+				border: `1px solid ${theme.palette.divider}`,
+			}}>
+			<Stack spacing={1}>
+				<Skeleton variant="text" width="40%" />
+				<Skeleton variant="text" width="60%" />
+				<Stack direction="row" spacing={2}>
+					<Skeleton variant="text" width={120} />
+					<Skeleton variant="text" width={160} />
+					<Skeleton variant="rectangular" width={80} height={22} />
+				</Stack>
+			</Stack>
+		</Box>
+	);
+}

--- a/src/components/DeviceSessionManager/useDeviceSessions.js
+++ b/src/components/DeviceSessionManager/useDeviceSessions.js
@@ -1,0 +1,168 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { useDispatch } from "react-redux";
+import { addSnackbar } from "../../slices/snackbarSlice";
+
+/**
+ * Placeholder API helpers
+ * Replace these with your real API calls (fetch/axios/etc).
+ */
+
+async function fetchDeviceSessionsApi() {
+	// fake latency
+	await new Promise((r) => setTimeout(r, 400));
+
+	// Example mock data; align this shape with your backend
+	return [
+		{
+			id: "current",
+			userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124.0",
+			deviceName: "Windows · Chrome",
+			location: "Mamaroneck, New York, United States",
+			ipAddress: "203.0.113.42",
+			lastActive: "2025-11-22T15:30:00.000Z",
+			isCurrent: true,
+		},
+		{
+			id: "ios-1",
+			userAgent: "Discord iOS/2019.4.1 (iPhone16,2; iOS 18.1.1)",
+			deviceName: "iOS · Discord",
+			location: "Mamaroneck, New York, United States",
+			ipAddress: "198.51.100.10",
+			lastActive: "2025-11-22T15:00:00.000Z",
+			isCurrent: false,
+		},
+		{
+			id: "mac-1",
+			userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15",
+			deviceName: "macOS · Safari",
+			location: "Mamaroneck, New York, United States",
+			ipAddress: "192.0.2.15",
+			lastActive: "2025-11-22T08:10:00.000Z",
+			isCurrent: false,
+		},
+	];
+}
+
+async function revokeDeviceSessionApi(deviceId) {
+	console.log("[mock] revoke device", deviceId);
+	await new Promise((r) => setTimeout(r, 250));
+}
+
+async function revokeAllExceptCurrentApi() {
+	console.log("[mock] revoke all devices except current");
+	await new Promise((r) => setTimeout(r, 400));
+}
+
+/**
+ * Hook
+ */
+
+export default function useDeviceSessions() {
+	const dispatch = useDispatch();
+	const [sessions, setSessions] = useState([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState(null);
+
+	const loadSessions = useCallback(async () => {
+		try {
+			setLoading(true);
+			setError(null);
+			const data = await fetchDeviceSessionsApi();
+			setSessions(data);
+		} catch (err) {
+			console.error(err);
+			setError("Failed to load devices");
+			dispatch(
+				addSnackbar({
+					snackbarMsg: "Failed to load devices",
+					snackbarSeverity: "error",
+					autoHideDuration: 4000,
+				})
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, [dispatch]);
+
+	useEffect(() => {
+		loadSessions();
+	}, [loadSessions]);
+
+	const handleRevokeSession = useCallback(
+		async (deviceId) => {
+			try {
+				setLoading(true);
+				await revokeDeviceSessionApi(deviceId);
+				setSessions((prev) => prev.filter((s) => s.id !== deviceId));
+
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Device logged out",
+						snackbarSeverity: "success",
+						autoHideDuration: 3000,
+					})
+				);
+			} catch (err) {
+				console.error(err);
+				setError("Failed to revoke device");
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Failed to revoke device",
+						snackbarSeverity: "error",
+						autoHideDuration: 4000,
+					})
+				);
+			} finally {
+				setLoading(false);
+			}
+		},
+		[dispatch]
+	);
+
+	const handleRevokeAllExceptCurrent = useCallback(async () => {
+		try {
+			setLoading(true);
+			await revokeAllExceptCurrentApi();
+			setSessions((prev) => prev.filter((s) => s.isCurrent));
+
+			dispatch(
+				addSnackbar({
+					snackbarMsg: "Logged out of all other devices",
+					snackbarSeverity: "warning",
+					autoHideDuration: 4000,
+				})
+			);
+		} catch (err) {
+			console.error(err);
+			setError("Failed to revoke devices");
+			dispatch(
+				addSnackbar({
+					snackbarMsg: "Failed to revoke devices",
+					snackbarSeverity: "error",
+					autoHideDuration: 4000,
+				})
+			);
+		} finally {
+			setLoading(false);
+		}
+	}, [dispatch]);
+
+	const value = useMemo(() => {
+		const current = sessions.find((s) => s.isCurrent) || null;
+		const others = sessions.filter((s) => !s.isCurrent);
+
+		return {
+			sessions,
+			currentSession: current,
+			otherSessions: others,
+			hasOtherSessions: others.length > 0,
+			loading,
+			error,
+			handleRevokeSession,
+			handleRevokeAllExceptCurrent,
+			refreshSessions: loadSessions,
+		};
+	}, [sessions, loading, error, handleRevokeSession, handleRevokeAllExceptCurrent, loadSessions]);
+
+	return value;
+}

--- a/src/routes/SecurityPage/SecurityPage.route.jsx
+++ b/src/routes/SecurityPage/SecurityPage.route.jsx
@@ -1,0 +1,40 @@
+import { Box, Stack, Typography } from "@mui/material";
+import { styled, useTheme } from "@mui/material/styles";
+import React from "react";
+import { useSelector } from "react-redux";
+
+import DeviceSessionsPanel from "../../components/DeviceSessionManager/DeviceSessionManager.jsx";
+
+const ItemPaper = styled(Box)(({ theme }) => ({
+	...theme.typography.body2,
+	padding: theme.spacing(1),
+	textAlign: "center",
+	color: theme.palette.text.secondary,
+}));
+
+export default function SecurityPage() {
+	const theme = useTheme();
+	const authState = useSelector((state) => state.auth);
+
+	return (
+		<Box
+			sx={{
+				display: "flex",
+				justifyContent: "center",
+				flexGrow: 1,
+				overflow: "hidden",
+			}}>
+			<Stack spacing={2} sx={{ height: "100%", width: "100%" }}>
+				<ItemPaper>
+					<Typography variant="h4" color="text.primary">
+						Security Dashboard
+					</Typography>
+				</ItemPaper>
+
+				<Box sx={{ flexGrow: 1, display: "flex", flexDirection: "column" }}>
+					<DeviceSessionsPanel />
+				</Box>
+			</Stack>
+		</Box>
+	);
+}


### PR DESCRIPTION
## Summary
- add utility to derive token metadata from incoming requests
- persist user agent, IP address, and origin location with stored refresh tokens
- capture metadata whenever new refresh tokens are issued

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69221b3f7b0c8327be320c70cecac0dd)