### PR TITLE
Improve chat scrollbar rendering

### DIFF
--- a/src/routes/ChatPage/hooks/useChatMessages.js
+++ b/src/routes/ChatPage/hooks/useChatMessages.js
@@ -5,6 +5,17 @@ const MESSAGE_PAGE_SIZE = 50;
 const SCROLL_TRIGGER_PX = 150;
 const SKELETON_BATCH_SIZE = 10;
 
+const getMaxScrollTop = (el) => {
+        if (!el) return 0;
+        return Math.max((el.scrollHeight ?? 0) - (el.clientHeight ?? 0), 0);
+};
+
+const normalizeScrollTop = (el, desiredTop) => {
+        if (!el) return 0;
+        const clampedTop = Math.max(0, Math.min(desiredTop, getMaxScrollTop(el)));
+        return clampedTop;
+};
+
 export default function useChatMessages(authState, dispatch) {
         const [messages, setMessages] = useState([]);
         const [loadingSkeletonCount, setLoadingSkeletonCount] = useState(0);
@@ -38,28 +49,53 @@ export default function useChatMessages(authState, dispatch) {
 		};
 	}, []);
 
+        const renderScrollTop = useCallback((desiredTop, { lock = false, frame = false } = {}) => {
+                const el = listRef.current;
+                if (!el) return null;
+
+                const apply = () => {
+                        const clampedTop = normalizeScrollTop(el, desiredTop);
+                        el.scrollTop = clampedTop;
+                        if (lock) {
+                                scrollLockRef.current = clampedTop;
+                        }
+                        return clampedTop;
+                };
+
+                if (frame) {
+                        requestAnimationFrame(apply);
+                        return null;
+                }
+
+                return apply();
+        }, []);
+
         const scrollToBottom = useCallback(() => {
                 const el = listRef.current;
                 if (!el) return;
-                el.scrollTop = el.scrollHeight;
-        }, []);
+                renderScrollTop(getMaxScrollTop(el));
+        }, [renderScrollTop]);
 
         useEffect(() => {
                 requestAnimationFrame(scrollToBottom);
         }, [scrollToBottom]);
 
-        const clampScrollIfLocked = useCallback((target) => {
-                if (!target || scrollLockRef.current == null) return;
-                if (target.scrollTop < scrollLockRef.current) {
-                        target.scrollTop = scrollLockRef.current;
-                }
-        }, []);
+        const clampScrollIfLocked = useCallback(
+                (target) => {
+                        if (!target || scrollLockRef.current == null) return;
+                        if (target.scrollTop < scrollLockRef.current) {
+                                renderScrollTop(scrollLockRef.current, { lock: true });
+                        }
+                },
+                [renderScrollTop]
+        );
 
-	const isNearBottom = useCallback(() => {
-		const el = listRef.current;
-		if (!el) return false;
-		return el.scrollHeight - el.clientHeight - el.scrollTop < SCROLL_TRIGGER_PX;
-	}, []);
+        const isNearBottom = useCallback(() => {
+                const el = listRef.current;
+                if (!el) return false;
+                const bottomGap = getMaxScrollTop(el) - (el.scrollTop ?? 0);
+                return bottomGap < SCROLL_TRIGGER_PX;
+        }, []);
 
         const fetchMessages = useCallback(
                 async (roomOverride) => {
@@ -81,7 +117,8 @@ export default function useChatMessages(authState, dispatch) {
                                 updatePageInfo(pageInfo, mapped);
                                 requestAnimationFrame(() => {
                                         scrollToBottom();
-                                        scrollLockRef.current = listRef.current?.scrollTop ?? null;
+                                        const el = listRef.current;
+                                        scrollLockRef.current = el ? normalizeScrollTop(el, el.scrollTop ?? 0) : null;
                                 });
                         } catch (err) {
                                 console.error("load messages error", err);
@@ -108,14 +145,14 @@ export default function useChatMessages(authState, dispatch) {
                 loadingOlderRef.current = true;
 
                 const el = listRef.current;
-                const previousScrollHeight = el?.scrollHeight ?? 0;
+                const previousMaxTop = getMaxScrollTop(el);
                 const previousScrollTop = el?.scrollTop ?? 0;
+                const previousBottomOffset = previousMaxTop - previousScrollTop;
 
                 const applyScrollLock = () => {
                         if (!el) return;
                         const lockTarget = Math.max(el.scrollTop ?? 0, SCROLL_TRIGGER_PX);
-                        scrollLockRef.current = lockTarget;
-                        el.scrollTop = lockTarget;
+                        renderScrollTop(lockTarget, { lock: true });
                 };
 
                 applyScrollLock();
@@ -124,10 +161,9 @@ export default function useChatMessages(authState, dispatch) {
                         setLoadingSkeletonCount(SKELETON_BATCH_SIZE);
                         requestAnimationFrame(() => {
                                 if (!listRef.current) return;
-                                const newHeight = listRef.current.scrollHeight;
-                                const adjustedTop = newHeight - previousScrollHeight + previousScrollTop;
-                                listRef.current.scrollTop = adjustedTop;
-                                scrollLockRef.current = adjustedTop;
+                                const newMaxTop = getMaxScrollTop(listRef.current);
+                                const adjustedTop = Math.max(newMaxTop - previousBottomOffset, 0);
+                                renderScrollTop(adjustedTop, { lock: true });
                         });
                 }
 
@@ -150,10 +186,9 @@ export default function useChatMessages(authState, dispatch) {
 
                         requestAnimationFrame(() => {
                                 if (!listRef.current) return;
-                                const newHeight = listRef.current.scrollHeight;
-                                const adjustedTop = newHeight - previousScrollHeight + previousScrollTop;
-                                listRef.current.scrollTop = adjustedTop;
-                                scrollLockRef.current = adjustedTop;
+                                const newMaxTop = getMaxScrollTop(listRef.current);
+                                const adjustedTop = Math.max(newMaxTop - previousBottomOffset, 0);
+                                renderScrollTop(adjustedTop, { lock: true });
                         });
                 } catch (err) {
                         console.error("load older messages error", err);
@@ -183,15 +218,15 @@ export default function useChatMessages(authState, dispatch) {
                         }
 
                         const { hasMoreBefore } = pageInfoRef.current;
-                        const scrollTop = target.scrollTop ?? 0;
+                        const scrollTop = normalizeScrollTop(target, target.scrollTop ?? 0);
 
                         if (scrollTop < SCROLL_TRIGGER_PX && hasMoreBefore) {
-                                scrollLockRef.current = Math.max(scrollTop, SCROLL_TRIGGER_PX);
-                                target.scrollTop = scrollLockRef.current;
+                                const lockTarget = Math.max(scrollTop, SCROLL_TRIGGER_PX);
+                                renderScrollTop(lockTarget, { lock: true });
                                 fetchOlderMessages();
                         }
                 },
-                [clampScrollIfLocked, fetchOlderMessages]
+                [clampScrollIfLocked, fetchOlderMessages, renderScrollTop]
         );
 
         const resetRoomState = useCallback(() => {

--- a/src/routes/ChatPage/hooks/useChatMessages.js
+++ b/src/routes/ChatPage/hooks/useChatMessages.js
@@ -10,9 +10,10 @@ const getMaxScrollTop = (el) => {
         return Math.max((el.scrollHeight ?? 0) - (el.clientHeight ?? 0), 0);
 };
 
-const clampScrollTop = (el, desiredTop) => {
+const normalizeScrollTop = (el, desiredTop) => {
         if (!el) return 0;
-        return Math.max(0, Math.min(desiredTop, getMaxScrollTop(el)));
+        const clampedTop = Math.max(0, Math.min(desiredTop, getMaxScrollTop(el)));
+        return clampedTop;
 };
 
 export default function useChatMessages(authState, dispatch) {
@@ -48,12 +49,12 @@ export default function useChatMessages(authState, dispatch) {
 		};
 	}, []);
 
-        const setScrollTop = useCallback((desiredTop, { lock = false, frame = false } = {}) => {
+        const renderScrollTop = useCallback((desiredTop, { lock = false, frame = false } = {}) => {
                 const el = listRef.current;
                 if (!el) return null;
 
                 const apply = () => {
-                        const clampedTop = clampScrollTop(el, desiredTop);
+                        const clampedTop = normalizeScrollTop(el, desiredTop);
                         el.scrollTop = clampedTop;
                         if (lock) {
                                 scrollLockRef.current = clampedTop;
@@ -72,19 +73,21 @@ export default function useChatMessages(authState, dispatch) {
         const scrollToBottom = useCallback(() => {
                 const el = listRef.current;
                 if (!el) return;
-                setScrollTop(getMaxScrollTop(el), { frame: true });
-        }, [setScrollTop]);
+                renderScrollTop(getMaxScrollTop(el));
+        }, [renderScrollTop]);
 
         useEffect(() => {
-                scrollToBottom();
+                requestAnimationFrame(scrollToBottom);
         }, [scrollToBottom]);
 
         const clampScrollIfLocked = useCallback(
                 (target) => {
                         if (!target || scrollLockRef.current == null) return;
-                        setScrollTop(scrollLockRef.current, { lock: true });
+                        if (target.scrollTop < scrollLockRef.current) {
+                                renderScrollTop(scrollLockRef.current, { lock: true });
+                        }
                 },
-                [setScrollTop]
+                [renderScrollTop]
         );
 
         const isNearBottom = useCallback(() => {
@@ -115,7 +118,7 @@ export default function useChatMessages(authState, dispatch) {
                                 requestAnimationFrame(() => {
                                         scrollToBottom();
                                         const el = listRef.current;
-                                        scrollLockRef.current = el ? clampScrollTop(el, el.scrollTop ?? 0) : null;
+                                        scrollLockRef.current = el ? normalizeScrollTop(el, el.scrollTop ?? 0) : null;
                                 });
                         } catch (err) {
                                 console.error("load messages error", err);
@@ -142,20 +145,27 @@ export default function useChatMessages(authState, dispatch) {
                 loadingOlderRef.current = true;
 
                 const el = listRef.current;
-                const lockedTop = clampScrollTop(el, el?.scrollTop ?? 0);
-                const bottomGap = el ? getMaxScrollTop(el) - lockedTop : 0;
-                scrollLockRef.current = lockedTop;
-                setScrollTop(Math.max(lockedTop, SCROLL_TRIGGER_PX), { lock: true });
+                const previousMaxTop = getMaxScrollTop(el);
+                const previousScrollTop = el?.scrollTop ?? 0;
+                const previousBottomOffset = previousMaxTop - previousScrollTop;
 
-                const restorePosition = () => {
-                        const container = listRef.current;
-                        if (!container) return;
-                        const targetTop = clampScrollTop(container, getMaxScrollTop(container) - bottomGap);
-                        setScrollTop(targetTop, { lock: true });
+                const applyScrollLock = () => {
+                        if (!el) return;
+                        const lockTarget = Math.max(el.scrollTop ?? 0, SCROLL_TRIGGER_PX);
+                        renderScrollTop(lockTarget, { lock: true });
                 };
 
-                setLoadingSkeletonCount(SKELETON_BATCH_SIZE);
-                requestAnimationFrame(restorePosition);
+                applyScrollLock();
+
+                if (hasMoreBefore) {
+                        setLoadingSkeletonCount(SKELETON_BATCH_SIZE);
+                        requestAnimationFrame(() => {
+                                if (!listRef.current) return;
+                                const newMaxTop = getMaxScrollTop(listRef.current);
+                                const adjustedTop = Math.max(newMaxTop - previousBottomOffset, 0);
+                                renderScrollTop(adjustedTop, { lock: true });
+                        });
+                }
 
                 try {
                         const { messages: olderMessages, pageInfo } = await dispatch(
@@ -175,7 +185,10 @@ export default function useChatMessages(authState, dispatch) {
                         });
 
                         requestAnimationFrame(() => {
-                                restorePosition();
+                                if (!listRef.current) return;
+                                const newMaxTop = getMaxScrollTop(listRef.current);
+                                const adjustedTop = Math.max(newMaxTop - previousBottomOffset, 0);
+                                renderScrollTop(adjustedTop, { lock: true });
                         });
                 } catch (err) {
                         console.error("load older messages error", err);
@@ -184,7 +197,6 @@ export default function useChatMessages(authState, dispatch) {
                         loadingOlderRef.current = false;
                         setLoadingSkeletonCount(0);
                         inFlightBeforeRef.current = null;
-                        scrollLockRef.current = null;
                 }
         }, [
                 authState.authToken,
@@ -192,7 +204,6 @@ export default function useChatMessages(authState, dispatch) {
                 dispatch,
                 mergeMessages,
                 updatePageInfo,
-                setScrollTop,
         ]);
 
 	// Now only called on scrollend, so we just check where the scroll finished.
@@ -207,15 +218,15 @@ export default function useChatMessages(authState, dispatch) {
                         }
 
                         const { hasMoreBefore } = pageInfoRef.current;
-                        const scrollTop = clampScrollTop(target, target.scrollTop ?? 0);
+                        const scrollTop = normalizeScrollTop(target, target.scrollTop ?? 0);
 
                         if (scrollTop < SCROLL_TRIGGER_PX && hasMoreBefore) {
                                 const lockTarget = Math.max(scrollTop, SCROLL_TRIGGER_PX);
-                                setScrollTop(lockTarget, { lock: true });
+                                renderScrollTop(lockTarget, { lock: true });
                                 fetchOlderMessages();
                         }
                 },
-                [clampScrollIfLocked, fetchOlderMessages, setScrollTop]
+                [clampScrollIfLocked, fetchOlderMessages, renderScrollTop]
         );
 
         const resetRoomState = useCallback(() => {

--- a/src/routes/ChatPage/hooks/useChatMessages.js
+++ b/src/routes/ChatPage/hooks/useChatMessages.js
@@ -10,10 +10,9 @@ const getMaxScrollTop = (el) => {
         return Math.max((el.scrollHeight ?? 0) - (el.clientHeight ?? 0), 0);
 };
 
-const normalizeScrollTop = (el, desiredTop) => {
+const clampScrollTop = (el, desiredTop) => {
         if (!el) return 0;
-        const clampedTop = Math.max(0, Math.min(desiredTop, getMaxScrollTop(el)));
-        return clampedTop;
+        return Math.max(0, Math.min(desiredTop, getMaxScrollTop(el)));
 };
 
 export default function useChatMessages(authState, dispatch) {
@@ -49,12 +48,12 @@ export default function useChatMessages(authState, dispatch) {
 		};
 	}, []);
 
-        const renderScrollTop = useCallback((desiredTop, { lock = false, frame = false } = {}) => {
+        const setScrollTop = useCallback((desiredTop, { lock = false, frame = false } = {}) => {
                 const el = listRef.current;
                 if (!el) return null;
 
                 const apply = () => {
-                        const clampedTop = normalizeScrollTop(el, desiredTop);
+                        const clampedTop = clampScrollTop(el, desiredTop);
                         el.scrollTop = clampedTop;
                         if (lock) {
                                 scrollLockRef.current = clampedTop;
@@ -73,21 +72,19 @@ export default function useChatMessages(authState, dispatch) {
         const scrollToBottom = useCallback(() => {
                 const el = listRef.current;
                 if (!el) return;
-                renderScrollTop(getMaxScrollTop(el));
-        }, [renderScrollTop]);
+                setScrollTop(getMaxScrollTop(el), { frame: true });
+        }, [setScrollTop]);
 
         useEffect(() => {
-                requestAnimationFrame(scrollToBottom);
+                scrollToBottom();
         }, [scrollToBottom]);
 
         const clampScrollIfLocked = useCallback(
                 (target) => {
                         if (!target || scrollLockRef.current == null) return;
-                        if (target.scrollTop < scrollLockRef.current) {
-                                renderScrollTop(scrollLockRef.current, { lock: true });
-                        }
+                        setScrollTop(scrollLockRef.current, { lock: true });
                 },
-                [renderScrollTop]
+                [setScrollTop]
         );
 
         const isNearBottom = useCallback(() => {
@@ -118,7 +115,7 @@ export default function useChatMessages(authState, dispatch) {
                                 requestAnimationFrame(() => {
                                         scrollToBottom();
                                         const el = listRef.current;
-                                        scrollLockRef.current = el ? normalizeScrollTop(el, el.scrollTop ?? 0) : null;
+                                        scrollLockRef.current = el ? clampScrollTop(el, el.scrollTop ?? 0) : null;
                                 });
                         } catch (err) {
                                 console.error("load messages error", err);
@@ -145,27 +142,20 @@ export default function useChatMessages(authState, dispatch) {
                 loadingOlderRef.current = true;
 
                 const el = listRef.current;
-                const previousMaxTop = getMaxScrollTop(el);
-                const previousScrollTop = el?.scrollTop ?? 0;
-                const previousBottomOffset = previousMaxTop - previousScrollTop;
+                const lockedTop = clampScrollTop(el, el?.scrollTop ?? 0);
+                const bottomGap = el ? getMaxScrollTop(el) - lockedTop : 0;
+                scrollLockRef.current = lockedTop;
+                setScrollTop(Math.max(lockedTop, SCROLL_TRIGGER_PX), { lock: true });
 
-                const applyScrollLock = () => {
-                        if (!el) return;
-                        const lockTarget = Math.max(el.scrollTop ?? 0, SCROLL_TRIGGER_PX);
-                        renderScrollTop(lockTarget, { lock: true });
+                const restorePosition = () => {
+                        const container = listRef.current;
+                        if (!container) return;
+                        const targetTop = clampScrollTop(container, getMaxScrollTop(container) - bottomGap);
+                        setScrollTop(targetTop, { lock: true });
                 };
 
-                applyScrollLock();
-
-                if (hasMoreBefore) {
-                        setLoadingSkeletonCount(SKELETON_BATCH_SIZE);
-                        requestAnimationFrame(() => {
-                                if (!listRef.current) return;
-                                const newMaxTop = getMaxScrollTop(listRef.current);
-                                const adjustedTop = Math.max(newMaxTop - previousBottomOffset, 0);
-                                renderScrollTop(adjustedTop, { lock: true });
-                        });
-                }
+                setLoadingSkeletonCount(SKELETON_BATCH_SIZE);
+                requestAnimationFrame(restorePosition);
 
                 try {
                         const { messages: olderMessages, pageInfo } = await dispatch(
@@ -185,10 +175,7 @@ export default function useChatMessages(authState, dispatch) {
                         });
 
                         requestAnimationFrame(() => {
-                                if (!listRef.current) return;
-                                const newMaxTop = getMaxScrollTop(listRef.current);
-                                const adjustedTop = Math.max(newMaxTop - previousBottomOffset, 0);
-                                renderScrollTop(adjustedTop, { lock: true });
+                                restorePosition();
                         });
                 } catch (err) {
                         console.error("load older messages error", err);
@@ -197,6 +184,7 @@ export default function useChatMessages(authState, dispatch) {
                         loadingOlderRef.current = false;
                         setLoadingSkeletonCount(0);
                         inFlightBeforeRef.current = null;
+                        scrollLockRef.current = null;
                 }
         }, [
                 authState.authToken,
@@ -204,6 +192,7 @@ export default function useChatMessages(authState, dispatch) {
                 dispatch,
                 mergeMessages,
                 updatePageInfo,
+                setScrollTop,
         ]);
 
 	// Now only called on scrollend, so we just check where the scroll finished.
@@ -218,15 +207,15 @@ export default function useChatMessages(authState, dispatch) {
                         }
 
                         const { hasMoreBefore } = pageInfoRef.current;
-                        const scrollTop = normalizeScrollTop(target, target.scrollTop ?? 0);
+                        const scrollTop = clampScrollTop(target, target.scrollTop ?? 0);
 
                         if (scrollTop < SCROLL_TRIGGER_PX && hasMoreBefore) {
                                 const lockTarget = Math.max(scrollTop, SCROLL_TRIGGER_PX);
-                                renderScrollTop(lockTarget, { lock: true });
+                                setScrollTop(lockTarget, { lock: true });
                                 fetchOlderMessages();
                         }
                 },
-                [clampScrollIfLocked, fetchOlderMessages, renderScrollTop]
+                [clampScrollIfLocked, fetchOlderMessages, setScrollTop]
         );
 
         const resetRoomState = useCallback(() => {


### PR DESCRIPTION
## Summary
- add helpers to normalize and render chat scroll positions directly in JavaScript
- clamp lockable scroll positions and preserve bottom offsets during pagination and skeleton rendering
- align near-bottom detection with bounded scrollbar math to respect chat direction

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923e5494fa48327ae50011ac1bddb26)