### PR TITLE
Use cookies for socket authentication

### DIFF
--- a/server/src/socketio/index.js
+++ b/server/src/socketio/index.js
@@ -7,7 +7,7 @@ import serverRooms from "./rooms.js";
 import serverDMs from "./dms.js";
 import serverWatchers from "./watchers.js";
 import UserModel from "../models/User.js";
-import { getAccessToken } from "../routes/auth.js";
+import { getAccessToken, parseCookieHeader } from "../routes/auth.js";
 import { hasPasswordChangedAfterTokenIssue } from "../utils/auth.js";
 
 class SocketBackend {
@@ -15,74 +15,75 @@ class SocketBackend {
 		this.io = null;
 	}
 
-        start(port = 6002) {
-                this.io = new Server({
-                        path: "/socket.io",
-                        cors: { origin: "*" },
-                });
+	start(port = 6002) {
+		this.io = new Server({
+			path: "/socket.io",
+			cors: { origin: true, credentials: true },
+		});
 
-                this.io.use(this._authenticate.bind(this));
+		this.io.use(this._authenticate.bind(this));
 
-                this.io.on("connection", this._onConnection.bind(this));
+		this.io.on("connection", this._onConnection.bind(this));
 
 		this.io.listen(port);
 		logger.info(`Socket.IO listening on port ${port}`);
 	}
 
-        async _authenticate(socket, next) {
-                const token = getAccessToken({ headers: socket.handshake.headers });
-                if (!token) return next(new Error("Authentication error"));
+	async _authenticate(socket, next) {
+		const cookies = parseCookieHeader(socket.handshake.headers?.cookie);
+		const token = getAccessToken({ headers: socket.handshake.headers, cookies });
+		if (!token) return next(new Error("Authentication error"));
 
-                try {
-                        const decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
-                        const user = await UserModel.findById(decoded.id);
+		try {
+			const decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
+			const user = await UserModel.findById(decoded.id);
 
-                        if (!user || !user.active) {
-                                throw new Error("Invalid or inactive user");
-                        }
+			if (!user || !user.active) {
+				throw new Error("Invalid or inactive user");
+			}
 
-                        if (decoded.tokenVersion !== user.tokenVersion) {
-                                throw new Error("Token version mismatch");
-                        }
+			if (decoded.tokenVersion !== user.tokenVersion) {
+				throw new Error("Token version mismatch");
+			}
 
-                        if (hasPasswordChangedAfterTokenIssue(user, decoded)) {
-                                throw new Error("Stale access token");
-                        }
+			if (hasPasswordChangedAfterTokenIssue(user, decoded)) {
+				throw new Error("Stale access token");
+			}
 
-                        socket.user = { id: user._id.toString(), username: user.username, tokenVersion: user.tokenVersion };
-                        next();
-                } catch (err) {
-                        logger.error("Socket authentication error:", err);
-                        next(new Error("Authentication error"));
-                }
-        }
+			socket.user = { id: user._id.toString(), username: user.username, tokenVersion: user.tokenVersion };
+			next();
+		} catch (err) {
+			logger.error("Socket authentication error:", err);
+			next(new Error("Authentication error"));
+		}
+	}
 
-        _onConnection(socket) {
-                logger.info(`User connected: '${socket.user.username}'`);
-                socket.emit("connected");
+	_onConnection(socket) {
+		logger.info(`User connected: '${socket.user.username}'`);
+		socket.emit("connected");
 
-                serverRooms.startListeners(socket);
+		serverRooms.startListeners(socket);
 
-                serverDMs.startListeners(socket);
+		serverDMs.startListeners(socket);
 
-                serverWatchers.init(socket);
+		serverWatchers.init(socket);
 
-                socket.on("disconnect", () => {
-                        logger.info(`User disconnected: '${socket.user.username}'`);
-                        serverRooms.listenerCleanup(socket);
-                        socket.removeAllListeners();
-                });
-        }
+		socket.on("disconnect", () => {
+			logger.info(`User disconnected: '${socket.user.username}'`);
+			serverRooms.listenerCleanup(socket);
+			socket.removeAllListeners();
+		});
+	}
 
-        async getSocketsInRoom(roomId) {
-                const sockets = await this.io.in(roomId).fetchSockets();
-                const profiles = await Promise.all(sockets.map((s) => UserModel.findById(s.user.id).then((u) => u.toProfilePubJSON(null))));
-                return [profiles, sockets];
-        }
+	async getSocketsInRoom(roomId) {
+		const sockets = await this.io.in(roomId).fetchSockets();
+		const profiles = await Promise.all(sockets.map((s) => UserModel.findById(s.user.id).then((u) => u.toProfilePubJSON(null))));
+		return [profiles, sockets];
+	}
 
-        emitToSocketById(socketId, event, payload) {
-                const sock = this.io.sockets.sockets.get(socketId);
-                if (sock) sock.emit(event, payload);
+	emitToSocketById(socketId, event, payload) {
+		const sock = this.io.sockets.sockets.get(socketId);
+		if (sock) sock.emit(event, payload);
 	}
 }
 

--- a/server/src/socketio/index.js
+++ b/server/src/socketio/index.js
@@ -1,5 +1,4 @@
 import { Server } from "socket.io";
-import jwt from "jsonwebtoken";
 import "dotenv/config";
 
 import logger from "../logger.js";
@@ -7,8 +6,7 @@ import serverRooms from "./rooms.js";
 import serverDMs from "./dms.js";
 import serverWatchers from "./watchers.js";
 import UserModel from "../models/User.js";
-import { getAccessToken, parseCookieHeader } from "../routes/auth.js";
-import { hasPasswordChangedAfterTokenIssue } from "../utils/auth.js";
+import { parseCookieHeader, validateAccessToken } from "../utils/auth.js";
 
 class SocketBackend {
 	constructor() {
@@ -31,25 +29,11 @@ class SocketBackend {
 
 	async _authenticate(socket, next) {
 		const cookies = parseCookieHeader(socket.handshake.headers?.cookie);
-		const token = getAccessToken({ headers: socket.handshake.headers, cookies });
+		const token = cookies?.token;
 		if (!token) return next(new Error("Authentication error"));
 
 		try {
-			const decoded = jwt.verify(token, process.env.ACCESS_TOKEN_SECRET);
-			const user = await UserModel.findById(decoded.id);
-
-			if (!user || !user.active) {
-				throw new Error("Invalid or inactive user");
-			}
-
-			if (decoded.tokenVersion !== user.tokenVersion) {
-				throw new Error("Token version mismatch");
-			}
-
-			if (hasPasswordChangedAfterTokenIssue(user, decoded)) {
-				throw new Error("Stale access token");
-			}
-
+			const { user } = await validateAccessToken(token);
 			socket.user = { id: user._id.toString(), username: user.username, tokenVersion: user.tokenVersion };
 			next();
 		} catch (err) {

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -114,7 +114,7 @@ const App = () => {
 
 	useEffect(() => {
 		if (authState.loggedIn && authState.authToken) {
-			dispatch(connectSocket({ userToken: authState.authToken }));
+			dispatch(connectSocket());
 		} else {
 			dispatch(disconnectSocket());
 		}

--- a/src/helpers/socketClient.js
+++ b/src/helpers/socketClient.js
@@ -1,23 +1,15 @@
 import { io } from "socket.io-client";
 
 let socketInstance = null;
-let socketMeta = { url: null, token: null };
+let socketMeta = { url: null };
 
 export const getSocketClient = () => socketInstance;
 export const getSocketMeta = () => socketMeta;
 
-export const updateSocketAuthToken = (token) => {
-	if (!socketInstance) return;
-	socketMeta = { ...socketMeta, token: token ?? null };
-};
-
-export const initSocketClient = (url, token) => {
+export const initSocketClient = (url) => {
 	if (!url) return null;
 
 	if (socketInstance && socketMeta.url === url) {
-		if (socketMeta.token !== token) {
-			updateSocketAuthToken(token);
-		}
 		if (!socketInstance.connected && !socketInstance.connecting) {
 			socketInstance.connect();
 		}
@@ -38,7 +30,7 @@ export const initSocketClient = (url, token) => {
 		transports: ["websocket"],
 		withCredentials: true,
 	});
-	socketMeta = { url, token };
+	socketMeta = { url };
 	return socketInstance;
 };
 
@@ -52,5 +44,5 @@ export const tearDownSocketClient = () => {
 		console.error("Error tearing down socket", err);
 	}
 	socketInstance = null;
-	socketMeta = { url: null, token: null };
+	socketMeta = { url: null };
 };

--- a/src/helpers/socketClient.js
+++ b/src/helpers/socketClient.js
@@ -7,14 +7,12 @@ export const getSocketClient = () => socketInstance;
 export const getSocketMeta = () => socketMeta;
 
 export const updateSocketAuthToken = (token) => {
-	if (!socketInstance || !token) return;
-	socketMeta = { ...socketMeta, token };
-	socketInstance.io.opts.extraHeaders = { Authorization: `Bearer ${token}` };
-	socketInstance.auth = { ...(socketInstance.auth || {}), token };
+	if (!socketInstance) return;
+	socketMeta = { ...socketMeta, token: token ?? null };
 };
 
 export const initSocketClient = (url, token) => {
-	if (!url || !token) return null;
+	if (!url) return null;
 
 	if (socketInstance && socketMeta.url === url) {
 		if (socketMeta.token !== token) {
@@ -38,7 +36,7 @@ export const initSocketClient = (url, token) => {
 	socketInstance = io(url, {
 		autoConnect: true,
 		transports: ["websocket"],
-		extraHeaders: { Authorization: `Bearer ${token}` },
+		withCredentials: true,
 	});
 	socketMeta = { url, token };
 	return socketInstance;

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -42,20 +42,35 @@ export default function useChatPage() {
 		return outMsgs;
 	}, []);
 
-	const updatePageInfo = useCallback((pageInfo = {}, roomIdOut = null, nextMessages = []) => {
+	const updatePageInfo = useCallback((pageInfo = {}, roomIdOut = undefined, nextMessages = []) => {
+		const resolvedChannelCandidate = roomIdOut ?? pageInfo.channel ?? nextMessages[0]?.roomId;
+		const resolvedChannel = resolvedChannelCandidate ?? pageInfoRef.current.channel ?? null;
+
 		pageInfoRef.current = {
 			hasMoreBefore: pageInfo.hasMoreBefore ?? pageInfoRef.current.hasMoreBefore,
 			hasMoreAfter: pageInfo.hasMoreAfter ?? pageInfoRef.current.hasMoreAfter,
 			nextBefore: pageInfo.nextBefore ?? nextMessages[0]?._id ?? pageInfoRef.current.nextBefore,
 			nextAfter: pageInfo.nextAfter ?? nextMessages[nextMessages.length - 1]?._id ?? pageInfoRef.current.nextAfter,
-			channel: roomIdOut ?? pageInfoRef.current.roomIdOut,
+			channel: resolvedChannel,
 		};
 	}, []);
 
 	const fetchMessages = useCallback(
 		async (roomOverride) => {
-			const roomId = roomOverride || sockets.currentRoom;
-			if (!roomId || fetchingRef.current || !authState.authToken || !sockets.connected) return;
+			let roomId = pageInfoRef.current.channel || roomOverride || sockets.currentRoom;
+			if (!roomId) {
+				console.error("Cannot fetch messages without an active channel");
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Unable to load messages: no active channel.",
+						snackbarSeverity: "error",
+						autoHideDuration: 2500,
+					})
+				);
+				return;
+			}
+			updatePageInfo(pageInfoRef.current, roomId);
+			if (fetchingRef.current || !authState.authToken || !sockets.connected) return;
 			fetchingRef.current = true;
 			try {
 				const {
@@ -71,7 +86,7 @@ export default function useChatPage() {
 				).unwrap();
 				const mapped = msgs || [];
 				setMessages(mapped);
-				updatePageInfo(pageInfo, roomIdOut, mapped);
+				updatePageInfo(pageInfo, roomIdOut || roomId, mapped);
 			} catch (err) {
 				console.error("load messages error", err);
 			} finally {
@@ -83,9 +98,24 @@ export default function useChatPage() {
 
 	const fetchOlderMessages = useCallback(
 		async (roomOverride) => {
-			const roomId = roomOverride || sockets.currentRoom || pageInfoRef.current.channel;
-			if (!roomId || fetchingRef.current || !authState.authToken || !sockets.connected) return;
-			if (!roomId || fetchingRef.current || !pageInfoRef.current.hasMoreBefore) {
+			let roomId = pageInfoRef.current.channel;
+			if (!roomId && roomOverride) {
+				updatePageInfo(pageInfoRef.current, roomOverride);
+				roomId = roomOverride;
+			}
+			if (!roomId) {
+				console.error("Cannot fetch older messages without an active channel");
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Unable to load messages: no active channel.",
+						snackbarSeverity: "error",
+						autoHideDuration: 2500,
+					})
+				);
+				return;
+			}
+			if (fetchingRef.current || !authState.authToken || !sockets.connected) return;
+			if (!pageInfoRef.current.hasMoreBefore) {
 				return;
 			}
 
@@ -109,7 +139,7 @@ export default function useChatPage() {
 				const mapped = olderMessages || [];
 				setMessages((prev) => {
 					const merged = mergeMessages(prev, mapped);
-					updatePageInfo(pageInfo, roomIdOut, merged);
+					updatePageInfo(pageInfo, roomIdOut || roomId, merged);
 					return merged;
 				});
 			} catch (err) {
@@ -123,10 +153,16 @@ export default function useChatPage() {
 	);
 
 	const resetRoomState = useCallback(() => {
-		pageInfoRef.current = { hasMoreBefore: false, hasMoreAfter: false, nextBefore: null, nextAfter: null };
+		pageInfoRef.current = { hasMoreBefore: false, hasMoreAfter: false, nextBefore: null, nextAfter: null, channel: null };
 		loadingOlderRef.current = false;
 		fetchingRef.current = false;
 	}, []);
+
+	useEffect(() => {
+		if (sockets.currentRoom) {
+			updatePageInfo(pageInfoRef.current, sockets.currentRoom);
+		}
+	}, [sockets.currentRoom, updatePageInfo]);
 
 	useEffect(() => {
 		const socket = getSocketClient();

--- a/src/slices/socketSlice.js
+++ b/src/slices/socketSlice.js
@@ -1,5 +1,5 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
-import { getSocketClient, initSocketClient, tearDownSocketClient, updateSocketAuthToken } from "../helpers/socketClient";
+import { getSocketClient, initSocketClient, tearDownSocketClient } from "../helpers/socketClient";
 
 let lifecycleHandlers = null;
 
@@ -43,22 +43,20 @@ const detachLifecycleHandlers = () => {
 	lifecycleHandlers = null;
 };
 
-export const connectSocket = createAsyncThunk("socketApi/connectSocket", async ({ socketURL, userToken } = {}, { getState, dispatch, rejectWithValue }) => {
+export const connectSocket = createAsyncThunk("socketApi/connectSocket", async ({ socketURL } = {}, { getState, dispatch, rejectWithValue }) => {
 	try {
 		const state = getState();
 		const url = socketURL ?? state.sockets?.socketURL;
-		const token = userToken ?? state.auth?.authToken ?? state.auth?.token ?? null;
 
 		if (!url) return rejectWithValue("Missing socketURL");
 
 		const existing = getSocketClient();
 		if (existing?.connected) {
-			updateSocketAuthToken(token);
 			attachLifecycleHandlers(dispatch);
 			return { reused: true };
 		}
 
-		initSocketClient(url, token);
+		initSocketClient(url);
 		attachLifecycleHandlers(dispatch);
 
 		return { reused: false };

--- a/src/slices/socketSlice.js
+++ b/src/slices/socketSlice.js
@@ -47,10 +47,9 @@ export const connectSocket = createAsyncThunk("socketApi/connectSocket", async (
 	try {
 		const state = getState();
 		const url = socketURL ?? state.sockets?.socketURL;
-		const token = userToken ?? state.auth?.authToken ?? state.auth?.token;
+		const token = userToken ?? state.auth?.authToken ?? state.auth?.token ?? null;
 
 		if (!url) return rejectWithValue("Missing socketURL");
-		if (!token) return rejectWithValue("Missing user token");
 
 		const existing = getSocketClient();
 		if (existing?.connected) {


### PR DESCRIPTION
## Summary
- remove browser socket auth headers and rely on cookies when connecting
- allow socket clients to include credentials and configure server CORS for cookies
- update socket authentication middleware to read tokens from handshake cookies

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928bc8238788327affaa756ec3b2865)