### PR TITLE
Fix Google OAuth callback to use frontend host in development

### DIFF
--- a/server/src/config/passport.js
+++ b/server/src/config/passport.js
@@ -30,15 +30,12 @@ class CustomPassport {
 		);
 		passport.use(
 			new GoogleStrategy(
-                                {
-                                        clientID: process.env.GOOGLE_CLIENT_ID,
-                                        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-                                        callbackURL:
-                                                process.env.GOOGLE_CALLBACK_URL ||
-                                                (process.env.NODE_ENV === "development"
-                                                        ? "http://localhost:6001/api/users/google/callback"
-                                                        : "https://rebound.nexus/api/users/google/callback"),
-                                },
+				{
+					clientID: process.env.GOOGLE_CLIENT_ID,
+					clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+					callbackURL:
+						process.env.NODE_ENV === "development" ? "http://localhost:6001/api/users/google/callback" : "https://rebound.nexus/api/users/google/callback",
+				},
 				async function (accessToken, refreshToken, profile, cb) {
 					try {
 						let user = await UserModel.findOne({ googleId: profile.id });

--- a/server/src/config/passport.js
+++ b/server/src/config/passport.js
@@ -36,7 +36,7 @@ class CustomPassport {
                                         callbackURL:
                                                 process.env.GOOGLE_CALLBACK_URL ||
                                                 (process.env.NODE_ENV === "development"
-                                                        ? "http://localhost:3000/api/users/google/callback"
+                                                        ? "http://localhost:6001/api/users/google/callback"
                                                         : "https://rebound.nexus/api/users/google/callback"),
                                 },
 				async function (accessToken, refreshToken, profile, cb) {

--- a/server/src/config/passport.js
+++ b/server/src/config/passport.js
@@ -30,12 +30,15 @@ class CustomPassport {
 		);
 		passport.use(
 			new GoogleStrategy(
-				{
-					clientID: process.env.GOOGLE_CLIENT_ID,
-					clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-					callbackURL:
-						process.env.NODE_ENV === "development" ? "http://localhost:6001/api/users/google/callback" : "https://rebound.nexus/api/users/google/callback",
-				},
+                                {
+                                        clientID: process.env.GOOGLE_CLIENT_ID,
+                                        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+                                        callbackURL:
+                                                process.env.GOOGLE_CALLBACK_URL ||
+                                                (process.env.NODE_ENV === "development"
+                                                        ? "http://localhost:3000/api/users/google/callback"
+                                                        : "https://rebound.nexus/api/users/google/callback"),
+                                },
 				async function (accessToken, refreshToken, profile, cb) {
 					try {
 						let user = await UserModel.findOne({ googleId: profile.id });

--- a/server/src/routes/api/users.js
+++ b/server/src/routes/api/users.js
@@ -120,6 +120,17 @@ const resolveClientRedirectTarget = (req) => {
         return "/";
 };
 
+const resolveCallbackUrl = (req) => {
+        if (process.env.GOOGLE_CALLBACK_URL) return process.env.GOOGLE_CALLBACK_URL;
+
+        const proto = req.get("x-forwarded-proto") || req.protocol;
+        const host = req.get("x-forwarded-host") || req.get("host");
+
+        if (!proto || !host) return null;
+
+        return `${proto}://${host}/api/users/google/callback`;
+};
+
 const withAuthErrorParam = (target) => `${target}${target.includes("?") ? "&" : "?"}authError=google`;
 
 const setCsrfCookie = (res) => {
@@ -354,17 +365,30 @@ router.get(
 
 router.get("/users/google", (req, res, next) => {
         const redirectTarget = resolveClientRedirectTarget(req);
+        const callbackURL = resolveCallbackUrl(req);
+
+        if (!callbackURL) {
+                logger.error("Unable to resolve Google callback URL from request headers");
+                return res.redirect(withAuthErrorParam(redirectTarget));
+        }
 
         return passport.authenticate("google", {
                 scope: ["profile", "email"],
                 state: encodeURIComponent(redirectTarget),
+                callbackURL,
         })(req, res, next);
 });
 router.get("/users/google/callback", (req, res, next) => {
         const redirectTarget = normalizeRedirectTarget(req.query?.state) || resolveClientRedirectTarget(req);
+        const callbackURL = resolveCallbackUrl(req);
         const redirectWithError = () => res.redirect(withAuthErrorParam(redirectTarget));
 
-        return passport.authenticate("google", { session: false }, async (err, user) => {
+        if (!callbackURL) {
+                logger.error("Unable to resolve Google callback URL from request headers");
+                return redirectWithError();
+        }
+
+        return passport.authenticate("google", { session: false, callbackURL }, async (err, user) => {
                 if (err || !user) {
                         if (err) {
                                 logger.error(`Google callback auth error: ${err.message}`);

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import SnackbarMapper from "./components/SnackbarMapper";
 import useDarkTheme from "./helpers/darkTheme";
 import socketIoHelper from "./helpers/socket";
 import { bootstrapAuth, setAuthState, setSocketStatus, verifyUser } from "./slices/authSlice";
+import { hasAuthSessionCookie } from "./helpers/api";
 
 import useCustomAppBar from "./components/CustomAppBar/useCustomAppBar";
 import useWindowDimensions from "./helpers/useWindowDimensions";
@@ -58,11 +59,14 @@ const App = () => {
 		}
 	}, [dispatch]);
 
-	useEffect(() => {
-		if (!authState.initialized && !authState.skipAutoLogin && !authState.authToken) {
-			dispatch(bootstrapAuth());
-		}
-	}, [authState.initialized, authState.skipAutoLogin, authState.authToken, dispatch]);
+        useEffect(() => {
+                if (authState.initialized || authState.authToken) return;
+
+                const hasSessionMarker = hasAuthSessionCookie();
+                if (!authState.skipAutoLogin || hasSessionMarker) {
+                        dispatch(bootstrapAuth());
+                }
+        }, [authState.initialized, authState.skipAutoLogin, authState.authToken, dispatch]);
 
 	const useSocketConnection = (authToken, loggedIn) => {
 		useEffect(() => {


### PR DESCRIPTION
## Summary
- add GOOGLE_CALLBACK_URL override and point default dev callback to frontend host
- ensure OAuth cookies align with Vite dev proxy for Google login

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692287c7ad84832784bd002309167b0d)