### PR TITLE
Fix Google OAuth production callback and proxy headers

### DIFF
--- a/server/nginx/default
+++ b/server/nginx/default
@@ -28,6 +28,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
@@ -41,6 +42,7 @@ server {
 
         proxy_pass http://localhost:6001;
         proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
@@ -99,6 +101,7 @@ server {
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection 'upgrade';
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header Host $host;
         proxy_cache_bypass $http_upgrade;
     }
@@ -111,6 +114,7 @@ server {
 
         proxy_pass http://localhost:6001;
         proxy_http_version 1.1;
+        proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;

--- a/server/src/config/passport.js
+++ b/server/src/config/passport.js
@@ -28,14 +28,19 @@ class CustomPassport {
 				}
 			)
 		);
-		passport.use(
-			new GoogleStrategy(
-				{
-					clientID: process.env.GOOGLE_CLIENT_ID,
-					clientSecret: process.env.GOOGLE_CLIENT_SECRET,
-					callbackURL:
-						process.env.NODE_ENV === "development" ? "http://localhost:6001/api/users/google/callback" : "https://rebound.nexus/api/users/google/callback",
-				},
+                const callbackURL =
+                        process.env.GOOGLE_CALLBACK_URL ||
+                        (process.env.NODE_ENV === "development"
+                                ? "http://localhost:6001/api/users/google/callback"
+                                : "https://www.rebound.nexus/api/users/google/callback");
+
+                passport.use(
+                        new GoogleStrategy(
+                                {
+                                        clientID: process.env.GOOGLE_CLIENT_ID,
+                                        clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+                                        callbackURL,
+                                },
 				async function (accessToken, refreshToken, profile, cb) {
 					try {
 						let user = await UserModel.findOne({ googleId: profile.id });


### PR DESCRIPTION
## Summary
- allow configuring the Google OAuth callback URL with an override and use the production host by default
- forward the original host through nginx proxy headers to keep OAuth redirect generation accurate

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922900186ac8327b60d137d3b6a7f0b)