### PR TITLE
Prevent duplicate refresh tokens and clean logout sessions

### DIFF
--- a/server/src/models/User.js
+++ b/server/src/models/User.js
@@ -7,6 +7,11 @@ import mongooseUniqueValidator from "mongoose-unique-validator";
 import serverWatchers from "../socketio/watchers.js";
 
 const hashRefreshToken = (token) => crypto.createHash("sha256").update(token).digest("hex");
+const normalizeFingerprintValue = (value) => {
+        if (!value) return null;
+        const trimmed = String(value).trim().toLowerCase();
+        return trimmed || null;
+};
 
 const REFRESH_TOKEN_LIFETIME_DAYS = 60;
 
@@ -117,9 +122,33 @@ UserSchema.methods.generateRefreshToken = async function (descriptor = {}, exist
 
         this.pruneExpiredRefreshTokens();
 
-        const targetIndex = existingTokenHash
+        const descriptorFingerprint = {
+                userAgent: normalizeFingerprintValue(descriptor.userAgentParsed || descriptor.userAgent),
+                device: normalizeFingerprintValue(descriptor.deviceName),
+                ip: normalizeFingerprintValue(descriptor.ipAddress),
+        };
+
+        let targetIndex = existingTokenHash
                 ? this.refreshTokens.findIndex((t) => t.tokenHash === existingTokenHash)
                 : null;
+
+        if (targetIndex === null || targetIndex < 0 || targetIndex >= this.refreshTokens.length) {
+                targetIndex = this.refreshTokens.findIndex((t) => {
+                        const tokenFingerprint = {
+                                userAgent: normalizeFingerprintValue(t.userAgentParsed || t.userAgent),
+                                device: normalizeFingerprintValue(t.deviceName),
+                                ip: normalizeFingerprintValue(t.ipAddress),
+                        };
+
+                        return (
+                                descriptorFingerprint.userAgent &&
+                                descriptorFingerprint.device &&
+                                tokenFingerprint.userAgent === descriptorFingerprint.userAgent &&
+                                tokenFingerprint.device === descriptorFingerprint.device &&
+                                (!descriptorFingerprint.ip || tokenFingerprint.ip === descriptorFingerprint.ip)
+                        );
+                });
+        }
 
         const expiresAt = new Date(Date.now() + REFRESH_TOKEN_LIFETIME_DAYS * 24 * 60 * 60 * 1000);
         const lastUsed = new Date();

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -328,18 +328,22 @@ router.post("/users/login", authLimiter, (req, res, next) => {
 		return res.status(422).json({ errors: { password: "is required" } });
 	}
 
-	passport.authenticate("local", { session: false }, async (err, user, info) => {
+        passport.authenticate("local", { session: false }, async (err, user, info) => {
 		if (err) {
 			logger.error(`Login error: ${err.message}`);
 			return next(err);
 		}
 		if (!user) {
 			return res.status(422).json(info);
-		}
+                }
 
                 try {
                         const accessToken = user.generateAccessToken();
-                        const refreshToken = await user.generateRefreshToken(buildRequestTokenDescriptor(req));
+                        const existingTokenHash = resolveCurrentRefreshTokenHash(req, user);
+                        const refreshToken = await user.generateRefreshToken(
+                                buildRequestTokenDescriptor(req),
+                                existingTokenHash
+                        );
 
                         const csrfToken = setAuthCookies(res, accessToken, refreshToken);
 
@@ -439,6 +443,11 @@ router.delete(
 
                         if (scope === "others" && currentTokenHash) {
                                 user.refreshTokens = user.refreshTokens.filter((token) => token.tokenHash === currentTokenHash);
+                        } else if (scope === "current" && currentTokenHash) {
+                                user.refreshTokens = user.refreshTokens.filter((token) => token.tokenHash !== currentTokenHash);
+                                clearAuthCookies(res);
+                        } else if (scope === "current") {
+                                clearAuthCookies(res);
                         } else {
                                 user.refreshTokens = [];
                                 clearAuthCookies(res);

--- a/src/components/CustomAppBar/useCustomAppBar.js
+++ b/src/components/CustomAppBar/useCustomAppBar.js
@@ -2,7 +2,7 @@ import socketIoHelper from "../../helpers/socket";
 import { useState } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
-import { setLoggedIn } from "../../slices/authSlice";
+import { logoutUser } from "../../slices/authSlice";
 import { setDialogOpened } from "../../slices/dialogSlice";
 import { addSnackbar } from "../../slices/snackbarSlice";
 
@@ -38,9 +38,9 @@ export default function useCustomAppBar(width) {
 		);
 	};
 
-        const handleLogout = () => {
+        const handleLogout = async () => {
                 const oldDisplayName = displayName;
-                dispatch(setLoggedIn({ loggedIn: false, disableAutoLogin: true }));
+                await dispatch(logoutUser({ disableAutoLogin: true }));
                 const socketClient = socketIoHelper.getSocket();
                 if (socketClient && socketClient.connected) {
                         socketIoHelper.disconnectSocket();

--- a/src/components/DeviceSessionManager/useDeviceSessions.js
+++ b/src/components/DeviceSessionManager/useDeviceSessions.js
@@ -10,10 +10,13 @@ import {
 export default function useDeviceSessions() {
         const dispatch = useDispatch();
         const { sessions, loading, error } = useSelector((state) => state.deviceSessions);
+        const loggedIn = useSelector((state) => state.auth.loggedIn);
 
         useEffect(() => {
-                dispatch(fetchDeviceSessions());
-        }, [dispatch]);
+                if (loggedIn) {
+                        dispatch(fetchDeviceSessions());
+                }
+        }, [dispatch, loggedIn]);
 
         const handleRevokeSession = useCallback(
                 (deviceId) => dispatch(revokeDeviceSession(deviceId)),

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -27,16 +27,33 @@ const setAuthSessionPresent = (present) => {
 };
 
 const resetAuthFields = (state) => {
-	state.authToken = null;
-	state.userId = null;
+        state.authToken = null;
+        state.userId = null;
 	state.username = "";
 	state.displayName = "";
 	state.bio = "";
 	state.friends = [];
 	state.createdAt = null;
-	state.bannerUrl = null;
-	state.avatarUrl = null;
-	state.socketInfo.currentRoom = null;
+        state.bannerUrl = null;
+        state.avatarUrl = null;
+        state.socketInfo.currentRoom = null;
+};
+
+const applyLoggedOutState = (state, disableAutoLogin = false) => {
+        clearAuthCookies();
+        setAuthSessionPresent(false);
+        resetAuthFields(state);
+        state.loggingIn = false;
+        state.loggedIn = false;
+        state.initialized = true;
+        state.refreshing = false;
+        state.skipAutoLogin = Boolean(disableAutoLogin);
+        if (disableAutoLogin) {
+                state.skipAutoLogin = true;
+                setAutoLoginBlocked(true);
+        } else {
+                setAutoLoginBlocked(false);
+        }
 };
 
 const initialState = {
@@ -113,10 +130,10 @@ export const bootstrapAuth = createAsyncThunk("auth/bootstrapAuth", async (_, { 
 });
 
 export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, password }, { rejectWithValue }) => {
-	const base = getApiBase();
-	try {
-		const { data } = await axios.post(
-			`${base}/users/login`,
+        const base = getApiBase();
+        try {
+                const { data } = await axios.post(
+                        `${base}/users/login`,
 			{
 				user: { email, password },
 			},
@@ -139,9 +156,31 @@ export const loginUser = createAsyncThunk("auth/loginUser", async ({ email, pass
 			createdAt: u.createdAt,
 		};
 	} catch (err) {
-		return rejectWithValue(err.response?.data || err.message);
-	}
+                return rejectWithValue(err.response?.data || err.message);
+        }
 });
+
+export const logoutUser = createAsyncThunk(
+        "auth/logoutUser",
+        async ({ disableAutoLogin = false } = {}, { getState, rejectWithValue }) => {
+                const base = getApiBase();
+                const authToken = getState().auth.authToken;
+
+                try {
+                        await axios.delete(
+                                `${base}/users/sessions`,
+                                buildApiConfig(authToken, { params: { scope: "current" } })
+                        );
+                        clearAuthCookies();
+                        setAuthSessionPresent(false);
+                        return { disableAutoLogin };
+                } catch (err) {
+                        clearAuthCookies();
+                        setAuthSessionPresent(false);
+                        return rejectWithValue({ error: err.response?.data || err.message, disableAutoLogin });
+                }
+        }
+);
 
 export const registerUser = createAsyncThunk("auth/registerUser", async ({ username, email, displayName, bio, password }, { rejectWithValue }) => {
 	const base = getApiBase();
@@ -186,25 +225,19 @@ const authSlice = createSlice({
 				}
 			}
 		},
-		setLoggedIn: (state, action) => {
-			if ("loggedIn" in action.payload) {
-				state.loggingIn = false;
-				state.loggedIn = action.payload.loggedIn;
+                setLoggedIn: (state, action) => {
+                        if ("loggedIn" in action.payload) {
+                                state.loggingIn = false;
+                                state.loggedIn = action.payload.loggedIn;
 
-				if (action.payload.loggedIn === false) {
-					clearAuthCookies();
-					resetAuthFields(state);
-					setAuthSessionPresent(false);
-					if (action.payload.disableAutoLogin) {
-						state.skipAutoLogin = true;
-						setAutoLoginBlocked(true);
-					}
-				}
-			}
-			if (action.payload.loggedIn) {
-				state.skipAutoLogin = false;
-				setAutoLoginBlocked(false);
-				setAuthSessionPresent(true);
+                                if (action.payload.loggedIn === false) {
+                                        applyLoggedOutState(state, action.payload.disableAutoLogin);
+                                }
+                        }
+                        if (action.payload.loggedIn) {
+                                state.skipAutoLogin = false;
+                                setAutoLoginBlocked(false);
+                                setAuthSessionPresent(true);
 			}
 			if ("authToken" in action.payload) {
 				state.authToken = action.payload.authToken;
@@ -344,9 +377,9 @@ const authSlice = createSlice({
 			.addCase(loginUser.pending, (state) => {
 				state.loggingIn = true;
 			})
-			.addCase(loginUser.fulfilled, (state, action) => {
-				state.loggingIn = false;
-				state.loggedIn = true;
+                        .addCase(loginUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
 				state.skipAutoLogin = false;
 				setAutoLoginBlocked(false);
 				state.initialized = true;
@@ -357,15 +390,21 @@ const authSlice = createSlice({
 				state.bio = action.payload.bio;
 				state.friends = action.payload.friends;
 				state.bannerUrl = action.payload.bannerUrl;
-				state.avatarUrl = action.payload.avatarUrl;
-				state.createdAt = action.payload.createdAt;
-			})
-			.addCase(loginUser.rejected, (state) => {
-				state.loggingIn = false;
-				state.loggedIn = false;
-				state.initialized = true;
-			});
-	},
+                                state.avatarUrl = action.payload.avatarUrl;
+                                state.createdAt = action.payload.createdAt;
+                        })
+                        .addCase(loginUser.rejected, (state) => {
+                                state.loggingIn = false;
+                                state.loggedIn = false;
+                                state.initialized = true;
+                        })
+                        .addCase(logoutUser.fulfilled, (state, action) => {
+                                applyLoggedOutState(state, action.payload?.disableAutoLogin);
+                        })
+                        .addCase(logoutUser.rejected, (state, action) => {
+                                applyLoggedOutState(state, action.payload?.disableAutoLogin || action.meta?.arg?.disableAutoLogin);
+                        });
+        },
 });
 
 export const { setAuthState, setLoggedIn, setLoggingIn, setSocketStatus, setSocketRoom } = authSlice.actions;

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -300,11 +300,11 @@ const authSlice = createSlice({
 			.addCase(verifyUser.pending, (state) => {
 				state.loggingIn = true;
 			})
-			.addCase(verifyUser.fulfilled, (state, action) => {
-				state.loggingIn = false;
-				state.loggedIn = true;
-				state.skipAutoLogin = false;
-				setAutoLoginBlocked(false);
+                        .addCase(verifyUser.fulfilled, (state, action) => {
+                                state.loggingIn = false;
+                                state.loggedIn = true;
+                                state.skipAutoLogin = false;
+                                setAutoLoginBlocked(false);
 				state.initialized = true;
 				state.authToken = action.payload.authToken;
 				state.userId = action.payload.userId;
@@ -315,28 +315,21 @@ const authSlice = createSlice({
 				state.bannerUrl = action.payload.bannerUrl;
 				state.avatarUrl = action.payload.avatarUrl;
 				state.createdAt = action.payload.createdAt;
-			})
-			.addCase(verifyUser.rejected, (state) => {
-				state.loggingIn = false;
-				state.loggedIn = false;
-				state.initialized = true;
-				clearAuthCookies();
-			})
-			.addCase(refreshAuthToken.pending, (state) => {
-				state.refreshing = true;
-				state.loggingIn = true;
-			})
-			.addCase(refreshAuthToken.fulfilled, (state, action) => {
-				state.refreshing = false;
-				state.authToken = action.payload.authToken;
-			})
-			.addCase(refreshAuthToken.rejected, (state) => {
-				state.refreshing = false;
-				state.loggingIn = false;
-				clearAuthCookies();
-				setAuthSessionPresent(false);
-				resetAuthFields(state);
-			})
+                        })
+                        .addCase(verifyUser.rejected, (state) => {
+                                applyLoggedOutState(state);
+                        })
+                        .addCase(refreshAuthToken.pending, (state) => {
+                                state.refreshing = true;
+                                state.loggingIn = true;
+                        })
+                        .addCase(refreshAuthToken.fulfilled, (state, action) => {
+                                state.refreshing = false;
+                                state.authToken = action.payload.authToken;
+                        })
+                        .addCase(refreshAuthToken.rejected, (state) => {
+                                applyLoggedOutState(state);
+                        })
 			.addCase(bootstrapAuth.pending, (state) => {
 				state.loggingIn = true;
 			})

--- a/src/slices/deviceSessionsSlice.js
+++ b/src/slices/deviceSessionsSlice.js
@@ -3,6 +3,7 @@ import axios from "axios";
 
 import { buildApiConfig, getApiBase } from "../helpers/api";
 import { addSnackbar } from "./snackbarSlice";
+import { logoutUser, setLoggedIn } from "./authSlice";
 
 const base = getApiBase();
 
@@ -92,11 +93,11 @@ export const revokeOtherDeviceSessions = createAsyncThunk("deviceSessions/revoke
 const deviceSessionsSlice = createSlice({
 	name: "deviceSessions",
 	initialState: { sessions: [], loading: false, error: null },
-	reducers: {},
-	extraReducers: (builder) => {
-		builder
-			.addCase(fetchDeviceSessions.pending, (state) => {
-				state.loading = true;
+        reducers: {},
+        extraReducers: (builder) => {
+                builder
+                        .addCase(fetchDeviceSessions.pending, (state) => {
+                                state.loading = true;
 				state.error = null;
 			})
 			.addCase(fetchDeviceSessions.fulfilled, (state, action) => {
@@ -126,12 +127,28 @@ const deviceSessionsSlice = createSlice({
 			.addCase(revokeOtherDeviceSessions.fulfilled, (state) => {
 				state.loading = false;
 				state.sessions = state.sessions.filter((session) => session.isCurrent);
-			})
-			.addCase(revokeOtherDeviceSessions.rejected, (state, action) => {
-				state.loading = false;
-				state.error = action.payload || "Failed to revoke devices";
-			});
-	},
+                        })
+                        .addCase(revokeOtherDeviceSessions.rejected, (state, action) => {
+                                state.loading = false;
+                                state.error = action.payload || "Failed to revoke devices";
+                        })
+                        .addCase(logoutUser.fulfilled, (state) => {
+                                state.sessions = [];
+                                state.loading = false;
+                                state.error = null;
+                        })
+                        .addCase(logoutUser.rejected, (state) => {
+                                state.sessions = [];
+                                state.loading = false;
+                        })
+                        .addCase(setLoggedIn, (state, action) => {
+                                if (action.payload?.loggedIn === false) {
+                                        state.sessions = [];
+                                        state.loading = false;
+                                        state.error = null;
+                                }
+                        });
+        },
 });
 
 export default deviceSessionsSlice.reducer;

--- a/src/slices/deviceSessionsSlice.js
+++ b/src/slices/deviceSessionsSlice.js
@@ -28,7 +28,11 @@ const normalizeSession = (session) => {
 const normalizeSessions = (sessions) => (Array.isArray(sessions) ? sessions : []).map(normalizeSession).filter((session) => session.id);
 
 export const fetchDeviceSessions = createAsyncThunk("deviceSessions/fetchDeviceSessions", async (_, { getState, rejectWithValue }) => {
-	const authToken = getState().auth.authToken;
+        const { authToken, loggedIn } = getState().auth;
+
+        if (!loggedIn || !authToken) {
+                return rejectWithValue("Not authenticated");
+        }
 
 	try {
 		const { data } = await axios.get(`${base}/users/sessions`, buildApiConfig(authToken));
@@ -104,9 +108,14 @@ const deviceSessionsSlice = createSlice({
 				state.loading = false;
 				state.sessions = action.payload;
 			})
-			.addCase(fetchDeviceSessions.rejected, (state, action) => {
-				state.loading = false;
-				state.error = action.payload || "Failed to load devices";
+                        .addCase(fetchDeviceSessions.rejected, (state, action) => {
+                                state.loading = false;
+                                if (action.payload === "Not authenticated") {
+                                        state.sessions = [];
+                                        state.error = null;
+                                        return;
+                                }
+                                state.error = action.payload || "Failed to load devices";
 			})
 			.addCase(revokeDeviceSession.pending, (state) => {
 				state.loading = true;


### PR DESCRIPTION
## Summary
- reuse existing refresh token entries per device and add server-side logout handling for current sessions
- avoid duplicate stored tokens by matching device fingerprints during login
- clear frontend device session state on logout and route logout through the API to keep cookies and UI in sync

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227c68180483278f3297058ce54a04)