### PR TITLE
Add backend device session management endpoints

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -219,6 +219,9 @@ importers:
       socket.io:
         specifier: ^4.8.1
         version: 4.8.1
+      ua-parser-js:
+        specifier: ^2.0.6
+        version: 2.0.6
       winston:
         specifier: ^3.17.0
         version: 3.18.2
@@ -1812,6 +1815,9 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
+  detect-europe-js@0.1.2:
+    resolution: {integrity: sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==}
+
   detect-libc@1.0.3:
     resolution: {integrity: sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==}
     engines: {node: '>=0.10'}
@@ -2436,6 +2442,9 @@ packages:
   is-regexp@3.1.0:
     resolution: {integrity: sha512-rbku49cWloU5bSMI+zaRaXdQHXnthP6DZ/vLnfdSKyL4zUzuWnomtOEiZZOd+ioQ+avFo/qau3KPTc7Fjy1uPA==}
     engines: {node: '>=12'}
+
+  is-standalone-pwa@0.1.1:
+    resolution: {integrity: sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==}
 
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
@@ -3735,8 +3744,15 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  ua-is-frozen@0.1.2:
+    resolution: {integrity: sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==}
+
   ua-parser-js@1.0.41:
     resolution: {integrity: sha512-LbBDqdIC5s8iROCUjMbW1f5dJQTEFB1+KO9ogbvlb3nm9n4YHa5p4KTvFPWvh2Hs8gZMBuiB1/8+pdfe/tDPug==}
+    hasBin: true
+
+  ua-parser-js@2.0.6:
+    resolution: {integrity: sha512-EmaxXfltJaDW75SokrY4/lXMrVyXomE/0FpIIqP2Ctic93gK7rlme55Cwkz8l3YZ6gqf94fCU7AnIkidd/KXPg==}
     hasBin: true
 
   uid-safe@2.1.5:
@@ -5637,6 +5653,8 @@ snapshots:
 
   dequal@2.0.3: {}
 
+  detect-europe-js@0.1.2: {}
+
   detect-libc@1.0.3:
     optional: true
 
@@ -6406,6 +6424,8 @@ snapshots:
   is-promise@4.0.0: {}
 
   is-regexp@3.1.0: {}
+
+  is-standalone-pwa@0.1.1: {}
 
   is-stream@2.0.1: {}
 
@@ -7813,7 +7833,15 @@ snapshots:
 
   typescript@5.9.2: {}
 
+  ua-is-frozen@0.1.2: {}
+
   ua-parser-js@1.0.41: {}
+
+  ua-parser-js@2.0.6:
+    dependencies:
+      detect-europe-js: 0.1.2
+      is-standalone-pwa: 0.1.1
+      ua-is-frozen: 0.1.2
 
   uid-safe@2.1.5:
     dependencies:

--- a/server/package.json
+++ b/server/package.json
@@ -47,6 +47,7 @@
 		"prettier": "^3.5.3",
 		"rebound-server": "file:",
 		"socket.io": "^4.8.1",
+		"ua-parser-js": "^2.0.6",
 		"winston": "^3.17.0"
 	},
 	"devDependencies": {

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -123,7 +123,13 @@ UserSchema.methods.generateRefreshToken = async function (descriptor = {}, exist
 
         const tokenHash = hashRefreshToken(token);
         const { userAgent, ipAddress, location } = descriptor;
+        const existingId =
+                targetIndex != null && targetIndex >= 0 && targetIndex < this.refreshTokens.length
+                        ? this.refreshTokens[targetIndex]._id
+                        : null;
+
         const tokenRecord = {
+                ...(existingId ? { _id: existingId } : {}),
                 tokenHash,
                 expiresAt,
                 userAgent: userAgent || "unknown",

--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -57,6 +57,9 @@ const UserSchema = new Schema(
                                 tokenHash: { type: String, required: true },
                                 expiresAt: { type: Date, required: true },
                                 userAgent: { type: String },
+                                userAgentParsed: { type: String },
+                                userAgentDeviceType: { type: String },
+                                deviceName: { type: String },
                                 ipAddress: { type: String },
                                 location: { type: String },
                                 lastUsed: { type: Date },
@@ -122,7 +125,7 @@ UserSchema.methods.generateRefreshToken = async function (descriptor = {}, exist
         const lastUsed = new Date();
 
         const tokenHash = hashRefreshToken(token);
-        const { userAgent, ipAddress, location } = descriptor;
+        const { userAgent, userAgentParsed, userAgentDeviceType, deviceName, ipAddress, location } = descriptor;
         const existingId =
                 targetIndex != null && targetIndex >= 0 && targetIndex < this.refreshTokens.length
                         ? this.refreshTokens[targetIndex]._id
@@ -132,9 +135,12 @@ UserSchema.methods.generateRefreshToken = async function (descriptor = {}, exist
                 ...(existingId ? { _id: existingId } : {}),
                 tokenHash,
                 expiresAt,
-                userAgent: userAgent || "unknown",
-                ipAddress: ipAddress || "unknown",
-                location: location || ipAddress || "unknown",
+                userAgent: userAgent || "Unknown",
+                userAgentParsed: userAgentParsed || userAgent || "Unknown",
+                userAgentDeviceType: userAgentDeviceType || "desktop",
+                deviceName: deviceName || userAgentParsed || userAgent || "Unknown device",
+                ipAddress: ipAddress || "Unknown",
+                location: location || ipAddress || "Unknown",
                 lastUsed,
         };
 

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -18,7 +18,7 @@ import serverWatchers from "../../socketio/watchers.js";
 import mongoose from "mongoose";
 import rateLimit from "express-rate-limit";
 
-import { buildRequestTokenDescriptor, createAuthContextMiddleware } from "../../utils/auth.js";
+import { buildRequestTokenDescriptor, createAuthContextMiddleware, parseCookieHeader } from "../../utils/auth.js";
 
 import "dotenv/config";
 
@@ -93,6 +93,31 @@ const clearAuthCookies = (res) => {
         res.clearCookie("token", ACCESS_COOKIE_OPTIONS);
         res.clearCookie("jid", REFRESH_COOKIE_OPTIONS);
         res.clearCookie("csrfToken", CSRF_COOKIE_OPTIONS);
+};
+
+const resolveCurrentRefreshTokenHash = (req, user) => {
+        const rawToken = req.cookies?.jid || parseCookieHeader(req.headers?.cookie || "")?.jid;
+        if (rawToken) return hashRefreshToken(rawToken);
+
+        const accessIssuedAtMs = req.authContext?.decoded?.iat ? req.authContext.decoded.iat * 1000 : null;
+        if (!accessIssuedAtMs || !Array.isArray(user?.refreshTokens)) return null;
+
+        const WINDOW_MS = 5 * 60 * 1000; // 5 minutes grace between issued access token and stored refresh record
+
+        let nearest = null;
+        for (const token of user.refreshTokens) {
+                if (!token?.lastUsed) continue;
+
+                const lastUsedMs = token.lastUsed instanceof Date ? token.lastUsed.getTime() : new Date(token.lastUsed).getTime();
+                if (Number.isNaN(lastUsedMs)) continue;
+
+                const delta = Math.abs(lastUsedMs - accessIssuedAtMs);
+                if (delta <= WINDOW_MS && (!nearest || delta < nearest.delta)) {
+                        nearest = { delta, tokenHash: token.tokenHash };
+                }
+        }
+
+        return nearest?.tokenHash || null;
 };
 
 const normalizeRefreshSession = (tokenRecord, currentTokenHash = null) => {
@@ -229,7 +254,7 @@ router.get(
         async (req, res, next) => {
                 try {
                         const { user } = req.authContext;
-                        const currentTokenHash = req.cookies?.jid ? hashRefreshToken(req.cookies.jid) : null;
+                        const currentTokenHash = resolveCurrentRefreshTokenHash(req, user);
 
                         user.pruneExpiredRefreshTokens();
                         await user.save();
@@ -375,7 +400,7 @@ router.delete(
                 try {
                         const { user } = req.authContext;
                         const scope = req.query.scope;
-                        const currentTokenHash = req.cookies?.jid ? hashRefreshToken(req.cookies.jid) : null;
+                        const currentTokenHash = resolveCurrentRefreshTokenHash(req, user);
 
                         user.pruneExpiredRefreshTokens();
 
@@ -404,7 +429,7 @@ router.delete(
                 try {
                         const { user } = req.authContext;
                         const { sessionId } = req.params;
-                        const currentTokenHash = req.cookies?.jid ? hashRefreshToken(req.cookies.jid) : null;
+                        const currentTokenHash = resolveCurrentRefreshTokenHash(req, user);
 
                         user.pruneExpiredRefreshTokens();
 

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -18,7 +18,12 @@ import serverWatchers from "../../socketio/watchers.js";
 import mongoose from "mongoose";
 import rateLimit from "express-rate-limit";
 
-import { buildRequestTokenDescriptor, createAuthContextMiddleware, parseCookieHeader } from "../../utils/auth.js";
+import {
+        buildRequestTokenDescriptor,
+        createAuthContextMiddleware,
+        parseCookieHeader,
+        sanitizeIpAddress,
+} from "../../utils/auth.js";
 
 import "dotenv/config";
 
@@ -120,19 +125,45 @@ const resolveCurrentRefreshTokenHash = (req, user) => {
         return nearest?.tokenHash || null;
 };
 
+const normalizeUnknownString = (value) => {
+        if (!value) return null;
+        const trimmed = String(value).trim();
+        return trimmed && trimmed.toLowerCase() !== "unknown" ? trimmed : null;
+};
+
 const normalizeRefreshSession = (tokenRecord, currentTokenHash = null) => {
         if (!tokenRecord) return null;
 
-        const { _id, tokenHash, userAgent, ipAddress, location, lastUsed, expiresAt } = tokenRecord;
+        const {
+                _id,
+                tokenHash,
+                userAgent,
+                userAgentParsed,
+                userAgentDeviceType,
+                deviceName,
+                ipAddress,
+                location,
+                lastUsed,
+                expiresAt,
+        } = tokenRecord;
 
         if (!_id) return null;
 
+        const normalizedIpAddress = sanitizeIpAddress(ipAddress);
+        const normalizedIp = normalizedIpAddress || normalizeUnknownString(ipAddress) || "Unknown";
+        const normalizedLocation = normalizeUnknownString(location) || normalizedIpAddress || normalizeUnknownString(ipAddress) || "Unknown";
+        const userAgentDisplay = normalizeUnknownString(userAgentParsed) || normalizeUnknownString(userAgent) || "Unknown";
+        const deviceLabel = normalizeUnknownString(deviceName) || userAgentDisplay || "Unknown device";
+        const deviceType = normalizeUnknownString(userAgentDeviceType) || "desktop";
+
         return {
                 id: _id.toString(),
-                userAgent: userAgent || "unknown",
-                deviceName: userAgent || "Unknown device",
-                ipAddress: ipAddress || "unknown",
-                location: location || ipAddress || "unknown",
+                userAgent: userAgentDisplay,
+                userAgentParsed: userAgentDisplay,
+                userAgentDeviceType: deviceType,
+                deviceName: deviceLabel,
+                ipAddress: normalizedIp,
+                location: normalizedLocation,
                 lastActive: lastUsed || expiresAt,
                 isCurrent: Boolean(currentTokenHash && tokenHash === currentTokenHash),
         };

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -82,11 +82,33 @@ const setCsrfCookie = (res) => {
 };
 
 const setAuthCookies = (res, accessToken, refreshToken) => {
-	res.cookie("token", accessToken, ACCESS_COOKIE_OPTIONS);
-	if (refreshToken) {
-		res.cookie("jid", refreshToken, REFRESH_COOKIE_OPTIONS);
-	}
-	return setCsrfCookie(res);
+        res.cookie("token", accessToken, ACCESS_COOKIE_OPTIONS);
+        if (refreshToken) {
+                res.cookie("jid", refreshToken, REFRESH_COOKIE_OPTIONS);
+        }
+        return setCsrfCookie(res);
+};
+
+const clearAuthCookies = (res) => {
+        res.clearCookie("token", ACCESS_COOKIE_OPTIONS);
+        res.clearCookie("jid", REFRESH_COOKIE_OPTIONS);
+        res.clearCookie("csrfToken", CSRF_COOKIE_OPTIONS);
+};
+
+const normalizeRefreshSession = (tokenRecord, currentTokenHash = null) => {
+        if (!tokenRecord) return null;
+
+        const { _id, tokenHash, userAgent, ipAddress, location, lastUsed, expiresAt } = tokenRecord;
+
+        return {
+                id: _id?.toString?.() || tokenHash,
+                userAgent: userAgent || "unknown",
+                deviceName: userAgent || "Unknown device",
+                ipAddress: ipAddress || "unknown",
+                location: location || ipAddress || "unknown",
+                lastActive: lastUsed || expiresAt,
+                isCurrent: Boolean(currentTokenHash && tokenHash === currentTokenHash),
+        };
 };
 
 const generateStoredFilename = (fieldName, userId, originalName) => {
@@ -179,23 +201,50 @@ router.post("/users/refresh", async (req, res, next) => {
 });
 
 router.get("/users/profile", generalLimiter, auth.required, requireAuthContext("Profile retrieval auth error"), async (req, res, next) => {
-	try {
-		const { user: requestingUser, decoded } = req.authContext;
-		const targetUserId = req.query.id || decoded.id;
-		const user = await UserModel.findById(targetUserId);
+        try {
+                const { user: requestingUser, decoded } = req.authContext;
+                const targetUserId = req.query.id || decoded.id;
+                const user = await UserModel.findById(targetUserId);
 
 		if (!user) {
 			return res.sendStatus(404);
 		}
 
-		const profile = decoded.id === user._id.toString() ? await user.toProfilePrivJSON(requestingUser) : await user.toProfilePubJSON(requestingUser);
+                const profile = decoded.id === user._id.toString()
+                        ? await user.toProfilePrivJSON(requestingUser)
+                        : await user.toProfilePubJSON(requestingUser);
 
-		return res.json({ user: profile });
-	} catch (err) {
-		logger.error(`Profile retrieval error: ${err.message}`);
-		return next(err);
-	}
+                return res.json({ user: profile });
+        } catch (err) {
+                logger.error(`Profile retrieval error: ${err.message}`);
+                return next(err);
+        }
 });
+
+router.get(
+        "/users/sessions",
+        generalLimiter,
+        auth.required,
+        requireAuthContext("Session retrieval auth error"),
+        async (req, res, next) => {
+                try {
+                        const { user } = req.authContext;
+                        const currentTokenHash = req.cookies?.jid ? hashRefreshToken(req.cookies.jid) : null;
+
+                        user.pruneExpiredRefreshTokens();
+                        await user.save();
+
+                        const sessions = user.refreshTokens
+                                .map((token) => normalizeRefreshSession(token, currentTokenHash))
+                                .filter(Boolean);
+
+                        return res.json({ sessions });
+                } catch (err) {
+                        logger.error(`Session retrieval error: ${err.message}`);
+                        return next(err);
+                }
+        }
+);
 
 router.get("/users/google", passport.authenticate("google", { scope: ["profile", "email"] }));
 router.get("/users/google/callback", passport.authenticate("google", { session: false, failureRedirect: "/" }), async (req, res, next) => {
@@ -268,10 +317,10 @@ router.post("/users/register", authLimiter, async (req, res, next) => {
 });
 
 router.put(
-	"/users/modify",
-	modifyLimiter,
-	auth.required,
-	requireAuthContext("Token verification error in modify"),
+        "/users/modify",
+        modifyLimiter,
+        auth.required,
+        requireAuthContext("Token verification error in modify"),
 	upload.fields([
 		{ name: "banner", maxCount: 1 },
 		{ name: "avatar", maxCount: 1 },
@@ -314,14 +363,79 @@ router.put(
 		} finally {
 			session.endSession();
 		}
-	}
+        }
+);
+
+router.delete(
+        "/users/sessions",
+        modifyLimiter,
+        auth.required,
+        requireAuthContext("Session bulk revoke auth error"),
+        async (req, res, next) => {
+                try {
+                        const { user } = req.authContext;
+                        const scope = req.query.scope;
+                        const currentTokenHash = req.cookies?.jid ? hashRefreshToken(req.cookies.jid) : null;
+
+                        user.pruneExpiredRefreshTokens();
+
+                        if (scope === "others" && currentTokenHash) {
+                                user.refreshTokens = user.refreshTokens.filter((token) => token.tokenHash === currentTokenHash);
+                        } else {
+                                user.refreshTokens = [];
+                                clearAuthCookies(res);
+                        }
+
+                        await user.save();
+                        return res.sendStatus(204);
+                } catch (err) {
+                        logger.error(`Session bulk revoke error: ${err.message}`);
+                        return next(err);
+                }
+        }
+);
+
+router.delete(
+        "/users/sessions/:sessionId",
+        modifyLimiter,
+        auth.required,
+        requireAuthContext("Session revoke auth error"),
+        async (req, res, next) => {
+                try {
+                        const { user } = req.authContext;
+                        const { sessionId } = req.params;
+                        const currentTokenHash = req.cookies?.jid ? hashRefreshToken(req.cookies.jid) : null;
+
+                        user.pruneExpiredRefreshTokens();
+
+                        const targetIndex = user.refreshTokens.findIndex(
+                                (token) => token._id?.toString?.() === sessionId || token.tokenHash === sessionId
+                        );
+
+                        if (targetIndex === -1) {
+                                return res.status(404).json({ error: "Session not found" });
+                        }
+
+                        const [removed] = user.refreshTokens.splice(targetIndex, 1);
+
+                        if (currentTokenHash && removed?.tokenHash === currentTokenHash) {
+                                clearAuthCookies(res);
+                        }
+
+                        await user.save();
+                        return res.sendStatus(204);
+                } catch (err) {
+                        logger.error(`Session revoke error: ${err.message}`);
+                        return next(err);
+                }
+        }
 );
 
 router.put(
-	"/users/addfriend",
-	generalLimiter,
-	auth.required,
-	requireAuthContext("Token verification error in addfriend"),
+        "/users/addfriend",
+        generalLimiter,
+        auth.required,
+        requireAuthContext("Token verification error in addfriend"),
 	friendAction("Add friend", async (req, res) => {
 		const { decoded, user: sender } = req.authContext;
 

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -125,8 +125,10 @@ const normalizeRefreshSession = (tokenRecord, currentTokenHash = null) => {
 
         const { _id, tokenHash, userAgent, ipAddress, location, lastUsed, expiresAt } = tokenRecord;
 
+        if (!_id) return null;
+
         return {
-                id: _id?.toString?.() || tokenHash,
+                id: _id.toString(),
                 userAgent: userAgent || "unknown",
                 deviceName: userAgent || "Unknown device",
                 ipAddress: ipAddress || "unknown",

--- a/server/src/utils/auth.js
+++ b/server/src/utils/auth.js
@@ -1,4 +1,6 @@
 import jwt from "jsonwebtoken";
+import net from "node:net";
+import UAParser from "ua-parser-js";
 
 import UserModel from "../models/User.js";
 
@@ -87,15 +89,57 @@ const handleAuthFailure = (err, res, context, logger) => {
         return res.status(err.status || 401).json({ error: err.message });
 };
 
+const sanitizeIpAddress = (value) => {
+        const trimmed = typeof value === "string" ? value.trim() : "";
+        if (!trimmed) return null;
+
+        const isLoopback = trimmed === "::1";
+        const isValid = net.isIP(trimmed) !== 0;
+
+        return !isLoopback && isValid ? trimmed : null;
+};
+
+const parseUserAgentDetails = (userAgentRaw) => {
+        const parser = new UAParser(userAgentRaw);
+
+        const browser = parser.getBrowser();
+        const os = parser.getOS();
+        const device = parser.getDevice();
+
+        const browserName = browser?.name || "Unknown browser";
+        const browserVersion = browser?.version ? browser.version.split(".")[0] : null;
+        const osName = os?.name || "Unknown OS";
+        const osVersion = os?.version ? ` ${os.version}` : "";
+
+        const userAgentParsed = `${browserName}${browserVersion ? ` ${browserVersion}` : ""} on ${osName}${osVersion}`.trim();
+
+        const deviceType = device?.type;
+        const userAgentDeviceType = deviceType === "mobile" || deviceType === "tablet" ? "mobile" : "desktop";
+
+        const deviceName =
+                device?.model || device?.vendor
+                        ? [device?.vendor, device?.model].filter(Boolean).join(" ")
+                        : osName;
+
+        return { userAgentParsed, userAgentDeviceType, deviceName };
+};
+
 const buildRequestTokenDescriptor = (req) => {
         const connectionAddress = req?.socket?.remoteAddress || req?.connection?.remoteAddress;
         const forwardedIps = Array.isArray(req?.ips) && req.ips.length ? req.ips : [];
-        const ipAddress = forwardedIps[0] || connectionAddress || req?.ip || "unknown";
+        const rawIp = forwardedIps[0] || connectionAddress || req?.ip;
+        const ipAddress = sanitizeIpAddress(rawIp);
+
+        const userAgentRaw = req?.get?.("user-agent") || "Unknown";
+        const { userAgentParsed, userAgentDeviceType, deviceName } = parseUserAgentDetails(userAgentRaw);
 
         return {
-                userAgent: req?.get?.("user-agent") || "unknown",
-                ipAddress,
-                location: forwardedIps[0] || connectionAddress || "unknown",
+                userAgent: userAgentRaw,
+                userAgentParsed,
+                userAgentDeviceType,
+                deviceName,
+                ipAddress: ipAddress || "Unknown",
+                location: ipAddress || "Unknown",
         };
 };
 
@@ -121,4 +165,6 @@ export {
         validateAccessTokenFromRequest,
         buildRequestTokenDescriptor,
         hasPasswordChangedAfterTokenIssue,
+        sanitizeIpAddress,
+        parseUserAgentDetails,
 };

--- a/src/components/DeviceSessionManager/DeviceSessionManager.jsx
+++ b/src/components/DeviceSessionManager/DeviceSessionManager.jsx
@@ -1,19 +1,18 @@
 import React from "react";
 import {
-	Box,
-	Card,
-	CardContent,
-	CardHeader,
-	Divider,
-	IconButton,
-	Stack,
-	Tooltip,
-	Typography,
-	Button,
-	Chip,
-	useTheme,
-	useMediaQuery,
-	Skeleton,
+        Box,
+        Card,
+        CardHeader,
+        Divider,
+        Stack,
+        Tooltip,
+        Typography,
+        Button,
+        Chip,
+        useTheme,
+        useMediaQuery,
+        Skeleton,
+        Alert,
 } from "@mui/material";
 
 import DevicesOtherRoundedIcon from "@mui/icons-material/DevicesOtherRounded";
@@ -39,16 +38,24 @@ function formatLastActive(dateString) {
 }
 
 export default function DeviceSessionsPanel(props) {
-	const { sx, ...rest } = props;
-	const theme = useTheme();
-	const isSmUp = useMediaQuery(theme.breakpoints.up("sm"));
+        const { sx, ...rest } = props;
+        const theme = useTheme();
+        const isSmUp = useMediaQuery(theme.breakpoints.up("sm"));
 
-	const { currentSession, otherSessions, hasOtherSessions, loading, error, handleRevokeSession, handleRevokeAllExceptCurrent } = useDeviceSessions();
+        const {
+                currentSession,
+                otherSessions,
+                hasOtherSessions,
+                loading,
+                error,
+                handleRevokeSession,
+                handleRevokeAllExceptCurrent,
+        } = useDeviceSessions();
 
-	return (
-		<Card
-			elevation={0}
-			sx={{
+        return (
+                <Card
+                        elevation={0}
+                        sx={{
 				width: "100%",
 				borderRadius: 2,
 				border: `1px solid ${theme.palette.divider}`,
@@ -77,101 +84,105 @@ export default function DeviceSessionsPanel(props) {
 						Logged-in devices
 					</Typography>
 				}
-				subheader={
-					<Typography variant="body2" color="text.secondary">
-						Manage where your account is signed in and revoke their login.
-					</Typography>
-				}
-				sx={{ pb: 0 }}
-			/>
+                                subheader={
+                                        <Typography variant="body2" color="text.secondary">
+                                                Manage where your account is signed in and revoke their login.
+                                        </Typography>
+                                }
+                                sx={{ pb: 0 }}
+                        />
 
-			<Divider flexItem />
+                        <Divider flexItem />
 
-			{/* Current device */}
-			<Box sx={{ mt: 1 }}>
-				<Stack direction="row" alignItems="center" justifyContent="space-between" spacing={2} sx={{ mx: 1 }}>
-					<Stack direction="row" spacing={3} alignItems="center">
-						<Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
-							Current device
-						</Typography>
-						<Chip
-							size="small"
-							icon={<SecurityRoundedIcon color="#12a4ff" sx={{ fontSize: 16, color: "#12a4ff" }} />}
-							label="Protected"
-							sx={{
-								fontSize: 11,
-								borderRadius: 999,
-							}}
-						/>
-					</Stack>
-				</Stack>
+                        <Stack spacing={2} sx={{ py: 1 }}>
+                                {error && (
+                                        <Alert severity="error" sx={{ mx: 2 }}>
+                                                {typeof error === "string" ? error : "Unable to load device sessions"}
+                                        </Alert>
+                                )}
 
-				<Box sx={{ padding: 1 }}>
-					{loading && !currentSession ? (
-						<DeviceRowSkeleton />
-					) : currentSession ? (
-						<DeviceRow
-							session={currentSession}
-							isCurrent
-							compact={!isSmUp}
-							// no revoke for current device
-						/>
-					) : (
-						<Typography variant="body2" color="text.secondary">
-							No active current device detected.
-						</Typography>
-					)}
-				</Box>
-			</Box>
+                                <SectionContainer>
+                                        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+                                                <Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
+                                                        Current device
+                                                </Typography>
+                                                <Chip
+                                                        size="small"
+                                                        icon={<SecurityRoundedIcon color="#12a4ff" sx={{ fontSize: 16, color: "#12a4ff" }} />}
+                                                        label="Protected"
+                                                        sx={{
+                                                                fontSize: 11,
+                                                                borderRadius: 999,
+                                                        }}
+                                                />
+                                        </Stack>
 
-			<Divider flexItem />
+                                        {loading && !currentSession ? (
+                                                <DeviceRowSkeleton />
+                                        ) : currentSession ? (
+                                                <DeviceRow
+                                                        session={currentSession}
+                                                        isCurrent
+                                                        compact={!isSmUp}
+                                                        // no revoke for current device
+                                                />
+                                        ) : (
+                                                <Typography variant="body2" color="text.secondary">
+                                                        No active current device detected.
+                                                </Typography>
+                                        )}
+                                </SectionContainer>
 
-			{/* Other devices */}
-			<Box sx={{ mt: 1 }}>
-				<Stack direction={isSmUp ? "row" : "column"} alignItems={isSmUp ? "center" : "flex-start"} justifyContent="space-between" spacing={2} sx={{ mx: 1 }}>
-					<Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
-						Other devices
-					</Typography>
+                                <Divider flexItem />
 
-					<Button
-						variant="contained"
-						sx={{ background: "#c94b4b" }}
-						size="small"
-						startIcon={<LogoutRoundedIcon />}
-						onClick={handleRevokeAllExceptCurrent}
-						disabled={!hasOtherSessions || loading}>
-						Logout All
-					</Button>
-				</Stack>
+                                <SectionContainer>
+                                        <Stack
+                                                direction={isSmUp ? "row" : "column"}
+                                                alignItems={isSmUp ? "center" : "flex-start"}
+                                                justifyContent="space-between"
+                                                spacing={1.5}>
+                                                <Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
+                                                        Other devices
+                                                </Typography>
 
-				<Box sx={{ padding: 1 }}>
-					{loading && otherSessions.length === 0 ? (
-						<Stack spacing={1.5}>
-							<DeviceRowSkeleton />
-							<DeviceRowSkeleton />
-						</Stack>
-					) : otherSessions.length === 0 ? (
-						<Typography variant="body2" color="text.secondary">
-							You’re only signed in on this device.
-						</Typography>
-					) : (
-						<Stack spacing={1.5}>
-							{otherSessions.map((session) => (
-								<DeviceRow
-									key={session.id}
-									session={session}
-									isCurrent={false}
-									compact={!isSmUp}
-									disabled={loading}
-									onRevoke={() => handleRevokeSession(session.id)}
-								/>
-							))}
-						</Stack>
-					)}
-				</Box>
-			</Box>
-		</Card>
-	);
+                                                <Button
+                                                        variant="contained"
+                                                        sx={{ background: "#c94b4b" }}
+                                                        size="small"
+                                                        startIcon={<LogoutRoundedIcon />}
+                                                        onClick={handleRevokeAllExceptCurrent}
+                                                        disabled={!hasOtherSessions || loading}>
+                                                        Logout All
+                                                </Button>
+                                        </Stack>
+
+                                        {loading && otherSessions.length === 0 ? (
+                                                <Stack spacing={1.5}>
+                                                        <DeviceRowSkeleton />
+                                                        <DeviceRowSkeleton />
+                                                </Stack>
+                                        ) : otherSessions.length === 0 ? (
+                                                <Typography variant="body2" color="text.secondary">
+                                                        You’re only signed in on this device.
+                                                </Typography>
+                                        ) : (
+                                                <Stack spacing={1.5}>
+                                                        {otherSessions.map((session) => (
+                                                                <DeviceRow
+                                                                        key={session.id}
+                                                                        session={session}
+                                                                        isCurrent={false}
+                                                                        compact={!isSmUp}
+                                                                        disabled={loading}
+                                                                        onRevoke={() => handleRevokeSession(session.id)}
+                                                                />
+                                                        ))}
+                                                </Stack>
+                                        )}
+                                </SectionContainer>
+                        </Stack>
+                </Card>
+        );
 }
 
 /**
@@ -261,6 +272,14 @@ function DeviceRow({ session, isCurrent, onRevoke, compact = false, disabled = f
 			</Stack>
 		</Box>
 	);
+}
+
+function SectionContainer({ children }) {
+        return (
+                <Stack spacing={1.25} sx={{ px: 2, py: 1 }}>
+                        {children}
+                </Stack>
+        );
 }
 
 function DeviceRowSkeleton() {

--- a/src/components/DeviceSessionManager/DeviceSessionManager.jsx
+++ b/src/components/DeviceSessionManager/DeviceSessionManager.jsx
@@ -1,19 +1,5 @@
 import React from "react";
-import {
-        Box,
-        Card,
-        CardHeader,
-        Divider,
-        Stack,
-        Tooltip,
-        Typography,
-        Button,
-        Chip,
-        useTheme,
-        useMediaQuery,
-        Skeleton,
-        Alert,
-} from "@mui/material";
+import { Box, Card, CardHeader, Divider, Stack, Tooltip, Typography, Button, Chip, useTheme, useMediaQuery, Skeleton, Alert } from "@mui/material";
 
 import DevicesOtherRoundedIcon from "@mui/icons-material/DevicesOtherRounded";
 import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
@@ -38,24 +24,16 @@ function formatLastActive(dateString) {
 }
 
 export default function DeviceSessionsPanel(props) {
-        const { sx, ...rest } = props;
-        const theme = useTheme();
-        const isSmUp = useMediaQuery(theme.breakpoints.up("sm"));
+	const { sx, ...rest } = props;
+	const theme = useTheme();
+	const isSmUp = useMediaQuery(theme.breakpoints.up("sm"));
 
-        const {
-                currentSession,
-                otherSessions,
-                hasOtherSessions,
-                loading,
-                error,
-                handleRevokeSession,
-                handleRevokeAllExceptCurrent,
-        } = useDeviceSessions();
+	const { currentSession, otherSessions, hasOtherSessions, loading, error, handleRevokeSession, handleRevokeAllExceptCurrent } = useDeviceSessions();
 
-        return (
-                <Card
-                        elevation={0}
-                        sx={{
+	return (
+		<Card
+			elevation={0}
+			sx={{
 				width: "100%",
 				borderRadius: 2,
 				border: `1px solid ${theme.palette.divider}`,
@@ -84,105 +62,102 @@ export default function DeviceSessionsPanel(props) {
 						Logged-in devices
 					</Typography>
 				}
-                                subheader={
-                                        <Typography variant="body2" color="text.secondary">
-                                                Manage where your account is signed in and revoke their login.
-                                        </Typography>
-                                }
-                                sx={{ pb: 0 }}
-                        />
+				subheader={
+					<Typography variant="body2" color="text.secondary">
+						Manage where your account is signed in and revoke their login.
+					</Typography>
+				}
+				sx={{ pb: 0 }}
+			/>
 
-                        <Divider flexItem />
+			<Divider flexItem />
 
-                        <Stack spacing={2} sx={{ py: 1 }}>
-                                {error && (
-                                        <Alert severity="error" sx={{ mx: 2 }}>
-                                                {typeof error === "string" ? error : "Unable to load device sessions"}
-                                        </Alert>
-                                )}
+			<Stack spacing={2} sx={{ py: 1 }}>
+				{error && (
+					<Alert severity="error" sx={{ mx: 2 }}>
+						{typeof error === "string" ? error : "Unable to load device sessions"}
+					</Alert>
+				)}
 
-                                <SectionContainer>
-                                        <Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
-                                                <Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
-                                                        Current device
-                                                </Typography>
-                                                <Chip
-                                                        size="small"
-                                                        icon={<SecurityRoundedIcon color="#12a4ff" sx={{ fontSize: 16, color: "#12a4ff" }} />}
-                                                        label="Protected"
-                                                        sx={{
-                                                                fontSize: 11,
-                                                                borderRadius: 999,
-                                                        }}
-                                                />
-                                        </Stack>
+				<SectionContainer>
+					<Stack direction="row" spacing={2} alignItems="center" flexWrap="wrap">
+						<Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
+							Current device
+						</Typography>
+						<Chip
+							size="small"
+							icon={<SecurityRoundedIcon color="#12a4ff" sx={{ fontSize: 16, color: "#12a4ff" }} />}
+							label="Protected"
+							sx={{
+								fontSize: 11,
+								borderRadius: 999,
+							}}
+						/>
+					</Stack>
 
-                                        {loading && !currentSession ? (
-                                                <DeviceRowSkeleton />
-                                        ) : currentSession ? (
-                                                <DeviceRow
-                                                        session={currentSession}
-                                                        isCurrent
-                                                        compact={!isSmUp}
-                                                        // no revoke for current device
-                                                />
-                                        ) : (
-                                                <Typography variant="body2" color="text.secondary">
-                                                        No active current device detected.
-                                                </Typography>
-                                        )}
-                                </SectionContainer>
+					{loading && !currentSession ? (
+						<DeviceRowSkeleton />
+					) : currentSession ? (
+						<DeviceRow
+							session={currentSession}
+							isCurrent
+							compact={!isSmUp}
+							// no revoke for current device
+						/>
+					) : (
+						<Typography variant="body2" color="text.secondary">
+							No active current device detected.
+						</Typography>
+					)}
+				</SectionContainer>
 
-                                <Divider flexItem />
+				<Divider flexItem />
 
-                                <SectionContainer>
-                                        <Stack
-                                                direction={isSmUp ? "row" : "column"}
-                                                alignItems={isSmUp ? "center" : "flex-start"}
-                                                justifyContent="space-between"
-                                                spacing={1.5}>
-                                                <Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
-                                                        Other devices
-                                                </Typography>
+				<SectionContainer>
+					<Stack direction={isSmUp ? "row" : "column"} alignItems={isSmUp ? "center" : "flex-start"} justifyContent="space-between" spacing={1.5}>
+						<Typography variant="subtitle2" sx={{ textTransform: "uppercase", letterSpacing: 0.6 }} color="text.secondary">
+							Other devices
+						</Typography>
 
-                                                <Button
-                                                        variant="contained"
-                                                        sx={{ background: "#c94b4b" }}
-                                                        size="small"
-                                                        startIcon={<LogoutRoundedIcon />}
-                                                        onClick={handleRevokeAllExceptCurrent}
-                                                        disabled={!hasOtherSessions || loading}>
-                                                        Logout All
-                                                </Button>
-                                        </Stack>
+						<Button
+							variant="contained"
+							sx={{ background: "#c94b4b" }}
+							style={{ display: !hasOtherSessions ? "none" : "inherit" }}
+							size="small"
+							startIcon={<LogoutRoundedIcon />}
+							onClick={handleRevokeAllExceptCurrent}
+							disabled={!hasOtherSessions || loading}>
+							Logout All
+						</Button>
+					</Stack>
 
-                                        {loading && otherSessions.length === 0 ? (
-                                                <Stack spacing={1.5}>
-                                                        <DeviceRowSkeleton />
-                                                        <DeviceRowSkeleton />
-                                                </Stack>
-                                        ) : otherSessions.length === 0 ? (
-                                                <Typography variant="body2" color="text.secondary">
-                                                        You’re only signed in on this device.
-                                                </Typography>
-                                        ) : (
-                                                <Stack spacing={1.5}>
-                                                        {otherSessions.map((session) => (
-                                                                <DeviceRow
-                                                                        key={session.id}
-                                                                        session={session}
-                                                                        isCurrent={false}
-                                                                        compact={!isSmUp}
-                                                                        disabled={loading}
-                                                                        onRevoke={() => handleRevokeSession(session.id)}
-                                                                />
-                                                        ))}
-                                                </Stack>
-                                        )}
-                                </SectionContainer>
-                        </Stack>
-                </Card>
-        );
+					{loading && otherSessions.length === 0 ? (
+						<Stack spacing={1.5}>
+							<DeviceRowSkeleton />
+							<DeviceRowSkeleton />
+						</Stack>
+					) : otherSessions.length === 0 ? (
+						<Typography variant="body2" color="text.secondary">
+							You’re only signed in on this device.
+						</Typography>
+					) : (
+						<Stack spacing={1.5}>
+							{otherSessions.map((session) => (
+								<DeviceRow
+									key={session.id}
+									session={session}
+									isCurrent={false}
+									compact={!isSmUp}
+									disabled={loading}
+									onRevoke={() => handleRevokeSession(session.id)}
+								/>
+							))}
+						</Stack>
+					)}
+				</SectionContainer>
+			</Stack>
+		</Card>
+	);
 }
 
 /**
@@ -275,11 +250,11 @@ function DeviceRow({ session, isCurrent, onRevoke, compact = false, disabled = f
 }
 
 function SectionContainer({ children }) {
-        return (
-                <Stack spacing={1.25} sx={{ px: 2, py: 1 }}>
-                        {children}
-                </Stack>
-        );
+	return (
+		<Stack spacing={1.25} sx={{ px: 2, py: 1 }}>
+			{children}
+		</Stack>
+	);
 }
 
 function DeviceRowSkeleton() {

--- a/src/components/DeviceSessionManager/DeviceSessionManager.jsx
+++ b/src/components/DeviceSessionManager/DeviceSessionManager.jsx
@@ -20,6 +20,8 @@ import LogoutRoundedIcon from "@mui/icons-material/LogoutRounded";
 import SecurityRoundedIcon from "@mui/icons-material/SecurityRounded";
 import LocationOnOutlinedIcon from "@mui/icons-material/LocationOnOutlined";
 import AccessTimeRoundedIcon from "@mui/icons-material/AccessTimeRounded";
+import LaptopMacRoundedIcon from "@mui/icons-material/LaptopMacRounded";
+import PhoneIphoneRoundedIcon from "@mui/icons-material/PhoneIphoneRounded";
 
 import useDeviceSessions from "./useDeviceSessions";
 
@@ -190,10 +192,13 @@ export default function DeviceSessionsPanel(props) {
  */
 
 function DeviceRow({ session, isCurrent, onRevoke, compact = false, disabled = false }) {
-	const theme = useTheme();
+        const theme = useTheme();
+        const DeviceIcon = session.userAgentDeviceType === "mobile" ? PhoneIphoneRoundedIcon : LaptopMacRoundedIcon;
+        const hasIp = session.ipAddress && session.ipAddress !== "Unknown";
+        const userAgentDisplay = session.userAgentParsed || session.userAgent;
 
-	return (
-		<Box
+        return (
+                <Box
 			sx={{
 				px: 2,
 				py: 1.25,
@@ -206,14 +211,17 @@ function DeviceRow({ session, isCurrent, onRevoke, compact = false, disabled = f
 				gap: 1.5,
 				bgcolor: (t) => (isCurrent ? t.palette.action.disabledBackground : t.palette.action.hover),
 			}}>
-			<Stack spacing={0.75}>
-				<Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
-					{session.deviceName}
-				</Typography>
+                        <Stack spacing={0.75}>
+                                <Stack direction="row" spacing={1} alignItems="center">
+                                        <DeviceIcon sx={{ fontSize: 20, color: "text.secondary" }} />
+                                        <Typography variant="subtitle2" sx={{ fontWeight: 600 }}>
+                                                {session.deviceName}
+                                        </Typography>
+                                </Stack>
 
-				<Typography variant="caption" color="text.secondary">
-					{session.userAgent}
-				</Typography>
+                                <Typography variant="caption" color="text.secondary">
+                                        {userAgentDisplay}
+                                </Typography>
 
 				<Stack direction="row" flexWrap="wrap" spacing={1.5} rowGap={0.5} sx={{ mt: 0.5 }}>
 					<Stack direction="row" spacing={0.5} alignItems="center">
@@ -230,22 +238,27 @@ function DeviceRow({ session, isCurrent, onRevoke, compact = false, disabled = f
 						</Typography>
 					</Stack>
 
-					<Tooltip title={session.ipAddress} arrow placement="top" describeChild>
-						<Typography
-							variant="body2"
-							color="text.secondary"
+                                        <Tooltip
+                                                title={hasIp ? session.ipAddress : undefined}
+                                                arrow
+                                                placement="top"
+                                                describeChild
+                                                disableHoverListener={!hasIp}>
+                                                <Typography
+                                                        variant="body2"
+                                                        color="text.secondary"
 							sx={{
 								fontFamily: "monospace",
 								cursor: "help",
 								borderRadius: 1,
-								px: 0.75,
-								py: 0.25,
-								border: `1px dashed ${theme.palette.divider}`,
-							}}>
-							IP: {MASK}
-						</Typography>
-					</Tooltip>
-				</Stack>
+                                                                px: 0.75,
+                                                                py: 0.25,
+                                                                border: `1px dashed ${theme.palette.divider}`,
+                                                        }}>
+                                                        IP: {hasIp ? MASK : "Unknown"}
+                                                </Typography>
+                                        </Tooltip>
+                                </Stack>
 			</Stack>
 
 			<Stack direction="row" alignItems="center" justifyContent={compact ? "flex-start" : "flex-end"} spacing={1}>

--- a/src/components/DeviceSessionManager/useDeviceSessions.js
+++ b/src/components/DeviceSessionManager/useDeviceSessions.js
@@ -1,168 +1,50 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { useDispatch } from "react-redux";
-import { addSnackbar } from "../../slices/snackbarSlice";
+import { useCallback, useEffect, useMemo } from "react";
+import { useDispatch, useSelector } from "react-redux";
 
-/**
- * Placeholder API helpers
- * Replace these with your real API calls (fetch/axios/etc).
- */
-
-async function fetchDeviceSessionsApi() {
-	// fake latency
-	await new Promise((r) => setTimeout(r, 400));
-
-	// Example mock data; align this shape with your backend
-	return [
-		{
-			id: "current",
-			userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/124.0",
-			deviceName: "Windows · Chrome",
-			location: "Mamaroneck, New York, United States",
-			ipAddress: "203.0.113.42",
-			lastActive: "2025-11-22T15:30:00.000Z",
-			isCurrent: true,
-		},
-		{
-			id: "ios-1",
-			userAgent: "Discord iOS/2019.4.1 (iPhone16,2; iOS 18.1.1)",
-			deviceName: "iOS · Discord",
-			location: "Mamaroneck, New York, United States",
-			ipAddress: "198.51.100.10",
-			lastActive: "2025-11-22T15:00:00.000Z",
-			isCurrent: false,
-		},
-		{
-			id: "mac-1",
-			userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15",
-			deviceName: "macOS · Safari",
-			location: "Mamaroneck, New York, United States",
-			ipAddress: "192.0.2.15",
-			lastActive: "2025-11-22T08:10:00.000Z",
-			isCurrent: false,
-		},
-	];
-}
-
-async function revokeDeviceSessionApi(deviceId) {
-	console.log("[mock] revoke device", deviceId);
-	await new Promise((r) => setTimeout(r, 250));
-}
-
-async function revokeAllExceptCurrentApi() {
-	console.log("[mock] revoke all devices except current");
-	await new Promise((r) => setTimeout(r, 400));
-}
-
-/**
- * Hook
- */
+import {
+        fetchDeviceSessions,
+        revokeDeviceSession,
+        revokeOtherDeviceSessions,
+} from "../../slices/deviceSessionsSlice";
 
 export default function useDeviceSessions() {
-	const dispatch = useDispatch();
-	const [sessions, setSessions] = useState([]);
-	const [loading, setLoading] = useState(true);
-	const [error, setError] = useState(null);
+        const dispatch = useDispatch();
+        const { sessions, loading, error } = useSelector((state) => state.deviceSessions);
 
-	const loadSessions = useCallback(async () => {
-		try {
-			setLoading(true);
-			setError(null);
-			const data = await fetchDeviceSessionsApi();
-			setSessions(data);
-		} catch (err) {
-			console.error(err);
-			setError("Failed to load devices");
-			dispatch(
-				addSnackbar({
-					snackbarMsg: "Failed to load devices",
-					snackbarSeverity: "error",
-					autoHideDuration: 4000,
-				})
-			);
-		} finally {
-			setLoading(false);
-		}
-	}, [dispatch]);
+        useEffect(() => {
+                dispatch(fetchDeviceSessions());
+        }, [dispatch]);
 
-	useEffect(() => {
-		loadSessions();
-	}, [loadSessions]);
+        const handleRevokeSession = useCallback(
+                (deviceId) => dispatch(revokeDeviceSession(deviceId)),
+                [dispatch]
+        );
 
-	const handleRevokeSession = useCallback(
-		async (deviceId) => {
-			try {
-				setLoading(true);
-				await revokeDeviceSessionApi(deviceId);
-				setSessions((prev) => prev.filter((s) => s.id !== deviceId));
+        const handleRevokeAllExceptCurrent = useCallback(
+                () => dispatch(revokeOtherDeviceSessions()),
+                [dispatch]
+        );
 
-				dispatch(
-					addSnackbar({
-						snackbarMsg: "Device logged out",
-						snackbarSeverity: "success",
-						autoHideDuration: 3000,
-					})
-				);
-			} catch (err) {
-				console.error(err);
-				setError("Failed to revoke device");
-				dispatch(
-					addSnackbar({
-						snackbarMsg: "Failed to revoke device",
-						snackbarSeverity: "error",
-						autoHideDuration: 4000,
-					})
-				);
-			} finally {
-				setLoading(false);
-			}
-		},
-		[dispatch]
-	);
+        const { currentSession, otherSessions, hasOtherSessions } = useMemo(() => {
+                const current = sessions.find((session) => session.isCurrent) || null;
+                const others = sessions.filter((session) => !session.isCurrent);
 
-	const handleRevokeAllExceptCurrent = useCallback(async () => {
-		try {
-			setLoading(true);
-			await revokeAllExceptCurrentApi();
-			setSessions((prev) => prev.filter((s) => s.isCurrent));
+                return {
+                        currentSession: current,
+                        otherSessions: others,
+                        hasOtherSessions: others.length > 0,
+                };
+        }, [sessions]);
 
-			dispatch(
-				addSnackbar({
-					snackbarMsg: "Logged out of all other devices",
-					snackbarSeverity: "warning",
-					autoHideDuration: 4000,
-				})
-			);
-		} catch (err) {
-			console.error(err);
-			setError("Failed to revoke devices");
-			dispatch(
-				addSnackbar({
-					snackbarMsg: "Failed to revoke devices",
-					snackbarSeverity: "error",
-					autoHideDuration: 4000,
-				})
-			);
-		} finally {
-			setLoading(false);
-		}
-	}, [dispatch]);
-
-	const value = useMemo(() => {
-		const current = sessions.find((s) => s.isCurrent) || null;
-		const others = sessions.filter((s) => !s.isCurrent);
-
-		return {
-			sessions,
-			currentSession: current,
-			otherSessions: others,
-			hasOtherSessions: others.length > 0,
-			loading,
-			error,
-			handleRevokeSession,
-			handleRevokeAllExceptCurrent,
-			refreshSessions: loadSessions,
-		};
-	}, [sessions, loading, error, handleRevokeSession, handleRevokeAllExceptCurrent, loadSessions]);
-
-	return value;
+        return {
+                sessions,
+                currentSession,
+                otherSessions,
+                hasOtherSessions,
+                loading,
+                error,
+                handleRevokeSession,
+                handleRevokeAllExceptCurrent,
+                refreshSessions: () => dispatch(fetchDeviceSessions()),
+        };
 }

--- a/src/slices/deviceSessionsSlice.js
+++ b/src/slices/deviceSessionsSlice.js
@@ -1,0 +1,143 @@
+import { createAsyncThunk, createSlice } from "@reduxjs/toolkit";
+import axios from "axios";
+
+import { buildApiConfig, getApiBase } from "../helpers/api";
+import { addSnackbar } from "./snackbarSlice";
+
+const base = getApiBase();
+
+const normalizeSession = (session) => {
+        const locationParts = [session?.city, session?.region, session?.country].filter(Boolean).join(", ");
+
+        return {
+                id: session?.id ?? session?._id ?? session?.sessionId ?? session?.sid ?? session?.token,
+                userAgent: session?.userAgent ?? session?.user_agent ?? session?.client ?? "Unknown client",
+                deviceName: session?.deviceName ?? session?.device_name ?? session?.device ?? session?.platform ?? "Unknown device",
+                location: session?.location ?? locationParts || "Unknown location",
+                ipAddress: session?.ipAddress ?? session?.ip ?? session?.ip_address ?? "Unknown",
+                lastActive: session?.lastActive ?? session?.lastActiveAt ?? session?.updatedAt ?? session?.createdAt,
+                isCurrent: Boolean(session?.isCurrent ?? session?.current ?? false),
+        };
+};
+
+const normalizeSessions = (sessions) =>
+        (Array.isArray(sessions) ? sessions : []).map(normalizeSession).filter((session) => session.id);
+
+export const fetchDeviceSessions = createAsyncThunk(
+        "deviceSessions/fetchDeviceSessions",
+        async (_, { getState, rejectWithValue }) => {
+                const authToken = getState().auth.authToken;
+
+                try {
+                        const { data } = await axios.get(`${base}/users/sessions`, buildApiConfig(authToken));
+                        const payload = Array.isArray(data?.sessions) ? data.sessions : data;
+
+                        return normalizeSessions(payload);
+                } catch (err) {
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
+
+export const revokeDeviceSession = createAsyncThunk(
+        "deviceSessions/revokeDeviceSession",
+        async (sessionId, { dispatch, getState, rejectWithValue }) => {
+                const authToken = getState().auth.authToken;
+
+                try {
+                        await axios.delete(`${base}/users/sessions/${sessionId}`, buildApiConfig(authToken));
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Device logged out",
+                                        snackbarSeverity: "success",
+                                        autoHideDuration: 3000,
+                                })
+                        );
+                        return sessionId;
+                } catch (err) {
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Failed to revoke device",
+                                        snackbarSeverity: "error",
+                                        autoHideDuration: 4000,
+                                })
+                        );
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
+
+export const revokeOtherDeviceSessions = createAsyncThunk(
+        "deviceSessions/revokeOtherDeviceSessions",
+        async (_, { dispatch, getState, rejectWithValue }) => {
+                const authToken = getState().auth.authToken;
+
+                try {
+                        await axios.delete(`${base}/users/sessions`, buildApiConfig(authToken, { params: { scope: "others" } }));
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Logged out of other devices",
+                                        snackbarSeverity: "warning",
+                                        autoHideDuration: 4000,
+                                })
+                        );
+                        return true;
+                } catch (err) {
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Failed to revoke devices",
+                                        snackbarSeverity: "error",
+                                        autoHideDuration: 4000,
+                                })
+                        );
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
+
+const deviceSessionsSlice = createSlice({
+        name: "deviceSessions",
+        initialState: { sessions: [], loading: false, error: null },
+        reducers: {},
+        extraReducers: (builder) => {
+                builder
+                        .addCase(fetchDeviceSessions.pending, (state) => {
+                                state.loading = true;
+                                state.error = null;
+                        })
+                        .addCase(fetchDeviceSessions.fulfilled, (state, action) => {
+                                state.loading = false;
+                                state.sessions = action.payload;
+                        })
+                        .addCase(fetchDeviceSessions.rejected, (state, action) => {
+                                state.loading = false;
+                                state.error = action.payload || "Failed to load devices";
+                        })
+                        .addCase(revokeDeviceSession.pending, (state) => {
+                                state.loading = true;
+                                state.error = null;
+                        })
+                        .addCase(revokeDeviceSession.fulfilled, (state, action) => {
+                                state.loading = false;
+                                state.sessions = state.sessions.filter((session) => session.id !== action.payload);
+                        })
+                        .addCase(revokeDeviceSession.rejected, (state, action) => {
+                                state.loading = false;
+                                state.error = action.payload || "Failed to revoke device";
+                        })
+                        .addCase(revokeOtherDeviceSessions.pending, (state) => {
+                                state.loading = true;
+                                state.error = null;
+                        })
+                        .addCase(revokeOtherDeviceSessions.fulfilled, (state) => {
+                                state.loading = false;
+                                state.sessions = state.sessions.filter((session) => session.isCurrent);
+                        })
+                        .addCase(revokeOtherDeviceSessions.rejected, (state, action) => {
+                                state.loading = false;
+                                state.error = action.payload || "Failed to revoke devices";
+                        });
+        },
+});
+
+export default deviceSessionsSlice.reducer;

--- a/src/slices/deviceSessionsSlice.js
+++ b/src/slices/deviceSessionsSlice.js
@@ -7,137 +7,127 @@ import { addSnackbar } from "./snackbarSlice";
 const base = getApiBase();
 
 const normalizeSession = (session) => {
-        const locationParts = [session?.city, session?.region, session?.country].filter(Boolean).join(", ");
+	const locationParts = [session?.city, session?.region, session?.country].filter(Boolean).join(", ");
 
-        return {
-                id: session?.id ?? session?._id ?? session?.sessionId ?? session?.sid ?? session?.token,
-                userAgent: session?.userAgent ?? session?.user_agent ?? session?.client ?? "Unknown client",
-                deviceName: session?.deviceName ?? session?.device_name ?? session?.device ?? session?.platform ?? "Unknown device",
-                location: session?.location ?? locationParts || "Unknown location",
-                ipAddress: session?.ipAddress ?? session?.ip ?? session?.ip_address ?? "Unknown",
-                lastActive: session?.lastActive ?? session?.lastActiveAt ?? session?.updatedAt ?? session?.createdAt,
-                isCurrent: Boolean(session?.isCurrent ?? session?.current ?? false),
-        };
+	return {
+		id: session?.id ?? session?._id ?? session?.sessionId ?? session?.sid ?? session?.token,
+		userAgent: session?.userAgent ?? session?.user_agent ?? session?.client ?? "Unknown client",
+		deviceName: session?.deviceName ?? session?.device_name ?? session?.device ?? session?.platform ?? "Unknown device",
+		location: session?.location ?? locationParts ?? "Unknown location",
+		ipAddress: session?.ipAddress ?? session?.ip ?? session?.ip_address ?? "Unknown",
+		lastActive: session?.lastActive ?? session?.lastActiveAt ?? session?.updatedAt ?? session?.createdAt,
+		isCurrent: Boolean(session?.isCurrent ?? session?.current ?? false),
+	};
 };
 
-const normalizeSessions = (sessions) =>
-        (Array.isArray(sessions) ? sessions : []).map(normalizeSession).filter((session) => session.id);
+const normalizeSessions = (sessions) => (Array.isArray(sessions) ? sessions : []).map(normalizeSession).filter((session) => session.id);
 
-export const fetchDeviceSessions = createAsyncThunk(
-        "deviceSessions/fetchDeviceSessions",
-        async (_, { getState, rejectWithValue }) => {
-                const authToken = getState().auth.authToken;
+export const fetchDeviceSessions = createAsyncThunk("deviceSessions/fetchDeviceSessions", async (_, { getState, rejectWithValue }) => {
+	const authToken = getState().auth.authToken;
 
-                try {
-                        const { data } = await axios.get(`${base}/users/sessions`, buildApiConfig(authToken));
-                        const payload = Array.isArray(data?.sessions) ? data.sessions : data;
+	try {
+		const { data } = await axios.get(`${base}/users/sessions`, buildApiConfig(authToken));
+		const payload = Array.isArray(data?.sessions) ? data.sessions : data;
 
-                        return normalizeSessions(payload);
-                } catch (err) {
-                        return rejectWithValue(err.response?.data || err.message);
-                }
-        }
-);
+		return normalizeSessions(payload);
+	} catch (err) {
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
-export const revokeDeviceSession = createAsyncThunk(
-        "deviceSessions/revokeDeviceSession",
-        async (sessionId, { dispatch, getState, rejectWithValue }) => {
-                const authToken = getState().auth.authToken;
+export const revokeDeviceSession = createAsyncThunk("deviceSessions/revokeDeviceSession", async (sessionId, { dispatch, getState, rejectWithValue }) => {
+	const authToken = getState().auth.authToken;
 
-                try {
-                        await axios.delete(`${base}/users/sessions/${sessionId}`, buildApiConfig(authToken));
-                        dispatch(
-                                addSnackbar({
-                                        snackbarMsg: "Device logged out",
-                                        snackbarSeverity: "success",
-                                        autoHideDuration: 3000,
-                                })
-                        );
-                        return sessionId;
-                } catch (err) {
-                        dispatch(
-                                addSnackbar({
-                                        snackbarMsg: "Failed to revoke device",
-                                        snackbarSeverity: "error",
-                                        autoHideDuration: 4000,
-                                })
-                        );
-                        return rejectWithValue(err.response?.data || err.message);
-                }
-        }
-);
+	try {
+		await axios.delete(`${base}/users/sessions/${sessionId}`, buildApiConfig(authToken));
+		dispatch(
+			addSnackbar({
+				snackbarMsg: "Device logged out",
+				snackbarSeverity: "success",
+				autoHideDuration: 3000,
+			})
+		);
+		return sessionId;
+	} catch (err) {
+		dispatch(
+			addSnackbar({
+				snackbarMsg: "Failed to revoke device",
+				snackbarSeverity: "error",
+				autoHideDuration: 4000,
+			})
+		);
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
-export const revokeOtherDeviceSessions = createAsyncThunk(
-        "deviceSessions/revokeOtherDeviceSessions",
-        async (_, { dispatch, getState, rejectWithValue }) => {
-                const authToken = getState().auth.authToken;
+export const revokeOtherDeviceSessions = createAsyncThunk("deviceSessions/revokeOtherDeviceSessions", async (_, { dispatch, getState, rejectWithValue }) => {
+	const authToken = getState().auth.authToken;
 
-                try {
-                        await axios.delete(`${base}/users/sessions`, buildApiConfig(authToken, { params: { scope: "others" } }));
-                        dispatch(
-                                addSnackbar({
-                                        snackbarMsg: "Logged out of other devices",
-                                        snackbarSeverity: "warning",
-                                        autoHideDuration: 4000,
-                                })
-                        );
-                        return true;
-                } catch (err) {
-                        dispatch(
-                                addSnackbar({
-                                        snackbarMsg: "Failed to revoke devices",
-                                        snackbarSeverity: "error",
-                                        autoHideDuration: 4000,
-                                })
-                        );
-                        return rejectWithValue(err.response?.data || err.message);
-                }
-        }
-);
+	try {
+		await axios.delete(`${base}/users/sessions`, buildApiConfig(authToken, { params: { scope: "others" } }));
+		dispatch(
+			addSnackbar({
+				snackbarMsg: "Logged out of other devices",
+				snackbarSeverity: "warning",
+				autoHideDuration: 4000,
+			})
+		);
+		return true;
+	} catch (err) {
+		dispatch(
+			addSnackbar({
+				snackbarMsg: "Failed to revoke devices",
+				snackbarSeverity: "error",
+				autoHideDuration: 4000,
+			})
+		);
+		return rejectWithValue(err.response?.data || err.message);
+	}
+});
 
 const deviceSessionsSlice = createSlice({
-        name: "deviceSessions",
-        initialState: { sessions: [], loading: false, error: null },
-        reducers: {},
-        extraReducers: (builder) => {
-                builder
-                        .addCase(fetchDeviceSessions.pending, (state) => {
-                                state.loading = true;
-                                state.error = null;
-                        })
-                        .addCase(fetchDeviceSessions.fulfilled, (state, action) => {
-                                state.loading = false;
-                                state.sessions = action.payload;
-                        })
-                        .addCase(fetchDeviceSessions.rejected, (state, action) => {
-                                state.loading = false;
-                                state.error = action.payload || "Failed to load devices";
-                        })
-                        .addCase(revokeDeviceSession.pending, (state) => {
-                                state.loading = true;
-                                state.error = null;
-                        })
-                        .addCase(revokeDeviceSession.fulfilled, (state, action) => {
-                                state.loading = false;
-                                state.sessions = state.sessions.filter((session) => session.id !== action.payload);
-                        })
-                        .addCase(revokeDeviceSession.rejected, (state, action) => {
-                                state.loading = false;
-                                state.error = action.payload || "Failed to revoke device";
-                        })
-                        .addCase(revokeOtherDeviceSessions.pending, (state) => {
-                                state.loading = true;
-                                state.error = null;
-                        })
-                        .addCase(revokeOtherDeviceSessions.fulfilled, (state) => {
-                                state.loading = false;
-                                state.sessions = state.sessions.filter((session) => session.isCurrent);
-                        })
-                        .addCase(revokeOtherDeviceSessions.rejected, (state, action) => {
-                                state.loading = false;
-                                state.error = action.payload || "Failed to revoke devices";
-                        });
-        },
+	name: "deviceSessions",
+	initialState: { sessions: [], loading: false, error: null },
+	reducers: {},
+	extraReducers: (builder) => {
+		builder
+			.addCase(fetchDeviceSessions.pending, (state) => {
+				state.loading = true;
+				state.error = null;
+			})
+			.addCase(fetchDeviceSessions.fulfilled, (state, action) => {
+				state.loading = false;
+				state.sessions = action.payload;
+			})
+			.addCase(fetchDeviceSessions.rejected, (state, action) => {
+				state.loading = false;
+				state.error = action.payload || "Failed to load devices";
+			})
+			.addCase(revokeDeviceSession.pending, (state) => {
+				state.loading = true;
+				state.error = null;
+			})
+			.addCase(revokeDeviceSession.fulfilled, (state, action) => {
+				state.loading = false;
+				state.sessions = state.sessions.filter((session) => session.id !== action.payload);
+			})
+			.addCase(revokeDeviceSession.rejected, (state, action) => {
+				state.loading = false;
+				state.error = action.payload || "Failed to revoke device";
+			})
+			.addCase(revokeOtherDeviceSessions.pending, (state) => {
+				state.loading = true;
+				state.error = null;
+			})
+			.addCase(revokeOtherDeviceSessions.fulfilled, (state) => {
+				state.loading = false;
+				state.sessions = state.sessions.filter((session) => session.isCurrent);
+			})
+			.addCase(revokeOtherDeviceSessions.rejected, (state, action) => {
+				state.loading = false;
+				state.error = action.payload || "Failed to revoke devices";
+			});
+	},
 });
 
 export default deviceSessionsSlice.reducer;

--- a/src/slices/deviceSessionsSlice.js
+++ b/src/slices/deviceSessionsSlice.js
@@ -8,11 +8,22 @@ const base = getApiBase();
 
 const normalizeSession = (session) => {
         const locationParts = [session?.city, session?.region, session?.country].filter(Boolean).join(", ");
+        const deviceType = session?.userAgentDeviceType ?? session?.deviceType ?? session?.clientType;
+        const userAgentDisplay =
+                session?.userAgentParsed ?? session?.user_agent_parsed ?? session?.userAgent ?? session?.user_agent ?? session?.client;
 
         return {
                 id: session?.id ?? session?._id ?? session?.sessionId ?? session?.sid ?? session?.token,
-                userAgent: session?.userAgent ?? session?.user_agent ?? session?.client ?? "Unknown client",
-                deviceName: session?.deviceName ?? session?.device_name ?? session?.device ?? session?.platform ?? "Unknown device",
+                userAgent: userAgentDisplay ?? "Unknown client",
+                userAgentParsed: userAgentDisplay ?? "Unknown client",
+                userAgentDeviceType: deviceType ?? "desktop",
+                deviceName:
+                        session?.deviceName ??
+                        session?.device_name ??
+                        session?.device ??
+                        session?.platform ??
+                        userAgentDisplay ??
+                        "Unknown device",
                 location: session?.location ?? locationParts || "Unknown location",
                 ipAddress: session?.ipAddress ?? session?.ip ?? session?.ip_address ?? "Unknown",
                 lastActive: session?.lastActive ?? session?.lastActiveAt ?? session?.updatedAt ?? session?.createdAt,

--- a/src/slices/index.js
+++ b/src/slices/index.js
@@ -7,15 +7,17 @@ import snackbarReducer from "./snackbarSlice";
 import userApiReducer from "./userApiSlice";
 import chatApiReducer from "./chatApiSlice";
 import dmApiReducer from "./dmApiSlice";
+import deviceSessionsReducer from "./deviceSessionsSlice";
 
 const rootReducer = combineReducers({
 	dialogs: dialogReducer,
 	auth: authReducer,
-	snackbars: snackbarReducer,
-	settings: settingsReducer,
-	userApi: userApiReducer,
-	chatApi: chatApiReducer,
-	dmApi: dmApiReducer,
+        snackbars: snackbarReducer,
+        settings: settingsReducer,
+        userApi: userApiReducer,
+        chatApi: chatApiReducer,
+        dmApi: dmApiReducer,
+        deviceSessions: deviceSessionsReducer,
 });
 
 export default rootReducer;


### PR DESCRIPTION
## Summary
- expose device session listing endpoint that normalizes stored refresh token metadata and marks the current device securely
- add endpoints to revoke individual sessions or all other sessions while clearing auth cookies when appropriate
- add helpers to clear auth cookies and reuse normalized session mapping for consistent responses

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692272acb0588327803be567b4d1104a)