### PR TITLE
Add mention suggestion bar with tab completion

### DIFF
--- a/src/components/Chat/ChatInput.jsx
+++ b/src/components/Chat/ChatInput.jsx
@@ -1,5 +1,6 @@
-import React, { useRef, useEffect, useMemo, useCallback } from "react";
+import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { styled, useTheme } from "@mui/material/styles";
+import { Box, Chip, Typography } from "@mui/material";
 import Button from "@mui/material/Button";
 import SendIcon from "@mui/icons-material/Send";
 import DOMPurify from "dompurify";
@@ -56,6 +57,20 @@ const EditableDiv = styled("div")(({ theme }) => ({
 // --- Utility helpers ------------------------------------------------------
 const escapeHtml = (text) => text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
+const getMentionQuery = (text = "", caret = 0) => {
+        const beforeCaret = text.slice(0, caret);
+        const lastAt = beforeCaret.lastIndexOf("@");
+        if (lastAt === -1) return null;
+
+        const charBefore = beforeCaret[lastAt - 1];
+        if (charBefore && !/\s/.test(charBefore)) return null;
+
+        const query = beforeCaret.slice(lastAt + 1);
+        if (query.includes("\n")) return null;
+
+        return query;
+};
+
 /** Save cursor position (offset from the start of the editable). */
 function getCaretCharacterOffsetWithin(element) {
 	const selection = window.getSelection();
@@ -92,19 +107,53 @@ function setCaretPosition(element, offset) {
 }
 
 // --- Component ------------------------------------------------------------
+const buildHighlightedHtml = (text, mentions) => {
+        if (!text) return "";
+        const parts = highlightMentions(text, mentions);
+        const raw = parts
+                .map((p) => (p.mention ? `<span class="mention">${escapeHtml(p.text)}</span>` : escapeHtml(p.text)))
+                .join("");
+        return DOMPurify.sanitize(raw);
+};
+
 export default function ChatInput({ message, setMessage, sendMessage, users = [] }) {
-	const theme = useTheme();
-	const divRef = useRef(null);
+        const theme = useTheme();
+        const divRef = useRef(null);
+        const [mentionQuery, setMentionQuery] = useState(null);
+        const [activeMentionIdx, setActiveMentionIdx] = useState(0);
 
 	// Pre‑compute mentions + highlighted markup -----------------------------
-	const mentions = useMemo(() => parseMentions(message, users), [message, users]);
+        const mentions = useMemo(() => parseMentions(message, users), [message, users]);
 
-	const highlightedHTML = useMemo(() => {
-		if (!message) return "";
-		const parts = highlightMentions(message, mentions);
-		const raw = parts.map((p) => (p.mention ? `<span class="mention">${escapeHtml(p.text)}</span>` : escapeHtml(p.text))).join("");
-		return DOMPurify.sanitize(raw);
-	}, [message, mentions]);
+        const highlightedHTML = useMemo(() => buildHighlightedHtml(message, mentions), [message, mentions]);
+
+        const mentionOptions = useMemo(() => {
+                if (mentionQuery === null) return [];
+
+                const normalizedQuery = mentionQuery.toLowerCase();
+                return (
+                        users
+                                .filter((u) => u?.displayName)
+                                .sort((a, b) => a.displayName.localeCompare(b.displayName))
+                                .filter((u) =>
+                                        normalizedQuery
+                                                ? u.displayName.toLowerCase().includes(normalizedQuery)
+                                                : true
+                                )
+                                .slice(0, 5)
+                );
+        }, [mentionQuery, users]);
+
+        useEffect(() => {
+                if (!message) {
+                        setMentionQuery(null);
+                        setActiveMentionIdx(0);
+                }
+        }, [message]);
+
+        useEffect(() => {
+                setActiveMentionIdx((idx) => (mentionOptions.length ? Math.min(idx, mentionOptions.length - 1) : 0));
+        }, [mentionOptions.length]);
 
 	// Keep DOM in sync when `message` changes (e.g. external clear) ---------
 	useEffect(() => {
@@ -119,67 +168,168 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 	}, [highlightedHTML]);
 
 	// Handle input events ----------------------------------------------------
-	const updatePlainText = useCallback(() => {
-		const el = divRef.current;
-		if (!el) return;
-		// textContent drops the markup – perfect for state
-		setMessage(el.textContent);
-	}, [setMessage]);
+        const syncFromDom = useCallback(
+                (resetActiveMention = false) => {
+                        const el = divRef.current;
+                        if (!el) return;
+                        const caret = getCaretCharacterOffsetWithin(el);
+                        const text = el.textContent || "";
+                        setMessage(text);
+                        setMentionQuery(getMentionQuery(text, caret));
+                        if (resetActiveMention) setActiveMentionIdx(0);
+                },
+                [setMessage]
+        );
 
-	const handleInput = useCallback(() => {
-		updatePlainText();
-	}, [updatePlainText]);
+        const handleInput = useCallback(() => {
+                syncFromDom(true);
+        }, [syncFromDom]);
 
-	const handlePaste = (e) => {
-		e.preventDefault();
-		const text = e.clipboardData.getData("text/plain");
-		document.execCommand("insertText", false, text); // execCommand is safe for plain text insertion here.
-	};
+        const handlePaste = (e) => {
+                e.preventDefault();
+                const text = e.clipboardData.getData("text/plain");
+                document.execCommand("insertText", false, text); // execCommand is safe for plain text insertion here.
+                requestAnimationFrame(() => syncFromDom(true));
+        };
 
-	const handleKeyDown = (e) => {
-		if (e.key === "Enter" && !e.shiftKey) {
-			e.preventDefault();
-			const trimmed = divRef.current?.textContent.trim();
-			if (trimmed) {
-				sendMessage();
-				setMessage("");
-				// Clear editable
-				requestAnimationFrame(() => {
-					if (divRef.current) divRef.current.innerHTML = "";
-				});
-			}
-		}
-	};
+        const applyMentionCompletion = useCallback(
+                (user) => {
+                        if (!user?.displayName) return;
+                        const el = divRef.current;
+                        if (!el) return;
 
-	return (
-		<ChatForm onSubmit={(e) => e.preventDefault()}>
-			<EditableDiv
-				ref={divRef}
-				contentEditable
-				suppressContentEditableWarning
-				spellCheck={false}
-				onInput={handleInput}
-				onPaste={handlePaste}
-				onKeyDown={handleKeyDown}
-				aria-label="Chat message input"
-			/>
-			<Button
-				type="button"
-				variant="contained"
-				endIcon={<SendIcon />}
-				sx={{ height: 42 }}
-				onClick={() => {
-					const trimmed = divRef.current?.textContent.trim();
-					if (trimmed) {
-						sendMessage();
-						setMessage("");
-						requestAnimationFrame(() => {
-							if (divRef.current) divRef.current.innerHTML = "";
-						});
-					}
-				}}>
-				Send
-			</Button>
-		</ChatForm>
-	);
+                        const currentText = el.textContent || "";
+                        const caret = getCaretCharacterOffsetWithin(el);
+                        const beforeCaret = currentText.slice(0, caret);
+                        const atIndex = beforeCaret.lastIndexOf("@");
+
+                        if (atIndex === -1) return;
+
+                        const before = currentText.slice(0, atIndex + 1);
+                        const after = currentText.slice(caret);
+                        const withMention = `${before}${user.displayName} `;
+                        const mergedText = `${withMention}${after}`;
+                        const mergedMentions = parseMentions(mergedText, users);
+                        const nextHTML = buildHighlightedHtml(mergedText, mergedMentions);
+
+                        setMessage(mergedText);
+                        setMentionQuery(null);
+                        setActiveMentionIdx(0);
+
+                        requestAnimationFrame(() => {
+                                if (!divRef.current) return;
+                                divRef.current.innerHTML = nextHTML;
+                                setCaretPosition(divRef.current, withMention.length);
+                        });
+                },
+                [setMessage, users]
+        );
+
+        const handleSend = useCallback(() => {
+                const trimmed = divRef.current?.textContent.trim();
+                if (trimmed) {
+                        sendMessage();
+                        setMessage("");
+                        setMentionQuery(null);
+                        setActiveMentionIdx(0);
+                        requestAnimationFrame(() => {
+                                if (divRef.current) divRef.current.innerHTML = "";
+                        });
+                }
+        }, [sendMessage, setMessage]);
+
+        const handleKeyDown = (e) => {
+                if (mentionOptions.length) {
+                        if (e.key === "Tab") {
+                                e.preventDefault();
+                                applyMentionCompletion(mentionOptions[activeMentionIdx]);
+                                return;
+                        }
+                        if (e.key === "ArrowDown") {
+                                e.preventDefault();
+                                setActiveMentionIdx((idx) => (idx + 1) % mentionOptions.length);
+                                return;
+                        }
+                        if (e.key === "ArrowUp") {
+                                e.preventDefault();
+                                setActiveMentionIdx((idx) => (idx - 1 + mentionOptions.length) % mentionOptions.length);
+                                return;
+                        }
+                }
+
+                if (e.key === "Enter" && !e.shiftKey) {
+                        e.preventDefault();
+                        handleSend();
+                }
+        };
+
+        const handleSelectionChange = useCallback(() => {
+                syncFromDom(false);
+        }, [syncFromDom]);
+
+        return (
+                <Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 0.5 }}>
+                        {mentionOptions.length > 0 && (
+                                <Box
+                                        aria-live="polite"
+                                        sx={{
+                                                display: "flex",
+                                                flexWrap: "wrap",
+                                                alignItems: "center",
+                                                gap: 0.5,
+                                                px: 1,
+                                                pt: 0.5,
+                                                pb: 0.5,
+                                                border: `1px solid ${theme.palette.divider}`,
+                                                borderRadius: theme.shape.borderRadius,
+                                                backgroundColor: theme.palette.background.paper,
+                                                overflowX: "auto",
+                                        }}>
+                                        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
+                                                Mention
+                                        </Typography>
+                                        {mentionOptions.map((u, idx) => (
+                                                <Chip
+                                                        key={u.id || u._id || u.displayName}
+                                                        label={u.displayName}
+                                                        size="small"
+                                                        color={idx === activeMentionIdx ? "primary" : "default"}
+                                                        onMouseDown={(evt) => {
+                                                                evt.preventDefault();
+                                                                applyMentionCompletion(u);
+                                                        }}
+                                                        onClick={(evt) => {
+                                                                evt.preventDefault();
+                                                                applyMentionCompletion(u);
+                                                        }}
+                                                        sx={{ cursor: "pointer" }}
+                                                />
+                                        ))}
+                                </Box>
+                        )}
+                        <ChatForm onSubmit={(e) => e.preventDefault()}>
+                                <EditableDiv
+                                        ref={divRef}
+                                        contentEditable
+                                        suppressContentEditableWarning
+                                        spellCheck={false}
+                                        onInput={handleInput}
+                                        onPaste={handlePaste}
+                                        onKeyDown={handleKeyDown}
+                                        onKeyUp={handleSelectionChange}
+                                        onMouseUp={handleSelectionChange}
+                                        onFocus={handleSelectionChange}
+                                        aria-label="Chat message input"
+                                />
+                                <Button
+                                        type="button"
+                                        variant="contained"
+                                        endIcon={<SendIcon />}
+                                        sx={{ height: 42 }}
+                                        onClick={handleSend}>
+                                        Send
+                                </Button>
+                        </ChatForm>
+                </Box>
+        );
 }

--- a/src/components/Chat/ChatInput.jsx
+++ b/src/components/Chat/ChatInput.jsx
@@ -1,22 +1,10 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { styled, useTheme } from "@mui/material/styles";
-import { Box, Chip, Typography } from "@mui/material";
+import { styled, useTheme, darken } from "@mui/material/styles";
+import { Box, Chip, Typography, Paper } from "@mui/material";
 import Button from "@mui/material/Button";
 import SendIcon from "@mui/icons-material/Send";
 import DOMPurify from "dompurify";
 import { parseMentions, highlightMentions } from "../../helpers/mentions";
-
-/** -------------------------------------------------------------------------
- *  Redesigned ChatInput
- *  ------------------------------------------------------------------------
- *  Key goals:
- *   • **No overlay/layer trickery** – a single `contentEditable` element is the
- *     source of truth. This fixes selection, copy‑paste and accessibility woes.
- *   • **Shift+Enter → new line**, bare Enter → submit.
- *   • Mentions (`@username`) are highlighted on‑the‑fly by rewriting the inner
- *     HTML. DOMPurify keeps the content safe.
- *   • Uses only React hooks + MUI `styled`, no external rich‑text libs.
- * ------------------------------------------------------------------------*/
 
 // --- Styled components ----------------------------------------------------
 const ChatForm = styled("form")(({ theme }) => ({
@@ -47,10 +35,19 @@ const EditableDiv = styled("div")(({ theme }) => ({
 	},
 	// mention highlight
 	"& .mention": {
-		backgroundColor: `${theme.palette.warning.main}80`,
-		color: theme.palette.common.white,
-		borderRadius: 4,
-		padding: "0 2px",
+		display: "inline-flex",
+		alignItems: "center",
+		padding: "0 4px",
+		borderRadius: 16,
+		backgroundColor: theme.palette.warning.main,
+		":hover": {
+			cursor: "pointer",
+			backgroundColor: theme.palette.warning.dark,
+		},
+		color: theme.palette.primary.contrastText,
+		fontSize: "0.75rem",
+		lineHeight: "22px",
+		margin: "0 2px",
 	},
 }));
 
@@ -58,17 +55,17 @@ const EditableDiv = styled("div")(({ theme }) => ({
 const escapeHtml = (text) => text.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
 
 const getMentionQuery = (text = "", caret = 0) => {
-        const beforeCaret = text.slice(0, caret);
-        const lastAt = beforeCaret.lastIndexOf("@");
-        if (lastAt === -1) return null;
+	const beforeCaret = text.slice(0, caret);
+	const lastAt = beforeCaret.lastIndexOf("@");
+	if (lastAt === -1) return null;
 
-        const charBefore = beforeCaret[lastAt - 1];
-        if (charBefore && !/\s/.test(charBefore)) return null;
+	const charBefore = beforeCaret[lastAt - 1];
+	if (charBefore && !/\s/.test(charBefore)) return null;
 
-        const query = beforeCaret.slice(lastAt + 1);
-        if (query.includes("\n")) return null;
+	const query = beforeCaret.slice(lastAt + 1);
+	if (query.includes("\n")) return null;
 
-        return query;
+	return query;
 };
 
 /** Save cursor position (offset from the start of the editable). */
@@ -108,52 +105,44 @@ function setCaretPosition(element, offset) {
 
 // --- Component ------------------------------------------------------------
 const buildHighlightedHtml = (text, mentions) => {
-        if (!text) return "";
-        const parts = highlightMentions(text, mentions);
-        const raw = parts
-                .map((p) => (p.mention ? `<span class="mention">${escapeHtml(p.text)}</span>` : escapeHtml(p.text)))
-                .join("");
-        return DOMPurify.sanitize(raw);
+	if (!text) return "";
+	const parts = highlightMentions(text, mentions);
+	const raw = parts.map((p) => (p.mention ? `<span class="mention">${escapeHtml(p.text)}</span>` : escapeHtml(p.text))).join("");
+	return DOMPurify.sanitize(raw);
 };
 
 export default function ChatInput({ message, setMessage, sendMessage, users = [] }) {
-        const theme = useTheme();
-        const divRef = useRef(null);
-        const [mentionQuery, setMentionQuery] = useState(null);
-        const [activeMentionIdx, setActiveMentionIdx] = useState(0);
+	const theme = useTheme();
+	const divRef = useRef(null);
+	const [mentionQuery, setMentionQuery] = useState(null);
+	const [activeMentionIdx, setActiveMentionIdx] = useState(0);
 
 	// Pre‑compute mentions + highlighted markup -----------------------------
-        const mentions = useMemo(() => parseMentions(message, users), [message, users]);
+	const mentions = useMemo(() => parseMentions(message, users), [message, users]);
 
-        const highlightedHTML = useMemo(() => buildHighlightedHtml(message, mentions), [message, mentions]);
+	const highlightedHTML = useMemo(() => buildHighlightedHtml(message, mentions), [message, mentions]);
 
-        const mentionOptions = useMemo(() => {
-                if (mentionQuery === null) return [];
+	const mentionOptions = useMemo(() => {
+		if (mentionQuery === null) return [];
 
-                const normalizedQuery = mentionQuery.toLowerCase();
-                return (
-                        users
-                                .filter((u) => u?.displayName)
-                                .sort((a, b) => a.displayName.localeCompare(b.displayName))
-                                .filter((u) =>
-                                        normalizedQuery
-                                                ? u.displayName.toLowerCase().includes(normalizedQuery)
-                                                : true
-                                )
-                                .slice(0, 5)
-                );
-        }, [mentionQuery, users]);
+		const normalizedQuery = mentionQuery.toLowerCase();
+		return users
+			.filter((u) => u?.displayName)
+			.sort((a, b) => a.displayName.localeCompare(b.displayName))
+			.filter((u) => (normalizedQuery ? u.displayName.toLowerCase().includes(normalizedQuery) : true))
+			.slice(0, 5);
+	}, [mentionQuery, users]);
 
-        useEffect(() => {
-                if (!message) {
-                        setMentionQuery(null);
-                        setActiveMentionIdx(0);
-                }
-        }, [message]);
+	useEffect(() => {
+		if (!message) {
+			setMentionQuery(null);
+			setActiveMentionIdx(0);
+		}
+	}, [message]);
 
-        useEffect(() => {
-                setActiveMentionIdx((idx) => (mentionOptions.length ? Math.min(idx, mentionOptions.length - 1) : 0));
-        }, [mentionOptions.length]);
+	useEffect(() => {
+		setActiveMentionIdx((idx) => (mentionOptions.length ? Math.min(idx, mentionOptions.length - 1) : 0));
+	}, [mentionOptions.length]);
 
 	// Keep DOM in sync when `message` changes (e.g. external clear) ---------
 	useEffect(() => {
@@ -168,168 +157,172 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 	}, [highlightedHTML]);
 
 	// Handle input events ----------------------------------------------------
-        const syncFromDom = useCallback(
-                (resetActiveMention = false) => {
-                        const el = divRef.current;
-                        if (!el) return;
-                        const caret = getCaretCharacterOffsetWithin(el);
-                        const text = el.textContent || "";
-                        setMessage(text);
-                        setMentionQuery(getMentionQuery(text, caret));
-                        if (resetActiveMention) setActiveMentionIdx(0);
-                },
-                [setMessage]
-        );
+	const syncFromDom = useCallback(
+		(resetActiveMention = false) => {
+			const el = divRef.current;
+			if (!el) return;
+			const caret = getCaretCharacterOffsetWithin(el);
+			const text = el.textContent || "";
+			setMessage(text);
+			setMentionQuery(getMentionQuery(text, caret));
+			if (resetActiveMention) setActiveMentionIdx(0);
+		},
+		[setMessage]
+	);
 
-        const handleInput = useCallback(() => {
-                syncFromDom(true);
-        }, [syncFromDom]);
+	const handleInput = useCallback(() => {
+		syncFromDom(true);
+	}, [syncFromDom]);
 
-        const handlePaste = (e) => {
-                e.preventDefault();
-                const text = e.clipboardData.getData("text/plain");
-                document.execCommand("insertText", false, text); // execCommand is safe for plain text insertion here.
-                requestAnimationFrame(() => syncFromDom(true));
-        };
+	const handlePaste = (e) => {
+		e.preventDefault();
+		const text = e.clipboardData.getData("text/plain");
+		document.execCommand("insertText", false, text); // execCommand is safe for plain text insertion here.
+		requestAnimationFrame(() => syncFromDom(true));
+	};
 
-        const applyMentionCompletion = useCallback(
-                (user) => {
-                        if (!user?.displayName) return;
-                        const el = divRef.current;
-                        if (!el) return;
+	const applyMentionCompletion = useCallback(
+		(user) => {
+			if (!user?.displayName) return;
+			const el = divRef.current;
+			if (!el) return;
 
-                        const currentText = el.textContent || "";
-                        const caret = getCaretCharacterOffsetWithin(el);
-                        const beforeCaret = currentText.slice(0, caret);
-                        const atIndex = beforeCaret.lastIndexOf("@");
+			const currentText = el.textContent || "";
+			const caret = getCaretCharacterOffsetWithin(el);
+			const beforeCaret = currentText.slice(0, caret);
+			const atIndex = beforeCaret.lastIndexOf("@");
 
-                        if (atIndex === -1) return;
+			if (atIndex === -1) return;
 
-                        const before = currentText.slice(0, atIndex + 1);
-                        const after = currentText.slice(caret);
-                        const withMention = `${before}${user.displayName} `;
-                        const mergedText = `${withMention}${after}`;
-                        const mergedMentions = parseMentions(mergedText, users);
-                        const nextHTML = buildHighlightedHtml(mergedText, mergedMentions);
+			const before = currentText.slice(0, atIndex + 1);
+			const after = currentText.slice(caret);
+			const withMention = `${before}${user.displayName} `;
+			const mergedText = `${withMention}${after}`;
+			const mergedMentions = parseMentions(mergedText, users);
+			const nextHTML = buildHighlightedHtml(mergedText, mergedMentions);
 
-                        setMessage(mergedText);
-                        setMentionQuery(null);
-                        setActiveMentionIdx(0);
+			setMessage(mergedText);
+			setMentionQuery(null);
+			setActiveMentionIdx(0);
 
-                        requestAnimationFrame(() => {
-                                if (!divRef.current) return;
-                                divRef.current.innerHTML = nextHTML;
-                                setCaretPosition(divRef.current, withMention.length);
-                        });
-                },
-                [setMessage, users]
-        );
+			requestAnimationFrame(() => {
+				if (!divRef.current) return;
+				divRef.current.innerHTML = nextHTML;
+				setCaretPosition(divRef.current, withMention.length);
+			});
+		},
+		[setMessage, users]
+	);
 
-        const handleSend = useCallback(() => {
-                const trimmed = divRef.current?.textContent.trim();
-                if (trimmed) {
-                        sendMessage();
-                        setMessage("");
-                        setMentionQuery(null);
-                        setActiveMentionIdx(0);
-                        requestAnimationFrame(() => {
-                                if (divRef.current) divRef.current.innerHTML = "";
-                        });
-                }
-        }, [sendMessage, setMessage]);
+	const handleSend = useCallback(() => {
+		const trimmed = divRef.current?.textContent.trim();
+		if (trimmed) {
+			sendMessage();
+			setMessage("");
+			setMentionQuery(null);
+			setActiveMentionIdx(0);
+			requestAnimationFrame(() => {
+				if (divRef.current) divRef.current.innerHTML = "";
+			});
+		}
+	}, [sendMessage, setMessage]);
 
-        const handleKeyDown = (e) => {
-                if (mentionOptions.length) {
-                        if (e.key === "Tab") {
-                                e.preventDefault();
-                                applyMentionCompletion(mentionOptions[activeMentionIdx]);
-                                return;
-                        }
-                        if (e.key === "ArrowDown") {
-                                e.preventDefault();
-                                setActiveMentionIdx((idx) => (idx + 1) % mentionOptions.length);
-                                return;
-                        }
-                        if (e.key === "ArrowUp") {
-                                e.preventDefault();
-                                setActiveMentionIdx((idx) => (idx - 1 + mentionOptions.length) % mentionOptions.length);
-                                return;
-                        }
-                }
+	const handleKeyDown = (e) => {
+		if (mentionOptions.length) {
+			if (e.key === "Tab") {
+				e.preventDefault();
+				applyMentionCompletion(mentionOptions[activeMentionIdx]);
+				return;
+			}
+			if (e.key === "ArrowDown") {
+				e.preventDefault();
+				setActiveMentionIdx((idx) => (idx + 1) % mentionOptions.length);
+				return;
+			}
+			if (e.key === "ArrowUp") {
+				e.preventDefault();
+				setActiveMentionIdx((idx) => (idx - 1 + mentionOptions.length) % mentionOptions.length);
+				return;
+			}
+		}
 
-                if (e.key === "Enter" && !e.shiftKey) {
-                        e.preventDefault();
-                        handleSend();
-                }
-        };
+		if (e.key === "Enter" && !e.shiftKey) {
+			e.preventDefault();
+			handleSend();
+		}
+	};
 
-        const handleSelectionChange = useCallback(() => {
-                syncFromDom(false);
-        }, [syncFromDom]);
+	const handleSelectionChange = useCallback(() => {
+		syncFromDom(false);
+	}, [syncFromDom]);
 
-        return (
-                <Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 0.5 }}>
-                        {mentionOptions.length > 0 && (
-                                <Box
-                                        aria-live="polite"
-                                        sx={{
-                                                display: "flex",
-                                                flexWrap: "wrap",
-                                                alignItems: "center",
-                                                gap: 0.5,
-                                                px: 1,
-                                                pt: 0.5,
-                                                pb: 0.5,
-                                                border: `1px solid ${theme.palette.divider}`,
-                                                borderRadius: theme.shape.borderRadius,
-                                                backgroundColor: theme.palette.background.paper,
-                                                overflowX: "auto",
-                                        }}>
-                                        <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600 }}>
-                                                Mention
-                                        </Typography>
-                                        {mentionOptions.map((u, idx) => (
-                                                <Chip
-                                                        key={u.id || u._id || u.displayName}
-                                                        label={u.displayName}
-                                                        size="small"
-                                                        color={idx === activeMentionIdx ? "primary" : "default"}
-                                                        onMouseDown={(evt) => {
-                                                                evt.preventDefault();
-                                                                applyMentionCompletion(u);
-                                                        }}
-                                                        onClick={(evt) => {
-                                                                evt.preventDefault();
-                                                                applyMentionCompletion(u);
-                                                        }}
-                                                        sx={{ cursor: "pointer" }}
-                                                />
-                                        ))}
-                                </Box>
-                        )}
-                        <ChatForm onSubmit={(e) => e.preventDefault()}>
-                                <EditableDiv
-                                        ref={divRef}
-                                        contentEditable
-                                        suppressContentEditableWarning
-                                        spellCheck={false}
-                                        onInput={handleInput}
-                                        onPaste={handlePaste}
-                                        onKeyDown={handleKeyDown}
-                                        onKeyUp={handleSelectionChange}
-                                        onMouseUp={handleSelectionChange}
-                                        onFocus={handleSelectionChange}
-                                        aria-label="Chat message input"
-                                />
-                                <Button
-                                        type="button"
-                                        variant="contained"
-                                        endIcon={<SendIcon />}
-                                        sx={{ height: 42 }}
-                                        onClick={handleSend}>
-                                        Send
-                                </Button>
-                        </ChatForm>
-                </Box>
-        );
+	return (
+		<Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 0.5 }}>
+			{mentionOptions.length > 0 && (
+				<Box
+					aria-live="polite"
+					sx={{
+						display: "flex",
+						flexWrap: "wrap",
+						alignItems: "center",
+						gap: 0.5,
+						px: 2,
+						py: 1,
+						mx: 1,
+						mb: -0.5,
+						border: `2px solid ${theme.palette.divider}`,
+						backgroundColor: `${darken(theme.palette.background.paper, 0.05)}`,
+						borderRadius: 2,
+						overflowX: "auto",
+						":hover": {
+							backgroundColor: `${darken(theme.palette.background.paper, 0.125)}`,
+						},
+					}}>
+					<Typography variant="caption" color="text.secondary" sx={{ fontWeight: 600, pr: 1 }}>
+						Mention:
+					</Typography>
+					{mentionOptions.map((u, idx) => (
+						<Chip
+							key={u.id || u._id || u.displayName}
+							label={`@${escapeHtml(u.displayName)}`}
+							size="small"
+							sx={{
+								backgroundColor: theme.palette.warning.main,
+								":hover": {
+									cursor: "pointer",
+									backgroundColor: theme.palette.warning.dark,
+								},
+							}}
+							onMouseDown={(evt) => {
+								evt.preventDefault();
+								applyMentionCompletion(u);
+							}}
+							onClick={(evt) => {
+								evt.preventDefault();
+								applyMentionCompletion(u);
+							}}
+						/>
+					))}
+				</Box>
+			)}
+			<ChatForm onSubmit={(e) => e.preventDefault()}>
+				<EditableDiv
+					ref={divRef}
+					contentEditable
+					suppressContentEditableWarning
+					spellCheck={false}
+					onInput={handleInput}
+					onPaste={handlePaste}
+					onKeyDown={handleKeyDown}
+					onKeyUp={handleSelectionChange}
+					onMouseUp={handleSelectionChange}
+					onFocus={handleSelectionChange}
+					aria-label="Chat message input"
+				/>
+				<Button type="button" variant="contained" endIcon={<SendIcon />} sx={{ height: 42 }} onClick={handleSend}>
+					Send
+				</Button>
+			</ChatForm>
+		</Box>
+	);
 }

--- a/src/components/Chat/IndividualMessage.jsx
+++ b/src/components/Chat/IndividualMessage.jsx
@@ -149,7 +149,18 @@ function IndividualMessage({
 									key={p.key}
 									style={
 										p.mention
-											? { backgroundColor: `${theme.palette.warning.main}80`, color: theme.palette.common.white, borderRadius: 4, padding: "0 2px" }
+											? {
+													display: "inline-flex",
+													alignItems: "center",
+													padding: "0 4px",
+													borderRadius: 16,
+													backgroundColor: theme.palette.warning.main,
+													cursor: "pointer",
+													color: theme.palette.primary.contrastText,
+													fontSize: "0.75rem",
+													lineHeight: "22px",
+													margin: "0 2px",
+												}
 											: {}
 									}>
 									{p.text}

--- a/src/helpers/mentions.js
+++ b/src/helpers/mentions.js
@@ -1,14 +1,17 @@
+const escapeRegExp = (value = "") => value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
 export function parseMentions(text, users = []) {
-	const mentions = [];
-	users.forEach((u) => {
-		if (!u?.displayName || !u?.id) return;
-		const regex = new RegExp(`@${u.displayName}\\b`, "g");
-		let m;
-		while ((m = regex.exec(text)) !== null) {
-			mentions.push({ user: u.id, start: m.index, end: m.index + m[0].length });
-		}
-	});
-	return mentions;
+        const mentions = [];
+        users.forEach((u) => {
+                const userId = u?.id ?? u?._id;
+                if (!u?.displayName || !userId) return;
+                const regex = new RegExp(`@${escapeRegExp(u.displayName)}\\b`, "g");
+                let m;
+                while ((m = regex.exec(text)) !== null) {
+                        mentions.push({ user: userId, start: m.index, end: m.index + m[0].length });
+                }
+        });
+        return mentions;
 }
 
 export function highlightMentions(text, mentions) {


### PR DESCRIPTION
## Summary
- add a mention suggestion bar above the chat input that surfaces up to five room users and supports click or tab completion
- track caret-driven mention queries to keep suggestions in sync and retain cursor position when inserting names or clearing the input
- reuse shared send handling so clearing the editor and mention state works consistently on desktop and mobile

## Testing
- pnpm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692391da04fc83278a51924c6f597444)