### PR TITLE
Ensure Google login sets auth session marker

### DIFF
--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -89,6 +89,39 @@ const AUTH_SESSION_COOKIE_OPTIONS = {
         path: "/",
 };
 
+const normalizeRedirectTarget = (rawValue) => {
+        if (!rawValue) return null;
+
+        try {
+                const decoded = decodeURIComponent(rawValue);
+                const parsed = new URL(decoded);
+
+                if (!parsed?.protocol || !["http:", "https:"].includes(parsed.protocol)) {
+                        return null;
+                }
+
+                return `${parsed.protocol}//${parsed.host}${parsed.pathname}`;
+        } catch (err) {
+                return null;
+        }
+};
+
+const resolveClientRedirectTarget = (req) => {
+        if (process.env.CLIENT_REDIRECT_BASE) return process.env.CLIENT_REDIRECT_BASE;
+
+        const referrerTarget = normalizeRedirectTarget(req.get("referer"));
+        if (referrerTarget) return referrerTarget;
+
+        const originTarget = normalizeRedirectTarget(req.get("origin"));
+        if (originTarget) return originTarget;
+
+        if (process.env.NODE_ENV === "development") return "http://localhost:3000";
+
+        return "/";
+};
+
+const withAuthErrorParam = (target) => `${target}${target.includes("?") ? "&" : "?"}authError=google`;
+
 const setCsrfCookie = (res) => {
         const csrfToken = crypto.randomBytes(32).toString("hex");
         res.cookie("csrfToken", csrfToken, CSRF_COOKIE_OPTIONS);
@@ -319,28 +352,39 @@ router.get(
         }
 );
 
-router.get("/users/google", passport.authenticate("google", { scope: ["profile", "email"] }));
-router.get(
-        "/users/google/callback",
-        passport.authenticate("google", { session: false, failureRedirect: "/" }),
-        async (req, res) => {
-                const redirectBase =
-                        process.env.CLIENT_REDIRECT_BASE || (process.env.NODE_ENV === "development" ? "http://localhost:3000" : "");
-                const redirectTarget = redirectBase || "/";
+router.get("/users/google", (req, res, next) => {
+        const redirectTarget = resolveClientRedirectTarget(req);
+
+        return passport.authenticate("google", {
+                scope: ["profile", "email"],
+                state: encodeURIComponent(redirectTarget),
+        })(req, res, next);
+});
+router.get("/users/google/callback", (req, res, next) => {
+        const redirectTarget = normalizeRedirectTarget(req.query?.state) || resolveClientRedirectTarget(req);
+        const redirectWithError = () => res.redirect(withAuthErrorParam(redirectTarget));
+
+        return passport.authenticate("google", { session: false }, async (err, user) => {
+                if (err || !user) {
+                        if (err) {
+                                logger.error(`Google callback auth error: ${err.message}`);
+                        }
+                        return redirectWithError();
+                }
 
                 try {
-                        const accessToken = req.user.generateAccessToken();
-                        const refreshToken = await req.user.generateRefreshToken(buildRequestTokenDescriptor(req));
+                        const accessToken = user.generateAccessToken();
+                        const refreshToken = await user.generateRefreshToken(buildRequestTokenDescriptor(req));
 
                         setAuthCookies(res, accessToken, refreshToken);
 
                         return res.redirect(redirectTarget);
                 } catch (e) {
                         logger.error(`Google callback token error: ${e.message}`);
-                        return res.redirect(`${redirectTarget}?authError=google`);
+                        return redirectWithError();
                 }
-        }
-);
+        })(req, res, next);
+});
 router.post("/users/login", authLimiter, (req, res, next) => {
 	if (!req.body?.user?.email) {
 		return res.status(422).json({ errors: { email: "is required" } });

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -320,21 +320,27 @@ router.get(
 );
 
 router.get("/users/google", passport.authenticate("google", { scope: ["profile", "email"] }));
-router.get("/users/google/callback", passport.authenticate("google", { session: false, failureRedirect: "/" }), async (req, res, next) => {
-	try {
-		console.log(req.user);
-		const accessToken = req.user.generateAccessToken();
-                const refreshToken = await req.user.generateRefreshToken(buildRequestTokenDescriptor(req));
+router.get(
+        "/users/google/callback",
+        passport.authenticate("google", { session: false, failureRedirect: "/" }),
+        async (req, res) => {
+                const redirectBase =
+                        process.env.CLIENT_REDIRECT_BASE || (process.env.NODE_ENV === "development" ? "http://localhost:3000" : "");
+                const redirectTarget = redirectBase || "/";
 
-		setAuthCookies(res, accessToken, refreshToken);
+                try {
+                        const accessToken = req.user.generateAccessToken();
+                        const refreshToken = await req.user.generateRefreshToken(buildRequestTokenDescriptor(req));
 
-		const redirectBase = process.env.NODE_ENV === "development" ? "http://localhost:3000" : "";
-		return res.redirect(redirectBase || "/");
-	} catch (e) {
-		logger.error(`Google callback token error: ${e.message}`);
-		next(e);
-	}
-});
+                        setAuthCookies(res, accessToken, refreshToken);
+
+                        return res.redirect(redirectTarget);
+                } catch (e) {
+                        logger.error(`Google callback token error: ${e.message}`);
+                        return res.redirect(`${redirectTarget}?authError=google`);
+                }
+        }
+);
 router.post("/users/login", authLimiter, (req, res, next) => {
 	if (!req.body?.user?.email) {
 		return res.status(422).json({ errors: { email: "is required" } });

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -74,16 +74,29 @@ const REFRESH_COOKIE_OPTIONS = {
 };
 
 const CSRF_COOKIE_OPTIONS = {
-	httpOnly: false,
-	secure: process.env.NODE_ENV === "production",
-	sameSite: "strict",
-	path: "/",
+        httpOnly: false,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        path: "/",
+};
+
+const AUTH_SESSION_COOKIE_NAME = "auth-session-present";
+
+const AUTH_SESSION_COOKIE_OPTIONS = {
+        httpOnly: false,
+        secure: process.env.NODE_ENV === "production",
+        sameSite: "strict",
+        path: "/",
 };
 
 const setCsrfCookie = (res) => {
-	const csrfToken = crypto.randomBytes(32).toString("hex");
-	res.cookie("csrfToken", csrfToken, CSRF_COOKIE_OPTIONS);
-	return csrfToken;
+        const csrfToken = crypto.randomBytes(32).toString("hex");
+        res.cookie("csrfToken", csrfToken, CSRF_COOKIE_OPTIONS);
+        return csrfToken;
+};
+
+const setAuthSessionCookie = (res) => {
+        res.cookie(AUTH_SESSION_COOKIE_NAME, "true", AUTH_SESSION_COOKIE_OPTIONS);
 };
 
 const setAuthCookies = (res, accessToken, refreshToken) => {
@@ -91,6 +104,7 @@ const setAuthCookies = (res, accessToken, refreshToken) => {
         if (refreshToken) {
                 res.cookie("jid", refreshToken, REFRESH_COOKIE_OPTIONS);
         }
+        setAuthSessionCookie(res);
         return setCsrfCookie(res);
 };
 
@@ -98,6 +112,7 @@ const clearAuthCookies = (res) => {
         res.clearCookie("token", ACCESS_COOKIE_OPTIONS);
         res.clearCookie("jid", REFRESH_COOKIE_OPTIONS);
         res.clearCookie("csrfToken", CSRF_COOKIE_OPTIONS);
+        res.clearCookie(AUTH_SESSION_COOKIE_NAME, AUTH_SESSION_COOKIE_OPTIONS);
 };
 
 const resolveCurrentRefreshTokenHash = (req, user) => {

--- a/src/helpers/api.js
+++ b/src/helpers/api.js
@@ -9,12 +9,13 @@ export const getApiBase = () => {
 const CSRF_COOKIE_NAME = "csrfToken";
 const CSRF_HEADER_NAME = "x-csrf-token";
 const AUTH_COOKIE_NAME = "authToken";
+const AUTH_SESSION_COOKIE_NAME = "auth-session-present";
 
 const getCookie = (name) => {
-	if (typeof document === "undefined" || !document.cookie) return null;
-	const match = document.cookie
-		.split(";")
-		.map((entry) => entry.trim())
+        if (typeof document === "undefined" || !document.cookie) return null;
+        const match = document.cookie
+                .split(";")
+                .map((entry) => entry.trim())
 		.find((entry) => entry.startsWith(`${name}=`));
 	if (!match) return null;
 	const [, value] = match.split("=");
@@ -22,8 +23,8 @@ const getCookie = (name) => {
 };
 
 const setCookie = (name, value) => {
-	if (!value || typeof document === "undefined") return;
-	const secureFlag = window.location.protocol === "https:" ? "; Secure" : "";
+        if (!value || typeof document === "undefined") return;
+        const secureFlag = window.location.protocol === "https:" ? "; Secure" : "";
 	document.cookie = `${name}=${value}; Path=/; SameSite=Strict${secureFlag}`;
 };
 
@@ -36,9 +37,16 @@ export const getCsrfToken = () => getCookie(CSRF_COOKIE_NAME);
 
 export const setCsrfTokenCookie = (csrfToken) => setCookie(CSRF_COOKIE_NAME, csrfToken);
 
+export const setAuthSessionCookie = () => setCookie(AUTH_SESSION_COOKIE_NAME, "true");
+
+export const clearAuthSessionCookie = () => clearCookie(AUTH_SESSION_COOKIE_NAME);
+
+export const hasAuthSessionCookie = () => Boolean(getCookie(AUTH_SESSION_COOKIE_NAME));
+
 export const clearAuthCookies = () => {
-	clearCookie(AUTH_COOKIE_NAME);
-	clearCookie(CSRF_COOKIE_NAME);
+        clearCookie(AUTH_COOKIE_NAME);
+        clearCookie(CSRF_COOKIE_NAME);
+        clearAuthSessionCookie();
 };
 
 export const buildApiConfig = (authToken, config = {}) => {

--- a/src/slices/authSlice.js
+++ b/src/slices/authSlice.js
@@ -2,7 +2,15 @@ import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
 
 import socketIoHelper from "../helpers/socket";
-import { buildApiConfig, clearAuthCookies, getApiBase, setCsrfTokenCookie } from "../helpers/api";
+import {
+        buildApiConfig,
+        clearAuthCookies,
+        clearAuthSessionCookie,
+        getApiBase,
+        hasAuthSessionCookie,
+        setAuthSessionCookie,
+        setCsrfTokenCookie,
+} from "../helpers/api";
 import { profileMediaUrl } from "../helpers/mediaUrl";
 
 const AUTO_LOGIN_BLOCK_KEY = "disable-auto-login";
@@ -18,12 +26,14 @@ const setAutoLoginBlocked = (blocked) => {
 };
 
 const setAuthSessionPresent = (present) => {
-	if (typeof window === "undefined") return;
-	if (present) {
-		window.localStorage.setItem(AUTH_SESSION_MARKER, "true");
-		return;
-	}
-	window.localStorage.removeItem(AUTH_SESSION_MARKER);
+        if (typeof window === "undefined") return;
+        if (present) {
+                window.localStorage.setItem(AUTH_SESSION_MARKER, "true");
+                setAuthSessionCookie();
+                return;
+        }
+        window.localStorage.removeItem(AUTH_SESSION_MARKER);
+        clearAuthSessionCookie();
 };
 
 const resetAuthFields = (state) => {
@@ -115,8 +125,10 @@ export const refreshAuthToken = createAsyncThunk("auth/refreshAuthToken", async 
 });
 
 export const bootstrapAuth = createAsyncThunk("auth/bootstrapAuth", async (_, { dispatch, rejectWithValue }) => {
-	try {
-		const hasSessionMarker = typeof window !== "undefined" && window.localStorage.getItem(AUTH_SESSION_MARKER) === "true";
+        try {
+                const hasSessionMarker =
+                        typeof window !== "undefined" &&
+                        (window.localStorage.getItem(AUTH_SESSION_MARKER) === "true" || hasAuthSessionCookie());
 
 		if (!hasSessionMarker) {
 			return rejectWithValue("No prior auth session");


### PR DESCRIPTION
## Summary
- set an auth-session-present cookie whenever auth cookies are issued so OAuth logins are recognized
- teach the client to honor the session cookie when bootstrapping authentication and keep it in sync
- clear the marker cookie during logout flows

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69227f78aadc8327aa6e81f59a31bcc4)