### PR TITLE
Improve chat pagination feedback

### DIFF
--- a/src/components/Chat/ChatArea.jsx
+++ b/src/components/Chat/ChatArea.jsx
@@ -1,43 +1,82 @@
-import { Box, List } from "@mui/material";
+import { Box, CircularProgress, List, Typography } from "@mui/material";
 import React, { useMemo } from "react";
 
 import { scrollbarStyles } from "../../routes/scrollbarStyles";
 import ConstructedMessages from "./ConstructedMessages";
 
-function ChatArea({ messages, previewUser, onContextMenu, editingMessageId, editingText, setEditingText, commitEdit, cancelEdit, onScroll, listRef }) {
-	const boxStyles = useMemo(
-		() => ({
-			position: "absolute",
-			left: "0px",
-			top: "0px",
-			right: "0px",
-			bottom: "0px",
-			overflowX: "hidden",
-			overflowY: "auto",
-			padding: 1,
+function ChatArea({
+        messages,
+        previewUser,
+        onContextMenu,
+        editingMessageId,
+        editingText,
+        setEditingText,
+        commitEdit,
+        cancelEdit,
+        onScroll,
+        listRef,
+        hasMoreBefore,
+        isLoadingOlder,
+}) {
+        const boxStyles = useMemo(
+                () => ({
+                        position: "absolute",
+                        left: "0px",
+                        top: "0px",
+                        right: "0px",
+                        bottom: "0px",
+                        overflowX: "hidden",
+                        overflowY: "auto",
+                        padding: 1,
                         display: "flex",
                         flexDirection: "column",
-			...scrollbarStyles,
-		}),
-		[]
-	);
+                        ...scrollbarStyles,
+                }),
+                []
+        );
 
-	return (
-		<Box sx={boxStyles} onScroll={onScroll} ref={listRef}>
-			<List disablePadding>
-				<ConstructedMessages
-					relevantMsgs={messages}
-					previewUser={previewUser}
-					onContextMenu={onContextMenu}
-					editingMessageId={editingMessageId}
-					editingText={editingText}
-					setEditingText={setEditingText}
-					commitEdit={commitEdit}
-					cancelEdit={cancelEdit}
-				/>
-			</List>
-		</Box>
-	);
+        const renderPaginationIndicator = () => {
+                if (isLoadingOlder) {
+                        return <CircularProgress size={18} thickness={4} />;
+                }
+
+                if (hasMoreBefore === false && messages.length > 0) {
+                        return (
+                                <Typography variant="caption" color="text.secondary" sx={{ px: 1 }}>
+                                        You&apos;re all caught up
+                                </Typography>
+                        );
+                }
+
+                return null;
+        };
+
+        return (
+                <Box sx={boxStyles} onScroll={onScroll} ref={listRef}>
+                        <List disablePadding>
+                                <Box
+                                        sx={{
+                                                display: "flex",
+                                                justifyContent: "center",
+                                                alignItems: "center",
+                                                minHeight: 32,
+                                                pb: 1,
+                                        }}>
+                                        {renderPaginationIndicator()}
+                                </Box>
+                                <ConstructedMessages
+                                        relevantMsgs={messages}
+                                        previewUser={previewUser}
+                                        onContextMenu={onContextMenu}
+                                        editingMessageId={editingMessageId}
+                                        editingText={editingText}
+                                        setEditingText={setEditingText}
+                                        commitEdit={commitEdit}
+                                        cancelEdit={cancelEdit}
+                                />
+                        </List>
+                </Box>
+        );
 }
 
 export default ChatArea;

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -29,15 +29,17 @@ function ChatPage() {
 		setUserPreviewEl,
 		userPreviewUser,
 		setUserPreviewUser,
-		selectedMessage,
-		msgMenuPos,
-		editingMessageId,
-		editingText,
-		setEditingText,
-		setMessages,
-		sendMessage,
-		clickRoomSelect,
-		clickUserList,
+                selectedMessage,
+                msgMenuPos,
+                editingMessageId,
+                editingText,
+                isLoadingOlder,
+                pageInfo,
+                setEditingText,
+                setMessages,
+                sendMessage,
+                clickRoomSelect,
+                clickUserList,
 		previewUser,
 		openMessageMenu,
 		closeMessageMenu,
@@ -122,15 +124,17 @@ function ChatPage() {
 						messages={messages}
 						previewUser={previewUser}
 						onContextMenu={openMessageMenu}
-						editingMessageId={editingMessageId}
-                                                editingText={editingText}
-                                                setEditingText={setEditingText}
-                                                commitEdit={commitEditMessage}
-                                                cancelEdit={cancelEditMessage}
-                                                listRef={listRef}
-                                                onScroll={handleScroll}
-                                        />
-                                </Box>
+                                        editingMessageId={editingMessageId}
+                                        editingText={editingText}
+                                        setEditingText={setEditingText}
+                                        commitEdit={commitEditMessage}
+                                        cancelEdit={cancelEditMessage}
+                                        listRef={listRef}
+                                        hasMoreBefore={pageInfo.hasMoreBefore}
+                                        isLoadingOlder={isLoadingOlder}
+                                        onScroll={handleScroll}
+                                />
+                        </Box>
 
 				{/* input */}
                                 <ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} users={users} />

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -141,11 +141,13 @@ function useMessageActions(authState, users) {
 }
 
 function useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNearBottom) {
-	const [messages, setMessages] = useState([]);
-	const pageInfoRef = useRef(initialPageInfo);
-	const fetchingRef = useRef(false);
-	const loadingOlderRef = useRef(false);
-	const initialFetchRoomRef = useRef(null);
+        const [messages, setMessages] = useState([]);
+        const [pageInfo, setPageInfo] = useState(initialPageInfo);
+        const [isLoadingOlder, setIsLoadingOlder] = useState(false);
+        const pageInfoRef = useRef(initialPageInfo);
+        const fetchingRef = useRef(false);
+        const loadingOlderRef = useRef(false);
+        const initialFetchRoomRef = useRef(null);
 
 	const mergeMessages = useCallback((existing, incoming) => {
 		const byId = new Map();
@@ -153,14 +155,23 @@ function useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNe
 		return Array.from(byId.values()).sort((a, b) => new Date(a.createdAt) - new Date(b.createdAt));
 	}, []);
 
-	const updatePageInfo = useCallback((pageInfo = {}, nextMessages = []) => {
-		pageInfoRef.current = {
-			...pageInfoRef.current,
-			...pageInfo,
-			hasMoreBefore: pageInfo.hasMoreBefore ?? pageInfoRef.current.hasMoreBefore,
-			nextBefore: pageInfo.nextBefore ?? nextMessages[0]?._id ?? pageInfoRef.current.nextBefore,
-		};
-	}, []);
+        const updatePageInfo = useCallback(
+                (nextPageInfo = {}, nextMessages = []) => {
+                        const mergedPageInfo = {
+                                ...pageInfoRef.current,
+                                ...nextPageInfo,
+                                hasMoreBefore: nextPageInfo.hasMoreBefore ?? pageInfoRef.current.hasMoreBefore,
+                                nextBefore:
+                                        nextPageInfo.nextBefore ??
+                                        nextMessages[0]?._id ??
+                                        pageInfoRef.current.nextBefore,
+                        };
+
+                        pageInfoRef.current = mergedPageInfo;
+                        setPageInfo(mergedPageInfo);
+                },
+                []
+        );
 
 	const fetchMessages = useCallback(
 		async (roomOverride) => {
@@ -196,10 +207,11 @@ function useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNe
 		}
 
 		fetchingRef.current = true;
-		loadingOlderRef.current = true;
-		const el = listRef.current;
-		const prevHeight = el?.scrollHeight ?? 0;
-		const prevTop = el?.scrollTop ?? 0;
+                loadingOlderRef.current = true;
+                setIsLoadingOlder(true);
+                const el = listRef.current;
+                const prevHeight = el?.scrollHeight ?? 0;
+                const prevTop = el?.scrollTop ?? 0;
 
 		try {
 			const { messages: olderMessages, pageInfo } = await dispatch(
@@ -223,13 +235,14 @@ function useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNe
 				const delta = el.scrollHeight - prevHeight;
 				el.scrollTop = prevTop + delta;
 			});
-		} catch (err) {
-			console.error("load older messages error", err);
-		} finally {
-			fetchingRef.current = false;
-			loadingOlderRef.current = false;
-		}
-	}, [authState.authToken, authState.socketInfo, dispatch, listRef, mergeMessages, updatePageInfo]);
+                } catch (err) {
+                        console.error("load older messages error", err);
+                } finally {
+                        fetchingRef.current = false;
+                        loadingOlderRef.current = false;
+                        setIsLoadingOlder(false);
+                }
+        }, [authState.authToken, authState.socketInfo, dispatch, listRef, mergeMessages, updatePageInfo]);
 
 	const handleScroll = useCallback(
 		(e) => {
@@ -267,14 +280,16 @@ function useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNe
 		[updatePageInfo]
 	);
 
-	const resetAndFetchForRoom = useCallback(
-		(roomId) => {
-			pageInfoRef.current = initialPageInfo;
-			if (!roomId) {
-				initialFetchRoomRef.current = null;
-				setMessages([]);
-				return;
-			}
+        const resetAndFetchForRoom = useCallback(
+                (roomId) => {
+                        pageInfoRef.current = initialPageInfo;
+                        setPageInfo(initialPageInfo);
+                        setIsLoadingOlder(false);
+                        if (!roomId) {
+                                initialFetchRoomRef.current = null;
+                                setMessages([]);
+                                return;
+                        }
 			if (initialFetchRoomRef.current === roomId) return;
 			initialFetchRoomRef.current = roomId;
 			setMessages([]);
@@ -297,12 +312,15 @@ function useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNe
 		fetchOlderMessages,
 		handleDeletedMessage,
 		handleIncomingMessages,
-		handleScroll,
-		loadingOlderRef,
-		messages,
-		resetAndFetchForRoom,
-		syncScrollIfNearBottom,
-	};
+                handleScroll,
+                isLoadingOlder,
+                loadingOlderRef,
+                messages,
+                pageInfo,
+                setMessages,
+                resetAndFetchForRoom,
+                syncScrollIfNearBottom,
+        };
 }
 
 export default function useChatPage() {
@@ -314,17 +332,20 @@ export default function useChatPage() {
 	const [users, setUsers] = useState([]);
 
 	const listRef = useRef(null);
-	const { isNearBottom, scrollToBottom } = useScrollHelpers(listRef);
-	const {
-		fetchOlderMessages,
-		handleDeletedMessage,
-		handleIncomingMessages,
-		handleScroll,
-		loadingOlderRef,
-		messages,
-		resetAndFetchForRoom,
-		syncScrollIfNearBottom,
-	} = useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNearBottom);
+        const { isNearBottom, scrollToBottom } = useScrollHelpers(listRef);
+        const {
+                fetchOlderMessages,
+                handleDeletedMessage,
+                handleIncomingMessages,
+                handleScroll,
+                isLoadingOlder,
+                loadingOlderRef,
+                messages,
+                pageInfo,
+                setMessages,
+                resetAndFetchForRoom,
+                syncScrollIfNearBottom,
+        } = useMessagePagination(authState, dispatch, listRef, scrollToBottom, isNearBottom);
 
 	const { clickRoomSelect, clickUserList, roomAnchorEl, setRoomAnchorEl, setUserListAnchorEl, userListAnchorEl } = useAnchors();
 	const { previewUser, setUserPreviewEl, setUserPreviewUser, userPreviewEl, userPreviewUser } = useUserPreview(authState, dispatch);
@@ -459,28 +480,31 @@ export default function useChatPage() {
 		confirmDeleteSelectedMessage,
 		editingMessageId,
 		editingText,
-		handleScroll,
-		listRef,
-		message,
-		messages,
-		msgMenuPos,
-		openMessageMenu,
-		previewUser,
-		roomAnchorEl,
-		scrollToBottom,
-		selectedMessage,
-		sendMessage,
-		setEditingText,
-		setMessage,
-		setRoomAnchorEl,
-		setUserListAnchorEl,
-		setUserPreviewEl,
-		setUserPreviewUser,
+                handleScroll,
+                isLoadingOlder,
+                listRef,
+                message,
+                messages,
+                msgMenuPos,
+                openMessageMenu,
+                pageInfo,
+                previewUser,
+                roomAnchorEl,
+                scrollToBottom,
+                selectedMessage,
+                sendMessage,
+                setEditingText,
+                setMessage,
+                setMessages,
+                setRoomAnchorEl,
+                setUserListAnchorEl,
+                setUserPreviewEl,
+                setUserPreviewUser,
 		startEditSelectedMessage,
 		userListAnchorEl,
 		userPreviewEl,
-		userPreviewUser,
-		users,
-		fetchOlderMessages,
-	};
+                userPreviewUser,
+                users,
+                fetchOlderMessages,
+        };
 }


### PR DESCRIPTION
## Summary
- expose pagination state for chat history scrolling and return message setter to consumers
- show a top-of-list indicator for loading older messages or when history is exhausted
- reset pagination flags when switching rooms to keep the UI state accurate

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923ddd628ec832798dacb432c50b46c)