### PR TITLE
Refactor chat page hooks

### DIFF
--- a/server/src/routes/api/chat.js
+++ b/server/src/routes/api/chat.js
@@ -1,6 +1,8 @@
+import mongoose from "mongoose";
 import { Router } from "express";
 import { auth } from "../auth.js";
 import RoomModel from "../../models/Room.js";
+import MessageModel from "../../models/Message.js";
 import logger from "../../logger.js";
 import rateLimit from "express-rate-limit";
 
@@ -15,25 +17,56 @@ const messagesLimiter = rateLimit({
 });
 
 router.get("/rooms/:roomId/messages", messagesLimiter, auth.required, async (req, res, next) => {
-	const { roomId } = req.params;
-	try {
-		const room = await RoomModel.findById(roomId)
-			.populate({
-				path: "messages",
-				options: { sort: { createdAt: 1 } },
-				populate: { path: "sender", select: "displayName avatarUrl" },
-			})
-			.lean();
+        const { roomId } = req.params;
+        const { before, after, limit: limitParam } = req.query;
+        const DEFAULT_LIMIT = 50;
 
-		if (!room) return res.sendStatus(404);
+        try {
+                const room = await RoomModel.findById(roomId).select("messages").lean();
+                if (!room) return res.sendStatus(404);
 
-		const total = room.messages.length;
+                const messageIds = room.messages ?? [];
+                const limit = Math.min(Math.max(parseInt(limitParam, 10) || DEFAULT_LIMIT, 1), 100);
 
-		return res.json({ messages: room.messages, total });
-	} catch (err) {
-		logger.error("Error fetching messages:", err);
-		return next(err);
-	}
+                const cursorQuery = { _id: { $in: messageIds } };
+                const buildCursor = (value, operator) => {
+                        if (!value) return;
+                        try {
+                                const objectId = new mongoose.Types.ObjectId(value);
+                                cursorQuery._id[operator] = objectId;
+                        } catch (err) {
+                                throw new Error("Invalid cursor value supplied.");
+                        }
+                };
+
+                buildCursor(before, "$lt");
+                buildCursor(after, "$gt");
+
+                const results = await MessageModel.find(cursorQuery)
+                        .sort({ _id: -1 })
+                        .limit(limit + 1)
+                        .populate({ path: "sender", select: "displayName avatarUrl" })
+                        .lean();
+
+                const hasExtra = results.length > limit;
+                const messages = results.slice(0, limit).reverse();
+
+                const pageInfo = {
+                        hasMoreBefore: before || !after ? hasExtra : false,
+                        hasMoreAfter: Boolean(after && hasExtra),
+                        nextBefore: messages[0]?._id ?? null,
+                        nextAfter: messages[messages.length - 1]?._id ?? null,
+                };
+
+                return res.json({ messages, pageInfo });
+        } catch (err) {
+                if (err.message === "Invalid cursor value supplied.") {
+                        return res.status(400).json({ error: err.message });
+                }
+
+                logger.error("Error fetching messages:", err);
+                return next(err);
+        }
 });
 
 export default router;

--- a/server/src/socketio/rooms.js
+++ b/server/src/socketio/rooms.js
@@ -5,6 +5,21 @@ import UserModel from "../models/User.js";
 import socketio from "./index.js";
 import "dotenv/config";
 
+const MESSAGE_LIMIT = 50;
+
+async function fetchRecentMessages(roomDoc, limit = MESSAGE_LIMIT) {
+        const messageIds = roomDoc?.messages ?? [];
+        if (!messageIds.length) return [];
+
+        const messages = await MessageModel.find({ _id: { $in: messageIds } })
+                .sort({ _id: -1 })
+                .limit(limit)
+                .populate({ path: "sender", select: "displayName avatarUrl" })
+                .lean();
+
+        return messages.reverse();
+}
+
 class ServerRooms {
 	async getRoomList() {
 		const idToName = {};
@@ -21,23 +36,29 @@ class ServerRooms {
 		await this.leaveRooms(socket);
 	}
 
-	async joinRoom(socket, roomId, roomDoc) {
-		socket.join(roomId);
-		socket.emit("joined_room", roomId, roomDoc.messages);
+        async joinRoom(socket, roomId, roomDoc) {
+                socket.join(roomId);
 
-		try {
-			const user = await UserModel.findById(socket.user.id);
-			const userProfile = await user.toProfilePubJSON(null);
-			const [usersInRoom, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
+                try {
+                        const messages = await fetchRecentMessages(roomDoc);
+                        socket.emit("joined_room", roomId, messages);
+                } catch (err) {
+                        logger.error("Error loading initial room messages:", err);
+                }
 
-			socketsInRoom.forEach((s) => {
-				s.emit("user_list", roomId, usersInRoom, userProfile, "join");
-			});
-			logger.info(`User '${socket.user.username}' joined room '${roomId}'.`);
-		} catch (err) {
-			logger.error("Error notifying join:", err);
-		}
-	}
+                try {
+                        const user = await UserModel.findById(socket.user.id);
+                        const userProfile = await user.toProfilePubJSON(null);
+                        const [usersInRoom, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
+
+                        socketsInRoom.forEach((s) => {
+                                s.emit("user_list", roomId, usersInRoom, userProfile, "join");
+                        });
+                        logger.info(`User '${socket.user.username}' joined room '${roomId}'.`);
+                } catch (err) {
+                        logger.error("Error notifying join:", err);
+                }
+        }
 
 	async leaveRooms(socket) {
 		try {
@@ -107,16 +128,12 @@ class ServerRooms {
 					throw new Error("Room not found by ID.");
 				}
 
-				const roomDoc = await RoomModel.findById(roomId).populate({
-					path: "messages",
-					options: { sort: { createdAt: 1 } },
-					populate: { path: "sender", select: "displayName avatarUrl" },
-				});
+                                const roomDoc = await RoomModel.findById(roomId);
 
-				await this.leaveRooms(socket);
-				await this.joinRoom(socket, roomId, roomDoc);
-			} catch (err) {
-				logger.error("Error joining room:", err);
+                                await this.leaveRooms(socket);
+                                await this.joinRoom(socket, roomId, roomDoc);
+                        } catch (err) {
+                                logger.error("Error joining room:", err);
 			}
 		});
 
@@ -156,66 +173,58 @@ class ServerRooms {
 					throw new Error("Room not found by ID.");
 				}
 
-				const sender = await UserModel.findById(socket.user.id);
-				if (!sender) throw new Error("Sender not found.");
+                                const sender = await UserModel.findById(socket.user.id);
+                                if (!sender) throw new Error("Sender not found.");
 
                                 const msg = new MessageModel({ sender, content, mentions });
-				await msg.save();
+                                await msg.save();
 
-				const roomDoc = await RoomModel.findById(roomId);
-				roomDoc.messages.push(msg);
-				await roomDoc.save();
+                                const roomDoc = await RoomModel.findById(roomId);
+                                roomDoc.messages.push(msg);
+                                await roomDoc.save();
+                                await msg.populate({ path: "sender", select: "displayName avatarUrl" });
 
-				await roomDoc.populate({
-					path: "messages",
-					options: { sort: { createdAt: 1 } },
-					populate: { path: "sender", select: "displayName avatarUrl" },
-				});
+                                const [usersInRoom, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
+                                socketsInRoom.forEach((s) => {
+                                        if (s.user.id === socket.user.id) {
+                                                s.emit("message_sent", roomId, msg);
+                                        } else {
+                                                s.emit("new_message", roomId, msg);
+                                        }
+                                });
 
-				const [usersInRoom, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
-				socketsInRoom.forEach((s) => {
-					if (s.user.id === socket.user.id) {
-						s.emit("message_sent", roomId, roomDoc.messages);
-					} else {
-						s.emit("new_message", roomId, roomDoc.messages);
-					}
-				});
-
-				logger.info(`User '${socket.user.username}' sent message '${msg._id}' to room '${roomId}'.`);
-			} catch (err) {
-				logger.error("Error handling message_room:", err);
-			}
-		});
+                                logger.info(`User '${socket.user.username}' sent message '${msg._id}' to room '${roomId}'.`);
+                        } catch (err) {
+                                logger.error("Error handling message_room:", err);
+                        }
+                });
 
                 socket.on("edit_message", async (roomId, messageId, content, mentions) => {
-			try {
-				const [idToName] = await this.getRoomList();
-				if (!idToName[roomId]) {
-					throw new Error("Room not found by ID.");
-				}
+                        try {
+                                const [idToName] = await this.getRoomList();
+                                if (!idToName[roomId]) {
+                                        throw new Error("Room not found by ID.");
+                                }
 
-				const msg = await MessageModel.findById(messageId);
-				if (!msg) return;
-				if (msg.sender.toString() !== socket.user.id) return;
+                                const roomDoc = await RoomModel.findById(roomId).select("messages");
+                                const msg = await MessageModel.findById(messageId);
+                                if (!msg) return;
+                                if (msg.sender.toString() !== socket.user.id) return;
+                                if (!roomDoc?.messages?.some((m) => m.toString() === messageId)) return;
 
                                 msg.content = content;
                                 msg.mentions = mentions;
                                 await msg.save();
+                                await msg.populate({ path: "sender", select: "displayName avatarUrl" });
 
-				const roomDoc = await RoomModel.findById(roomId).populate({
-					path: "messages",
-					options: { sort: { createdAt: 1 } },
-					populate: { path: "sender", select: "displayName avatarUrl" },
-				});
-
-				const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
-				socketsInRoom.forEach((s) => {
-					s.emit("messages_updated", roomId, roomDoc.messages);
-				});
-			} catch (err) {
-				logger.error("Error handling edit_message:", err);
-			}
-		});
+                                const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
+                                socketsInRoom.forEach((s) => {
+                                        s.emit("messages_updated", roomId, { type: "edit", message: msg });
+                                });
+                        } catch (err) {
+                                logger.error("Error handling edit_message:", err);
+                        }
+                });
 
 		socket.on("delete_message", async (roomId, messageId) => {
 			try {
@@ -228,25 +237,22 @@ class ServerRooms {
 				if (!msg) return;
 				if (msg.sender.toString() !== socket.user.id) return;
 
-				await MessageModel.deleteOne({ _id: messageId });
-				await RoomModel.findByIdAndUpdate(roomId, {
-					$pull: { messages: messageId },
-				});
+                                const roomDoc = await RoomModel.findById(roomId).select("messages");
+                                if (!roomDoc?.messages?.some((m) => m.toString() === messageId)) return;
 
-				const roomDoc = await RoomModel.findById(roomId).populate({
-					path: "messages",
-					options: { sort: { createdAt: 1 } },
-					populate: { path: "sender", select: "displayName avatarUrl" },
-				});
+                                await MessageModel.deleteOne({ _id: messageId });
+                                await RoomModel.findByIdAndUpdate(roomId, {
+                                        $pull: { messages: messageId },
+                                });
 
-				const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
-				socketsInRoom.forEach((s) => {
-					s.emit("messages_updated", roomId, roomDoc.messages);
-				});
-			} catch (err) {
-				logger.error("Error handling delete_message:", err);
-			}
-		});
+                                const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
+                                socketsInRoom.forEach((s) => {
+                                        s.emit("messages_updated", roomId, { type: "delete", messageId });
+                                });
+                        } catch (err) {
+                                logger.error("Error handling delete_message:", err);
+                        }
+                });
 	}
 }
 

--- a/src/components/Chat/ChatArea.jsx
+++ b/src/components/Chat/ChatArea.jsx
@@ -15,8 +15,8 @@ function ChatArea({ messages, previewUser, onContextMenu, editingMessageId, edit
 			overflowX: "hidden",
 			overflowY: "auto",
 			padding: 1,
-			display: "flex",
-			flexDirection: "column-reverse",
+                        display: "flex",
+                        flexDirection: "column",
 			...scrollbarStyles,
 		}),
 		[]

--- a/src/components/Chat/ChatArea.jsx
+++ b/src/components/Chat/ChatArea.jsx
@@ -15,15 +15,30 @@ function ChatArea({ messages, previewUser, onContextMenu, editingMessageId, edit
 			overflowX: "hidden",
 			overflowY: "auto",
 			padding: 1,
-                        display: "flex",
-                        flexDirection: "column",
+			display: "flex",
+			flexDirection: "column",
 			...scrollbarStyles,
 		}),
 		[]
 	);
 
+	React.useEffect(() => {
+		console.log(listRef);
+		if (listRef.current) {
+			// Attach the event listener
+			listRef.current.addEventListener("scrollend", onScroll);
+		}
+
+		// Cleanup function: remove the event listener when the component unmounts
+		return () => {
+			if (listRef.current) {
+				listRef.current.removeEventListener("scrollend", onScroll);
+			}
+		};
+	}, []);
+
 	return (
-		<Box sx={boxStyles} onScroll={onScroll} ref={listRef}>
+		<Box sx={boxStyles} ref={listRef}>
 			<List disablePadding>
 				<ConstructedMessages
 					relevantMsgs={messages}

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -41,13 +41,13 @@ function ChatPage() {
 		previewUser,
 		openMessageMenu,
 		closeMessageMenu,
-                startEditSelectedMessage,
-                confirmDeleteSelectedMessage,
-                commitEditMessage,
-                cancelEditMessage,
-                handleScroll,
-                listRef,
-        } = useChatPage();
+		startEditSelectedMessage,
+		confirmDeleteSelectedMessage,
+		commitEditMessage,
+		cancelEditMessage,
+		handleScroll,
+		listRef,
+	} = useChatPage();
 
 	return (
 		<Box
@@ -123,17 +123,17 @@ function ChatPage() {
 						previewUser={previewUser}
 						onContextMenu={openMessageMenu}
 						editingMessageId={editingMessageId}
-                                                editingText={editingText}
-                                                setEditingText={setEditingText}
-                                                commitEdit={commitEditMessage}
-                                                cancelEdit={cancelEditMessage}
-                                                listRef={listRef}
-                                                onScroll={handleScroll}
-                                        />
-                                </Box>
+						editingText={editingText}
+						setEditingText={setEditingText}
+						commitEdit={commitEditMessage}
+						cancelEdit={cancelEditMessage}
+						listRef={listRef}
+						onScroll={handleScroll}
+					/>
+				</Box>
 
 				{/* input */}
-                                <ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} users={users} />
+				<ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} users={users} />
 			</Paper>
 		</Box>
 	);

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -41,12 +41,13 @@ function ChatPage() {
 		previewUser,
 		openMessageMenu,
 		closeMessageMenu,
-		startEditSelectedMessage,
-		confirmDeleteSelectedMessage,
-		commitEditMessage,
-		cancelEditMessage,
-		listRef,
-	} = useChatPage();
+                startEditSelectedMessage,
+                confirmDeleteSelectedMessage,
+                commitEditMessage,
+                cancelEditMessage,
+                handleScroll,
+                listRef,
+        } = useChatPage();
 
 	return (
 		<Box
@@ -122,13 +123,14 @@ function ChatPage() {
 						previewUser={previewUser}
 						onContextMenu={openMessageMenu}
 						editingMessageId={editingMessageId}
-						editingText={editingText}
-						setEditingText={setEditingText}
-						commitEdit={commitEditMessage}
-						cancelEdit={cancelEditMessage}
-						listRef={listRef}
-					/>
-				</Box>
+                                                editingText={editingText}
+                                                setEditingText={setEditingText}
+                                                commitEdit={commitEditMessage}
+                                                cancelEdit={cancelEditMessage}
+                                                listRef={listRef}
+                                                onScroll={handleScroll}
+                                        />
+                                </Box>
 
 				{/* input */}
                                 <ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} users={users} />

--- a/src/routes/ChatPage/hooks/useChatMessages.js
+++ b/src/routes/ChatPage/hooks/useChatMessages.js
@@ -5,175 +5,163 @@ const MESSAGE_PAGE_SIZE = 50;
 const SCROLL_TRIGGER_PX = 150;
 
 export default function useChatMessages(authState, dispatch) {
-        const [messages, setMessages] = useState([]);
-        const listRef = useRef(null);
-        const fetchingRef = useRef(false);
-        const pageInfoRef = useRef({ hasMoreBefore: false, hasMoreAfter: false, nextBefore: null, nextAfter: null });
-        const loadingOlderRef = useRef(false);
-        const initialFetchRoomRef = useRef(null);
-        const topFetchLockedRef = useRef(false);
-        const rearmScrollTopRef = useRef(SCROLL_TRIGGER_PX * 2);
-        const lastScrollTopRef = useRef(0);
+	const [messages, setMessages] = useState([]);
+	const listRef = useRef(null);
+	const fetchingRef = useRef(false);
+	const pageInfoRef = useRef({
+		hasMoreBefore: false,
+		hasMoreAfter: false,
+		nextBefore: null,
+		nextAfter: null,
+	});
+	const loadingOlderRef = useRef(false);
+	const initialFetchRoomRef = useRef(null);
 
-        const mergeMessages = useCallback((existing, incoming) => {
-                const merged = new Map();
-                existing.forEach((msg) => merged.set(msg._id, msg));
-                incoming.forEach((msg) => merged.set(msg._id, msg));
+	const mergeMessages = useCallback((existing, incoming) => {
+		const merged = new Map();
+		existing.forEach((msg) => merged.set(msg._id, msg));
+		incoming.forEach((msg) => merged.set(msg._id, msg));
 
-                return Array.from(merged.values()).sort(
-                        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
-                );
-        }, []);
+		return Array.from(merged.values()).sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime());
+	}, []);
 
-        const updatePageInfo = useCallback((pageInfo = {}, nextMessages = []) => {
-                pageInfoRef.current = {
-                        hasMoreBefore: pageInfo.hasMoreBefore ?? pageInfoRef.current.hasMoreBefore,
-                        hasMoreAfter: pageInfo.hasMoreAfter ?? pageInfoRef.current.hasMoreAfter,
-                        nextBefore: pageInfo.nextBefore ?? nextMessages[0]?._id ?? pageInfoRef.current.nextBefore,
-                        nextAfter:
-                                pageInfo.nextAfter ?? nextMessages[nextMessages.length - 1]?._id ?? pageInfoRef.current.nextAfter,
-                };
-        }, []);
+	const updatePageInfo = useCallback((pageInfo = {}, nextMessages = []) => {
+		pageInfoRef.current = {
+			hasMoreBefore: pageInfo.hasMoreBefore ?? pageInfoRef.current.hasMoreBefore,
+			hasMoreAfter: pageInfo.hasMoreAfter ?? pageInfoRef.current.hasMoreAfter,
+			nextBefore: pageInfo.nextBefore ?? (nextMessages[0] && nextMessages[0]._id) ?? pageInfoRef.current.nextBefore,
+			nextAfter: pageInfo.nextAfter ?? (nextMessages[nextMessages.length - 1] && nextMessages[nextMessages.length - 1]._id) ?? pageInfoRef.current.nextAfter,
+		};
+	}, []);
 
-        const scrollToBottom = useCallback(() => {
-                const el = listRef.current;
-                if (!el) return;
-                el.scrollTop = el.scrollHeight;
-        }, []);
+	const scrollToBottom = useCallback(() => {
+		const el = listRef.current;
+		if (!el) return;
+		el.scrollTop = el.scrollHeight;
+	}, []);
 
-        const isNearBottom = useCallback(() => {
-                const el = listRef.current;
-                if (!el) return false;
-                return el.scrollHeight - el.clientHeight - el.scrollTop < SCROLL_TRIGGER_PX;
-        }, []);
+	const isNearBottom = useCallback(() => {
+		const el = listRef.current;
+		if (!el) return false;
+		return el.scrollHeight - el.clientHeight - el.scrollTop < SCROLL_TRIGGER_PX;
+	}, []);
 
-        const fetchMessages = useCallback(
-                async (roomOverride) => {
-                        const roomId = roomOverride || authState.socketInfo.currentRoom;
-                        if (!roomId || fetchingRef.current || !authState.authToken) return;
-                        fetchingRef.current = true;
-                        try {
-                                const { messages: msgs, pageInfo } = await dispatch(
-                                        fetchRoomMessages({
-                                                roomId,
-                                                authToken: authState.authToken,
-                                                limit: MESSAGE_PAGE_SIZE,
-                                        })
-                                ).unwrap();
-                                const mapped = msgs || [];
-                                setMessages(mapped);
-                                updatePageInfo(pageInfo, mapped);
-                                requestAnimationFrame(scrollToBottom);
-                        } catch (err) {
-                                console.error("load messages error", err);
-                        } finally {
-                                fetchingRef.current = false;
-                        }
-                },
-                [authState.authToken, authState.socketInfo.currentRoom, dispatch, scrollToBottom, updatePageInfo]
-        );
+	const fetchMessages = useCallback(
+		async (roomOverride) => {
+			const roomId = roomOverride || authState.socketInfo.currentRoom;
+			if (!roomId || fetchingRef.current || !authState.authToken) return;
 
-        const fetchOlderMessages = useCallback(async () => {
-                if (
-                        !authState.socketInfo.currentRoom ||
-                        fetchingRef.current ||
-                        !pageInfoRef.current.hasMoreBefore ||
-                        !pageInfoRef.current.nextBefore
-                ) {
-                        return;
-                }
+			fetchingRef.current = true;
+			try {
+				const { messages: msgs, pageInfo } = await dispatch(
+					fetchRoomMessages({
+						roomId,
+						authToken: authState.authToken,
+						limit: MESSAGE_PAGE_SIZE,
+					})
+				).unwrap();
 
-                fetchingRef.current = true;
-                loadingOlderRef.current = true;
-                const el = listRef.current;
-                const previousScrollHeight = el?.scrollHeight ?? 0;
-                const previousScrollTop = el?.scrollTop ?? 0;
+				const mapped = msgs || [];
+				setMessages(mapped);
+				updatePageInfo(pageInfo, mapped);
+				requestAnimationFrame(scrollToBottom);
+			} catch (err) {
+				console.error("load messages error", err);
+			} finally {
+				fetchingRef.current = false;
+			}
+		},
+		[authState.authToken, authState.socketInfo.currentRoom, dispatch, scrollToBottom, updatePageInfo]
+	);
 
-                try {
-                        const { messages: olderMessages, pageInfo } = await dispatch(
-                                fetchRoomMessages({
-                                        roomId: authState.socketInfo.currentRoom,
-                                        authToken: authState.authToken,
-                                        before: pageInfoRef.current.nextBefore,
-                                        limit: MESSAGE_PAGE_SIZE,
-                                })
-                        ).unwrap();
+	const fetchOlderMessages = useCallback(async () => {
+		const { currentRoom } = authState.socketInfo;
+		const { hasMoreBefore, nextBefore } = pageInfoRef.current;
 
-                        const mapped = olderMessages || [];
-                        setMessages((prev) => {
-                                const merged = mergeMessages(mapped, prev);
-                                updatePageInfo(pageInfo, merged);
-                                return merged;
-                        });
+		if (!currentRoom || fetchingRef.current || !hasMoreBefore || !nextBefore) {
+			console.log(authState, fetchingRef, hasMoreBefore, nextBefore);
+			return;
+		}
 
-                        requestAnimationFrame(() => {
-                                if (!el) return;
-                                const newHeight = el.scrollHeight;
-                                const adjustedTop = newHeight - previousScrollHeight + previousScrollTop;
-                                el.scrollTop = adjustedTop;
-                                lastScrollTopRef.current = adjustedTop;
+		fetchingRef.current = true;
+		loadingOlderRef.current = true;
 
-                                rearmScrollTopRef.current = adjustedTop + SCROLL_TRIGGER_PX;
+		const el = listRef.current;
+		const previousScrollHeight = el?.scrollHeight ?? 0;
+		const previousScrollTop = el?.scrollTop ?? 0;
 
-                                if (adjustedTop > SCROLL_TRIGGER_PX * 2) {
-                                        topFetchLockedRef.current = false;
-                                }
-                        });
-                } catch (err) {
-                        console.error("load older messages error", err);
-                } finally {
-                        fetchingRef.current = false;
-                        loadingOlderRef.current = false;
-                }
-        }, [authState.authToken, authState.socketInfo.currentRoom, dispatch, mergeMessages, updatePageInfo]);
+		try {
+			const { messages: olderMessages, pageInfo } = await dispatch(
+				fetchRoomMessages({
+					roomId: currentRoom,
+					authToken: authState.authToken,
+					before: nextBefore,
+					limit: MESSAGE_PAGE_SIZE,
+				})
+			).unwrap();
 
-        const handleScroll = useCallback(
-                (e) => {
-                        const { scrollTop } = e.target;
-                        const scrollingUp = scrollTop < lastScrollTopRef.current;
-                        lastScrollTopRef.current = scrollTop;
+			const mapped = olderMessages || [];
+			setMessages((prev) => {
+				const merged = mergeMessages(mapped, prev);
+				updatePageInfo(pageInfo, merged);
+				return merged;
+			});
 
-                        if (loadingOlderRef.current || fetchingRef.current) return;
+			// Preserve scroll position relative to messages after prepending
+			requestAnimationFrame(() => {
+				if (!el) return;
+				const newHeight = el.scrollHeight;
+				const adjustedTop = newHeight - previousScrollHeight + previousScrollTop;
+				el.scrollTop = adjustedTop;
+			});
+		} catch (err) {
+			console.error("load older messages error", err);
+		} finally {
+			fetchingRef.current = false;
+			loadingOlderRef.current = false;
+		}
+	}, [authState.authToken, authState.socketInfo.currentRoom, dispatch, mergeMessages, updatePageInfo]);
 
-                        if (topFetchLockedRef.current) {
-                                if (scrollTop > rearmScrollTopRef.current) {
-                                        topFetchLockedRef.current = false;
-                                }
+	// Now only called on scrollend, so we just check where the scroll finished.
+	const handleScroll = useCallback(
+		(e) => {
+			if (loadingOlderRef.current || fetchingRef.current) return;
 
-                                if (topFetchLockedRef.current) return;
-                        }
+			const target = e.target;
+			const scrollTop = target.scrollTop ?? 0;
 
-                        if (scrollingUp && scrollTop < SCROLL_TRIGGER_PX) {
-                                topFetchLockedRef.current = true;
-                                fetchOlderMessages();
-                        }
-                },
-                [fetchOlderMessages]
-        );
+			if (scrollTop < SCROLL_TRIGGER_PX) {
+				fetchOlderMessages();
+			}
+		},
+		[fetchOlderMessages]
+	);
 
-        const resetRoomState = useCallback(() => {
-                pageInfoRef.current = { hasMoreBefore: false, hasMoreAfter: false, nextBefore: null, nextAfter: null };
-                rearmScrollTopRef.current = SCROLL_TRIGGER_PX * 2;
-                lastScrollTopRef.current = 0;
-                topFetchLockedRef.current = false;
-                loadingOlderRef.current = false;
-                fetchingRef.current = false;
-        }, []);
+	const resetRoomState = useCallback(() => {
+		pageInfoRef.current = {
+			hasMoreBefore: false,
+			hasMoreAfter: false,
+			nextBefore: null,
+			nextAfter: null,
+		};
+		loadingOlderRef.current = false;
+		fetchingRef.current = false;
+	}, []);
 
-        return {
-                messages,
-                setMessages,
-                listRef,
-                handleScroll,
-                fetchMessages,
-                mergeMessages,
-                updatePageInfo,
-                scrollToBottom,
-                isNearBottom,
-                pageInfoRef,
-                fetchingRef,
-                loadingOlderRef,
-                resetRoomState,
-                initialFetchRoomRef,
-        };
+	return {
+		messages,
+		setMessages,
+		listRef,
+		handleScroll,
+		fetchMessages,
+		mergeMessages,
+		updatePageInfo,
+		scrollToBottom,
+		isNearBottom,
+		pageInfoRef,
+		fetchingRef,
+		loadingOlderRef,
+		resetRoomState,
+		initialFetchRoomRef,
+	};
 }

--- a/src/routes/ChatPage/hooks/useChatMessages.js
+++ b/src/routes/ChatPage/hooks/useChatMessages.js
@@ -1,0 +1,179 @@
+import { useState, useCallback, useRef } from "react";
+import { fetchRoomMessages } from "../../../slices/chatApiSlice";
+
+const MESSAGE_PAGE_SIZE = 50;
+const SCROLL_TRIGGER_PX = 150;
+
+export default function useChatMessages(authState, dispatch) {
+        const [messages, setMessages] = useState([]);
+        const listRef = useRef(null);
+        const fetchingRef = useRef(false);
+        const pageInfoRef = useRef({ hasMoreBefore: false, hasMoreAfter: false, nextBefore: null, nextAfter: null });
+        const loadingOlderRef = useRef(false);
+        const initialFetchRoomRef = useRef(null);
+        const topFetchLockedRef = useRef(false);
+        const rearmScrollTopRef = useRef(SCROLL_TRIGGER_PX * 2);
+        const lastScrollTopRef = useRef(0);
+
+        const mergeMessages = useCallback((existing, incoming) => {
+                const merged = new Map();
+                existing.forEach((msg) => merged.set(msg._id, msg));
+                incoming.forEach((msg) => merged.set(msg._id, msg));
+
+                return Array.from(merged.values()).sort(
+                        (a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime()
+                );
+        }, []);
+
+        const updatePageInfo = useCallback((pageInfo = {}, nextMessages = []) => {
+                pageInfoRef.current = {
+                        hasMoreBefore: pageInfo.hasMoreBefore ?? pageInfoRef.current.hasMoreBefore,
+                        hasMoreAfter: pageInfo.hasMoreAfter ?? pageInfoRef.current.hasMoreAfter,
+                        nextBefore: pageInfo.nextBefore ?? nextMessages[0]?._id ?? pageInfoRef.current.nextBefore,
+                        nextAfter:
+                                pageInfo.nextAfter ?? nextMessages[nextMessages.length - 1]?._id ?? pageInfoRef.current.nextAfter,
+                };
+        }, []);
+
+        const scrollToBottom = useCallback(() => {
+                const el = listRef.current;
+                if (!el) return;
+                el.scrollTop = el.scrollHeight;
+        }, []);
+
+        const isNearBottom = useCallback(() => {
+                const el = listRef.current;
+                if (!el) return false;
+                return el.scrollHeight - el.clientHeight - el.scrollTop < SCROLL_TRIGGER_PX;
+        }, []);
+
+        const fetchMessages = useCallback(
+                async (roomOverride) => {
+                        const roomId = roomOverride || authState.socketInfo.currentRoom;
+                        if (!roomId || fetchingRef.current || !authState.authToken) return;
+                        fetchingRef.current = true;
+                        try {
+                                const { messages: msgs, pageInfo } = await dispatch(
+                                        fetchRoomMessages({
+                                                roomId,
+                                                authToken: authState.authToken,
+                                                limit: MESSAGE_PAGE_SIZE,
+                                        })
+                                ).unwrap();
+                                const mapped = msgs || [];
+                                setMessages(mapped);
+                                updatePageInfo(pageInfo, mapped);
+                                requestAnimationFrame(scrollToBottom);
+                        } catch (err) {
+                                console.error("load messages error", err);
+                        } finally {
+                                fetchingRef.current = false;
+                        }
+                },
+                [authState.authToken, authState.socketInfo.currentRoom, dispatch, scrollToBottom, updatePageInfo]
+        );
+
+        const fetchOlderMessages = useCallback(async () => {
+                if (
+                        !authState.socketInfo.currentRoom ||
+                        fetchingRef.current ||
+                        !pageInfoRef.current.hasMoreBefore ||
+                        !pageInfoRef.current.nextBefore
+                ) {
+                        return;
+                }
+
+                fetchingRef.current = true;
+                loadingOlderRef.current = true;
+                const el = listRef.current;
+                const previousScrollHeight = el?.scrollHeight ?? 0;
+                const previousScrollTop = el?.scrollTop ?? 0;
+
+                try {
+                        const { messages: olderMessages, pageInfo } = await dispatch(
+                                fetchRoomMessages({
+                                        roomId: authState.socketInfo.currentRoom,
+                                        authToken: authState.authToken,
+                                        before: pageInfoRef.current.nextBefore,
+                                        limit: MESSAGE_PAGE_SIZE,
+                                })
+                        ).unwrap();
+
+                        const mapped = olderMessages || [];
+                        setMessages((prev) => {
+                                const merged = mergeMessages(mapped, prev);
+                                updatePageInfo(pageInfo, merged);
+                                return merged;
+                        });
+
+                        requestAnimationFrame(() => {
+                                if (!el) return;
+                                const newHeight = el.scrollHeight;
+                                const adjustedTop = newHeight - previousScrollHeight + previousScrollTop;
+                                el.scrollTop = adjustedTop;
+                                lastScrollTopRef.current = adjustedTop;
+
+                                rearmScrollTopRef.current = adjustedTop + SCROLL_TRIGGER_PX;
+
+                                if (adjustedTop > SCROLL_TRIGGER_PX * 2) {
+                                        topFetchLockedRef.current = false;
+                                }
+                        });
+                } catch (err) {
+                        console.error("load older messages error", err);
+                } finally {
+                        fetchingRef.current = false;
+                        loadingOlderRef.current = false;
+                }
+        }, [authState.authToken, authState.socketInfo.currentRoom, dispatch, mergeMessages, updatePageInfo]);
+
+        const handleScroll = useCallback(
+                (e) => {
+                        const { scrollTop } = e.target;
+                        const scrollingUp = scrollTop < lastScrollTopRef.current;
+                        lastScrollTopRef.current = scrollTop;
+
+                        if (loadingOlderRef.current || fetchingRef.current) return;
+
+                        if (topFetchLockedRef.current) {
+                                if (scrollTop > rearmScrollTopRef.current) {
+                                        topFetchLockedRef.current = false;
+                                }
+
+                                if (topFetchLockedRef.current) return;
+                        }
+
+                        if (scrollingUp && scrollTop < SCROLL_TRIGGER_PX) {
+                                topFetchLockedRef.current = true;
+                                fetchOlderMessages();
+                        }
+                },
+                [fetchOlderMessages]
+        );
+
+        const resetRoomState = useCallback(() => {
+                pageInfoRef.current = { hasMoreBefore: false, hasMoreAfter: false, nextBefore: null, nextAfter: null };
+                rearmScrollTopRef.current = SCROLL_TRIGGER_PX * 2;
+                lastScrollTopRef.current = 0;
+                topFetchLockedRef.current = false;
+                loadingOlderRef.current = false;
+                fetchingRef.current = false;
+        }, []);
+
+        return {
+                messages,
+                setMessages,
+                listRef,
+                handleScroll,
+                fetchMessages,
+                mergeMessages,
+                updatePageInfo,
+                scrollToBottom,
+                isNearBottom,
+                pageInfoRef,
+                fetchingRef,
+                loadingOlderRef,
+                resetRoomState,
+                initialFetchRoomRef,
+        };
+}

--- a/src/routes/ChatPage/hooks/useChatSockets.js
+++ b/src/routes/ChatPage/hooks/useChatSockets.js
@@ -1,0 +1,133 @@
+import { useEffect } from "react";
+import { addSnackbar } from "../../../slices/snackbarSlice";
+import { mapMessages } from "../../../slices/chatApiSlice";
+import socketIoHelper from "../../../helpers/socket";
+import { setSocketRoom } from "../../../slices/authSlice";
+
+export default function useChatSockets({
+        authState,
+        dispatch,
+        setChannels,
+        setUsers,
+        setMessages,
+        mergeMessages,
+        updatePageInfo,
+        scrollToBottom,
+        isNearBottom,
+        pageInfoRef,
+}) {
+        useEffect(() => {
+                const socket = socketIoHelper.getSocket();
+                if (authState.loggedIn && socket) {
+                        socket.on("room_list", ([idMap, roomObjs]) => {
+                                setChannels(roomObjs);
+                                if (!authState.socketInfo.currentRoom) {
+                                        dispatch(
+                                                setSocketRoom({
+                                                        lastRoom: null,
+                                                        currentRoom: Object.keys(idMap)[0] || null,
+                                                })
+                                        );
+                                }
+                        });
+                        socket.on("joined_room", async (_id, msgs) => {
+                                const mapped = await mapMessages(msgs || []);
+                                setMessages((prev) => {
+                                        const merged = mergeMessages(prev, mapped);
+                                        updatePageInfo(pageInfoRef.current, merged);
+                                        return merged;
+                                });
+                                if (mapped.length) {
+                                        requestAnimationFrame(scrollToBottom);
+                                }
+                        });
+
+                        const handleIncomingMessage = async (payload) => {
+                                if (!payload) return;
+                                const normalized = Array.isArray(payload) ? payload : [payload];
+                                const mapped = await mapMessages(normalized);
+                                setMessages((prev) => {
+                                        const merged = mergeMessages(prev, mapped);
+                                        updatePageInfo(pageInfoRef.current, merged);
+                                        return merged;
+                                });
+                                if (isNearBottom()) {
+                                        requestAnimationFrame(scrollToBottom);
+                                }
+                        };
+
+                        socket.on("message_sent", async (_id, msg) => {
+                                await handleIncomingMessage(msg);
+                        });
+                        socket.on("new_message", async (_id, msg) => {
+                                await handleIncomingMessage(msg);
+                        });
+                        socket.on("messages_updated", async (_id, payload) => {
+                                if (payload?.type === "delete" && payload.messageId) {
+                                        setMessages((prev) => {
+                                                const filtered = prev.filter((m) => m._id !== payload.messageId);
+                                                updatePageInfo(pageInfoRef.current, filtered);
+                                                return filtered;
+                                        });
+                                        return;
+                                }
+
+                                if (payload?.type === "edit" && payload.message) {
+                                        await handleIncomingMessage(payload.message);
+                                        return;
+                                }
+
+                                await handleIncomingMessage(payload);
+                        });
+                        socket.on("user_list", (_roomId, list, sender, evt) => {
+                                if (sender.id !== authState.userId) {
+                                        dispatch(
+                                                addSnackbar({
+                                                        snackbarMsg: `'${sender.displayName}' ${evt === "join" ? "joined!" : "left."}`,
+                                                        snackbarSeverity: "info",
+                                                        autoHideDuration: 1500,
+                                                })
+                                        );
+                                }
+                                setUsers(list);
+                        });
+                        socket.emit("list_rooms");
+                } else if (!authState.loggingIn && !authState.loggedIn) {
+                        dispatch(
+                                addSnackbar({
+                                        snackbarMsg: "Login or register to use this page.",
+                                        snackbarSeverity: "warning",
+                                        autoHideDuration: 1500,
+                                })
+                        );
+                }
+
+                return () => {
+                        if (socket) {
+                                socket.off("room_list");
+                                socket.off("joined_room");
+                                socket.off("message_sent");
+                                socket.off("new_message");
+                                socket.off("messages_updated");
+                                socket.off("user_list");
+                        }
+                        setChannels({});
+                        setMessages([]);
+                        setUsers([]);
+                };
+        }, [
+                authState.loggedIn,
+                authState.loggingIn,
+                authState.socketInfo.currentRoom,
+                authState.userId,
+                authState.socketInfo.connected,
+                dispatch,
+                isNearBottom,
+                mergeMessages,
+                scrollToBottom,
+                setChannels,
+                setMessages,
+                setUsers,
+                updatePageInfo,
+        ]);
+}

--- a/src/routes/ChatPage/hooks/useRoomLifecycle.js
+++ b/src/routes/ChatPage/hooks/useRoomLifecycle.js
@@ -1,0 +1,40 @@
+import { useEffect } from "react";
+import useWindowDimensions from "../../../helpers/useWindowDimensions";
+
+export default function useRoomLifecycle({
+        authState,
+        fetchMessages,
+        setMessages,
+        setUsers,
+        resetRoomState,
+        initialFetchRoomRef,
+        loadingOlderRef,
+        isNearBottom,
+        scrollToBottom,
+}) {
+        const { width, height } = useWindowDimensions();
+
+        useEffect(() => {
+                if (loadingOlderRef.current) return;
+                if (isNearBottom()) {
+                        requestAnimationFrame(scrollToBottom);
+                }
+        }, [height, isNearBottom, scrollToBottom, width]);
+
+        useEffect(() => {
+                const roomId = authState.socketInfo.currentRoom;
+                setUsers([]);
+                resetRoomState();
+                if (!roomId) {
+                        initialFetchRoomRef.current = null;
+                        setMessages([]);
+                        return;
+                }
+
+                if (initialFetchRoomRef.current === roomId) return;
+
+                initialFetchRoomRef.current = roomId;
+                setMessages([]);
+                fetchMessages(roomId);
+        }, [authState.authToken, authState.socketInfo.currentRoom, fetchMessages, initialFetchRoomRef, resetRoomState, setMessages, setUsers]);
+}

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -1,128 +1,77 @@
-import { useState, useEffect, useRef, useCallback } from "react";
-import useWindowDimensions from "../../helpers/useWindowDimensions";
+import { useState, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { fetchRoomMessages, mapMessages } from "../../slices/chatApiSlice";
 import { parseMentions } from "../../helpers/mentions";
 import { fetchUserProfile } from "../../slices/userApiSlice";
 import socketIoHelper from "../../helpers/socket";
 import { setSocketRoom } from "../../slices/authSlice";
-import { addSnackbar } from "../../slices/snackbarSlice";
-import { getApiBase } from "../../helpers/api";
-
-const REQUEST_BASE = getApiBase();
+import useChatMessages from "./hooks/useChatMessages";
+import useChatSockets from "./hooks/useChatSockets";
+import useRoomLifecycle from "./hooks/useRoomLifecycle";
 
 export default function useChatPage() {
-	const authState = useSelector((state) => state.auth);
-	const dispatch = useDispatch();
+        const authState = useSelector((state) => state.auth);
+        const dispatch = useDispatch();
 
-	const [message, setMessage] = useState("");
-	const [messages, setMessages] = useState([]);
-	const [channels, setChannels] = useState({});
-	const [users, setUsers] = useState([]);
+        const [message, setMessage] = useState("");
+        const [channels, setChannels] = useState({});
+        const [users, setUsers] = useState([]);
 
-	const [roomAnchorEl, setRoomAnchorEl] = useState(null);
-	const [userListAnchorEl, setUserListAnchorEl] = useState(null);
-	const [userPreviewEl, setUserPreviewEl] = useState(null);
-	const [userPreviewUser, setUserPreviewUser] = useState(null);
-	const [msgMenuPos, setMsgMenuPos] = useState(null);
-	const [selectedMessage, setSelectedMessage] = useState(null);
-	const [editingMessageId, setEditingMessageId] = useState(null);
-	const [editingText, setEditingText] = useState("");
-	const listRef = useRef(null);
-	const fetchingRef = useRef(false);
+        const [roomAnchorEl, setRoomAnchorEl] = useState(null);
+        const [userListAnchorEl, setUserListAnchorEl] = useState(null);
+        const [userPreviewEl, setUserPreviewEl] = useState(null);
+        const [userPreviewUser, setUserPreviewUser] = useState(null);
+        const [msgMenuPos, setMsgMenuPos] = useState(null);
+        const [selectedMessage, setSelectedMessage] = useState(null);
+        const [editingMessageId, setEditingMessageId] = useState(null);
+        const [editingText, setEditingText] = useState("");
 
-	const fetchMessages = useCallback(async () => {
-		if (!authState.socketInfo.currentRoom || fetchingRef.current) return;
-		fetchingRef.current = true;
-		try {
-			const { messages: msgs } = await dispatch(fetchRoomMessages({ roomId: authState.socketInfo.currentRoom, authToken: authState.authToken })).unwrap();
-			setMessages(msgs);
-		} catch (err) {
-			console.error("load messages error", err);
-		} finally {
-			fetchingRef.current = false;
-		}
-	}, [authState.socketInfo.currentRoom, authState.authToken, dispatch]);
+        const {
+                messages,
+                setMessages,
+                listRef,
+                handleScroll,
+                fetchMessages,
+                mergeMessages,
+                updatePageInfo,
+                scrollToBottom,
+                isNearBottom,
+                pageInfoRef,
+                loadingOlderRef,
+                resetRoomState,
+                initialFetchRoomRef,
+        } = useChatMessages(authState, dispatch);
 
-	useEffect(() => {
-		const socket = socketIoHelper.getSocket();
-		if (authState.loggedIn && socket) {
-			socket.on("room_list", ([idMap, roomObjs]) => {
-				setChannels(roomObjs);
-				if (!authState.socketInfo.currentRoom) {
-					dispatch(
-						setSocketRoom({
-							lastRoom: null,
-							currentRoom: Object.keys(idMap)[0] || null,
-						})
-					);
-				}
-			});
-			socket.on("joined_room", async (_id, msgs) => {
-				setMessages(await mapMessages(msgs));
-			});
-			socket.on("message_sent", async (_id, msgs) => {
-				setMessages(await mapMessages(msgs));
-			});
-			socket.on("new_message", async (_id, msgs) => {
-				setMessages(await mapMessages(msgs));
-			});
-			socket.on("messages_updated", async (_id, msgs) => {
-				setMessages(await mapMessages(msgs));
-			});
-			socket.on("user_list", (_roomId, list, sender, evt) => {
-				if (sender.id !== authState.userId) {
-					dispatch(
-						addSnackbar({
-							snackbarMsg: `'${sender.displayName}' ${evt === "join" ? "joined!" : "left."}`,
-							snackbarSeverity: "info",
-							autoHideDuration: 1500,
-						})
-					);
-				}
-				setUsers(list);
-			});
-			socket.emit("list_rooms");
-		} else if (!authState.loggingIn && !authState.loggedIn) {
-			dispatch(
-				addSnackbar({
-					snackbarMsg: "Login or register to use this page.",
-					snackbarSeverity: "warning",
-					autoHideDuration: 1500,
-				})
-			);
-		}
+        useChatSockets({
+                authState,
+                dispatch,
+                setChannels,
+                setUsers,
+                setMessages,
+                mergeMessages,
+                updatePageInfo,
+                scrollToBottom,
+                isNearBottom,
+                pageInfoRef,
+        });
 
-		return () => {
-			if (socket) {
-				socket.off("room_list");
-				socket.off("joined_room");
-				socket.off("message_sent");
-				socket.off("new_message");
-				socket.off("messages_updated");
-				socket.off("user_list");
-			}
-			setChannels({});
-			setMessages([]);
-			setUsers([]);
-		};
-	}, [authState.loggedIn, authState.loggingIn, authState.socketInfo.currentRoom, authState.userId, authState.socketInfo.connected, dispatch]);
+        useRoomLifecycle({
+                authState,
+                fetchMessages,
+                setMessages,
+                setUsers,
+                resetRoomState,
+                initialFetchRoomRef,
+                loadingOlderRef,
+                isNearBottom,
+                scrollToBottom,
+        });
 
-	useEffect(() => {
-		setUsers([]);
-	}, [authState.socketInfo.currentRoom]);
-
-	useEffect(() => {
-		setMessages([]);
-		fetchMessages();
-	}, [authState.socketInfo.currentRoom, fetchMessages]);
-
-	useEffect(
-		() => () => {
-			dispatch(setSocketRoom({ currentRoom: null }));
-		},
-		[dispatch]
-	);
+        useEffect(
+                () => () => {
+                        dispatch(setSocketRoom({ currentRoom: null }));
+                },
+                [dispatch]
+        );
 
         const sendMessage = (e) => {
                 e?.preventDefault();
@@ -133,57 +82,59 @@ export default function useChatPage() {
                 setMessage("");
         };
 
-	const clickRoomSelect = (e) => {
-		setRoomAnchorEl(e.currentTarget);
-		setUserListAnchorEl(null);
-	};
+        const clickRoomSelect = (e) => {
+                setRoomAnchorEl(e.currentTarget);
+                setUserListAnchorEl(null);
+        };
 
-	const clickUserList = (e) => {
-		setUserListAnchorEl(e.currentTarget);
-		setRoomAnchorEl(null);
-	};
+        const clickUserList = (e) => {
+                setUserListAnchorEl(e.currentTarget);
+                setRoomAnchorEl(null);
+        };
 
-	const previewUser = async (elRef, u) => {
-		if (!elRef?.current) {
-			setUserPreviewEl(null);
-			setUserPreviewUser(null);
-			return;
-		}
-		if (!u?._id) return;
-		try {
-			const { profile: info } = await dispatch(fetchUserProfile({ userId: u._id, authToken: authState.authToken })).unwrap();
-			if (info) {
-				setUserPreviewEl(elRef.current);
-				setUserPreviewUser(info);
-			}
-		} catch (err) {
-			console.error(err);
-		}
-	};
+        const previewUser = async (elRef, u) => {
+                if (!elRef?.current) {
+                        setUserPreviewEl(null);
+                        setUserPreviewUser(null);
+                        return;
+                }
+                if (!u?._id) return;
+                try {
+                        const { profile: info } = await dispatch(
+                                fetchUserProfile({ userId: u._id, authToken: authState.authToken })
+                        ).unwrap();
+                        if (info) {
+                                setUserPreviewEl(elRef.current);
+                                setUserPreviewUser(info);
+                        }
+                } catch (err) {
+                        console.error(err);
+                }
+        };
 
-	const openMessageMenu = (msg, pos) => {
-		setSelectedMessage(msg);
-		setMsgMenuPos(pos);
-	};
+        const openMessageMenu = (msg, pos) => {
+                setSelectedMessage(msg);
+                setMsgMenuPos(pos);
+        };
 
-	const closeMessageMenu = () => {
-		setMsgMenuPos(null);
-		setSelectedMessage(null);
-	};
+        const closeMessageMenu = () => {
+                setMsgMenuPos(null);
+                setSelectedMessage(null);
+        };
 
-	const startEditSelectedMessage = () => {
-		if (!selectedMessage) return;
-		setEditingMessageId(selectedMessage._id);
-		setEditingText(selectedMessage.content);
-		closeMessageMenu();
-	};
+        const startEditSelectedMessage = () => {
+                if (!selectedMessage) return;
+                setEditingMessageId(selectedMessage._id);
+                setEditingText(selectedMessage.content);
+                closeMessageMenu();
+        };
 
-	const confirmDeleteSelectedMessage = () => {
-		if (!selectedMessage) return;
-		const s = socketIoHelper.getSocket();
-		s.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
-		closeMessageMenu();
-	};
+        const confirmDeleteSelectedMessage = () => {
+                if (!selectedMessage) return;
+                const s = socketIoHelper.getSocket();
+                s.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
+                closeMessageMenu();
+        };
 
         const commitEditMessage = () => {
                 if (!editingMessageId) return;
@@ -194,52 +145,43 @@ export default function useChatPage() {
                 setEditingText("");
         };
 
-	const cancelEditMessage = () => {
-		setEditingMessageId(null);
-		setEditingText("");
-	};
+        const cancelEditMessage = () => {
+                setEditingMessageId(null);
+                setEditingText("");
+        };
 
-	const { width, height } = useWindowDimensions();
-
-	useEffect(() => {
-		const el = listRef.current;
-		if (!el) return;
-		requestAnimationFrame(() => {
-			el.scrollTop = 0;
-		});
-	}, [width, height, messages.length]);
-
-	return {
-		authState,
-		message,
-		setMessage,
-		messages,
-		setMessages,
-		channels,
-		users,
-		roomAnchorEl,
-		setRoomAnchorEl,
-		userListAnchorEl,
-		setUserListAnchorEl,
-		userPreviewEl,
-		setUserPreviewEl,
-		userPreviewUser,
-		setUserPreviewUser,
-		msgMenuPos,
-		selectedMessage,
-		editingMessageId,
-		editingText,
-		setEditingText,
-		sendMessage,
-		clickRoomSelect,
-		clickUserList,
-		previewUser,
-		openMessageMenu,
-		closeMessageMenu,
-		startEditSelectedMessage,
-		confirmDeleteSelectedMessage,
-		commitEditMessage,
-		cancelEditMessage,
-		listRef,
-	};
+        return {
+                authState,
+                message,
+                setMessage,
+                messages,
+                setMessages,
+                channels,
+                users,
+                roomAnchorEl,
+                setRoomAnchorEl,
+                userListAnchorEl,
+                setUserListAnchorEl,
+                userPreviewEl,
+                setUserPreviewEl,
+                userPreviewUser,
+                setUserPreviewUser,
+                msgMenuPos,
+                selectedMessage,
+                editingMessageId,
+                editingText,
+                setEditingText,
+                sendMessage,
+                clickRoomSelect,
+                clickUserList,
+                previewUser,
+                openMessageMenu,
+                closeMessageMenu,
+                startEditSelectedMessage,
+                confirmDeleteSelectedMessage,
+                commitEditMessage,
+                cancelEditMessage,
+                handleScroll,
+                listRef,
+        };
 }

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -9,179 +9,177 @@ import useChatSockets from "./hooks/useChatSockets";
 import useRoomLifecycle from "./hooks/useRoomLifecycle";
 
 export default function useChatPage() {
-        const authState = useSelector((state) => state.auth);
-        const dispatch = useDispatch();
+	const authState = useSelector((state) => state.auth);
+	const dispatch = useDispatch();
 
-        const [message, setMessage] = useState("");
-        const [channels, setChannels] = useState({});
-        const [users, setUsers] = useState([]);
+	const [message, setMessage] = useState("");
+	const [channels, setChannels] = useState({});
+	const [users, setUsers] = useState([]);
 
-        const [roomAnchorEl, setRoomAnchorEl] = useState(null);
-        const [userListAnchorEl, setUserListAnchorEl] = useState(null);
-        const [userPreviewEl, setUserPreviewEl] = useState(null);
-        const [userPreviewUser, setUserPreviewUser] = useState(null);
-        const [msgMenuPos, setMsgMenuPos] = useState(null);
-        const [selectedMessage, setSelectedMessage] = useState(null);
-        const [editingMessageId, setEditingMessageId] = useState(null);
-        const [editingText, setEditingText] = useState("");
+	const [roomAnchorEl, setRoomAnchorEl] = useState(null);
+	const [userListAnchorEl, setUserListAnchorEl] = useState(null);
+	const [userPreviewEl, setUserPreviewEl] = useState(null);
+	const [userPreviewUser, setUserPreviewUser] = useState(null);
+	const [msgMenuPos, setMsgMenuPos] = useState(null);
+	const [selectedMessage, setSelectedMessage] = useState(null);
+	const [editingMessageId, setEditingMessageId] = useState(null);
+	const [editingText, setEditingText] = useState("");
 
-        const {
-                messages,
-                setMessages,
-                listRef,
-                handleScroll,
-                fetchMessages,
-                mergeMessages,
-                updatePageInfo,
-                scrollToBottom,
-                isNearBottom,
-                pageInfoRef,
-                loadingOlderRef,
-                resetRoomState,
-                initialFetchRoomRef,
-        } = useChatMessages(authState, dispatch);
+	const {
+		messages,
+		setMessages,
+		listRef,
+		handleScroll,
+		fetchMessages,
+		mergeMessages,
+		updatePageInfo,
+		scrollToBottom,
+		isNearBottom,
+		pageInfoRef,
+		loadingOlderRef,
+		resetRoomState,
+		initialFetchRoomRef,
+	} = useChatMessages(authState, dispatch);
 
-        useChatSockets({
-                authState,
-                dispatch,
-                setChannels,
-                setUsers,
-                setMessages,
-                mergeMessages,
-                updatePageInfo,
-                scrollToBottom,
-                isNearBottom,
-                pageInfoRef,
-        });
+	useChatSockets({
+		authState,
+		dispatch,
+		setChannels,
+		setUsers,
+		setMessages,
+		mergeMessages,
+		updatePageInfo,
+		scrollToBottom,
+		isNearBottom,
+		pageInfoRef,
+	});
 
-        useRoomLifecycle({
-                authState,
-                fetchMessages,
-                setMessages,
-                setUsers,
-                resetRoomState,
-                initialFetchRoomRef,
-                loadingOlderRef,
-                isNearBottom,
-                scrollToBottom,
-        });
+	useRoomLifecycle({
+		authState,
+		fetchMessages,
+		setMessages,
+		setUsers,
+		resetRoomState,
+		initialFetchRoomRef,
+		loadingOlderRef,
+		isNearBottom,
+		scrollToBottom,
+	});
 
-        useEffect(
-                () => () => {
-                        dispatch(setSocketRoom({ currentRoom: null }));
-                },
-                [dispatch]
-        );
+	useEffect(
+		() => () => {
+			dispatch(setSocketRoom({ currentRoom: null }));
+		},
+		[dispatch]
+	);
 
-        const sendMessage = (e) => {
-                e?.preventDefault();
-                if (!message || !authState.socketInfo.currentRoom) return;
-                const s = socketIoHelper.getSocket();
-                const mentions = parseMentions(message, users);
-                s.emit("message_room", [authState.socketInfo.currentRoom, message, mentions]);
-                setMessage("");
-        };
+	const sendMessage = (e) => {
+		e?.preventDefault();
+		if (!message || !authState.socketInfo.currentRoom) return;
+		const s = socketIoHelper.getSocket();
+		const mentions = parseMentions(message, users);
+		s.emit("message_room", [authState.socketInfo.currentRoom, message, mentions]);
+		setMessage("");
+	};
 
-        const clickRoomSelect = (e) => {
-                setRoomAnchorEl(e.currentTarget);
-                setUserListAnchorEl(null);
-        };
+	const clickRoomSelect = (e) => {
+		setRoomAnchorEl(e.currentTarget);
+		setUserListAnchorEl(null);
+	};
 
-        const clickUserList = (e) => {
-                setUserListAnchorEl(e.currentTarget);
-                setRoomAnchorEl(null);
-        };
+	const clickUserList = (e) => {
+		setUserListAnchorEl(e.currentTarget);
+		setRoomAnchorEl(null);
+	};
 
-        const previewUser = async (elRef, u) => {
-                if (!elRef?.current) {
-                        setUserPreviewEl(null);
-                        setUserPreviewUser(null);
-                        return;
-                }
-                if (!u?._id) return;
-                try {
-                        const { profile: info } = await dispatch(
-                                fetchUserProfile({ userId: u._id, authToken: authState.authToken })
-                        ).unwrap();
-                        if (info) {
-                                setUserPreviewEl(elRef.current);
-                                setUserPreviewUser(info);
-                        }
-                } catch (err) {
-                        console.error(err);
-                }
-        };
+	const previewUser = async (elRef, u) => {
+		if (!elRef?.current) {
+			setUserPreviewEl(null);
+			setUserPreviewUser(null);
+			return;
+		}
+		if (!u?._id) return;
+		try {
+			const { profile: info } = await dispatch(fetchUserProfile({ userId: u._id, authToken: authState.authToken })).unwrap();
+			if (info) {
+				setUserPreviewEl(elRef.current);
+				setUserPreviewUser(info);
+			}
+		} catch (err) {
+			console.error(err);
+		}
+	};
 
-        const openMessageMenu = (msg, pos) => {
-                setSelectedMessage(msg);
-                setMsgMenuPos(pos);
-        };
+	const openMessageMenu = (msg, pos) => {
+		setSelectedMessage(msg);
+		setMsgMenuPos(pos);
+	};
 
-        const closeMessageMenu = () => {
-                setMsgMenuPos(null);
-                setSelectedMessage(null);
-        };
+	const closeMessageMenu = () => {
+		setMsgMenuPos(null);
+		setSelectedMessage(null);
+	};
 
-        const startEditSelectedMessage = () => {
-                if (!selectedMessage) return;
-                setEditingMessageId(selectedMessage._id);
-                setEditingText(selectedMessage.content);
-                closeMessageMenu();
-        };
+	const startEditSelectedMessage = () => {
+		if (!selectedMessage) return;
+		setEditingMessageId(selectedMessage._id);
+		setEditingText(selectedMessage.content);
+		closeMessageMenu();
+	};
 
-        const confirmDeleteSelectedMessage = () => {
-                if (!selectedMessage) return;
-                const s = socketIoHelper.getSocket();
-                s.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
-                closeMessageMenu();
-        };
+	const confirmDeleteSelectedMessage = () => {
+		if (!selectedMessage) return;
+		const s = socketIoHelper.getSocket();
+		s.emit("delete_message", authState.socketInfo.currentRoom, selectedMessage._id);
+		closeMessageMenu();
+	};
 
-        const commitEditMessage = () => {
-                if (!editingMessageId) return;
-                const s = socketIoHelper.getSocket();
-                const mentions = parseMentions(editingText, users);
-                s.emit("edit_message", authState.socketInfo.currentRoom, editingMessageId, editingText, mentions);
-                setEditingMessageId(null);
-                setEditingText("");
-        };
+	const commitEditMessage = () => {
+		if (!editingMessageId) return;
+		const s = socketIoHelper.getSocket();
+		const mentions = parseMentions(editingText, users);
+		s.emit("edit_message", authState.socketInfo.currentRoom, editingMessageId, editingText, mentions);
+		setEditingMessageId(null);
+		setEditingText("");
+	};
 
-        const cancelEditMessage = () => {
-                setEditingMessageId(null);
-                setEditingText("");
-        };
+	const cancelEditMessage = () => {
+		setEditingMessageId(null);
+		setEditingText("");
+	};
 
-        return {
-                authState,
-                message,
-                setMessage,
-                messages,
-                setMessages,
-                channels,
-                users,
-                roomAnchorEl,
-                setRoomAnchorEl,
-                userListAnchorEl,
-                setUserListAnchorEl,
-                userPreviewEl,
-                setUserPreviewEl,
-                userPreviewUser,
-                setUserPreviewUser,
-                msgMenuPos,
-                selectedMessage,
-                editingMessageId,
-                editingText,
-                setEditingText,
-                sendMessage,
-                clickRoomSelect,
-                clickUserList,
-                previewUser,
-                openMessageMenu,
-                closeMessageMenu,
-                startEditSelectedMessage,
-                confirmDeleteSelectedMessage,
-                commitEditMessage,
-                cancelEditMessage,
-                handleScroll,
-                listRef,
-        };
+	return {
+		authState,
+		message,
+		setMessage,
+		messages,
+		setMessages,
+		channels,
+		users,
+		roomAnchorEl,
+		setRoomAnchorEl,
+		userListAnchorEl,
+		setUserListAnchorEl,
+		userPreviewEl,
+		setUserPreviewEl,
+		userPreviewUser,
+		setUserPreviewUser,
+		msgMenuPos,
+		selectedMessage,
+		editingMessageId,
+		editingText,
+		setEditingText,
+		sendMessage,
+		clickRoomSelect,
+		clickUserList,
+		previewUser,
+		openMessageMenu,
+		closeMessageMenu,
+		startEditSelectedMessage,
+		confirmDeleteSelectedMessage,
+		commitEditMessage,
+		cancelEditMessage,
+		handleScroll,
+		listRef,
+	};
 }

--- a/src/slices/chatApiSlice.js
+++ b/src/slices/chatApiSlice.js
@@ -14,17 +14,24 @@ export const mapMessages = (msgs) =>
 		},
 	}));
 
-export const fetchRoomMessages = createAsyncThunk("chatApi/fetchRoomMessages", async ({ roomId, authToken }, { rejectWithValue }) => {
-	try {
-                const { data } = await axios.get(
-                        `${base}/rooms/${roomId}/messages`,
-                        buildApiConfig(authToken)
-                );
-		return { roomId, messages: await mapMessages(data.messages) };
-	} catch (err) {
-		return rejectWithValue(err.response?.data || err.message);
-	}
-});
+export const fetchRoomMessages = createAsyncThunk(
+        "chatApi/fetchRoomMessages",
+        async ({ roomId, authToken, before, after, limit }, { rejectWithValue }) => {
+                try {
+                        const params = new URLSearchParams();
+                        if (before) params.append("before", before);
+                        if (after) params.append("after", after);
+                        if (limit) params.append("limit", limit);
+
+                        const query = params.toString();
+                        const url = `${base}/rooms/${roomId}/messages${query ? `?${query}` : ""}`;
+                        const { data } = await axios.get(url, buildApiConfig(authToken));
+                        return { roomId, messages: await mapMessages(data.messages), pageInfo: data.pageInfo };
+                } catch (err) {
+                        return rejectWithValue(err.response?.data || err.message);
+                }
+        }
+);
 
 const chatApiSlice = createSlice({
 	name: "chatApi",
@@ -39,10 +46,10 @@ const chatApiSlice = createSlice({
 		},
 	},
 	extraReducers: (builder) => {
-		builder.addCase(fetchRoomMessages.fulfilled, (state, action) => {
-			state.messages[action.payload.roomId] = action.payload.messages;
-		});
-	},
+                builder.addCase(fetchRoomMessages.fulfilled, (state, action) => {
+                        state.messages[action.payload.roomId] = action.payload.messages;
+                });
+        },
 });
 
 export const { clearMessages } = chatApiSlice.actions;


### PR DESCRIPTION
## Summary
- split chat page state into dedicated hooks for messages/pagination, sockets, and room lifecycle
- compose the chat page hook from the new modules while preserving message actions and scroll behavior

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923a10cfbfc83278491c2e9df073d3f)