### PR TITLE
Improve Electron updater gating and mobile viewport sizing

### DIFF
--- a/public/electron.js
+++ b/public/electron.js
@@ -15,6 +15,10 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
 let mainWindow;
 
+if (process.platform === "win32") {
+	app.setAppUserModelId("com.brandoncasa.rebound");
+}
+
 autoUpdater.autoDownload = false;
 autoUpdater.autoInstallOnAppQuit = true;
 
@@ -22,6 +26,14 @@ function sendStatus(channel, payload = {}) {
 	if (mainWindow?.webContents) {
 		mainWindow.webContents.send(channel, payload);
 	}
+}
+
+function allowUpdateAction(actionName) {
+	if (isDev) {
+		log.warn(`Skipping ${actionName} while running in development.`);
+		return false;
+	}
+	return true;
 }
 
 async function createWindow() {
@@ -51,9 +63,18 @@ async function createWindow() {
 }
 
 // wire up IPC
-ipcMain.on("check-for-updates", () => autoUpdater.checkForUpdates());
-ipcMain.on("download-update", () => autoUpdater.downloadUpdate());
-ipcMain.on("install-update", () => autoUpdater.quitAndInstall(true, true));
+ipcMain.on("check-for-updates", () => {
+	if (!allowUpdateAction("check-for-updates")) return;
+	autoUpdater.checkForUpdates();
+});
+ipcMain.on("download-update", () => {
+	if (!allowUpdateAction("download-update")) return;
+	autoUpdater.downloadUpdate();
+});
+ipcMain.on("install-update", () => {
+	if (!allowUpdateAction("install-update")) return;
+	autoUpdater.quitAndInstall(true, true);
+});
 ipcMain.on("simulate-update", async () => {
 	log.info("Simulating an update…");
 	autoUpdater.emit("checking-for-update");

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -120,9 +120,11 @@ const App = () => {
 		}
 	}, [authState.loggedIn, authState.authToken, dispatch]);
 
+	const showAutoUpdate = window.isElectron && import.meta.env.PROD;
+
 	return (
 		<ThemeProvider theme={darkTheme}>
-			{window.isElectron && <AutoUpdate />}
+			{showAutoUpdate && <AutoUpdate />}
 			<CssBaseline />
 			<SnackbarMapper drawerWidth={customAppBarProps.drawerWidth} drawerOpen={customAppBarProps.drawerOpen} />
 			<AppRouter>

--- a/src/index.css
+++ b/src/index.css
@@ -1,32 +1,42 @@
+:root {
+        --app-height: 100vh;
+}
+
 html {
-	margin: 0;
-	padding: 0;
-	width: 100vw;
-	height: 100vh;
-	overflow: hidden;
-	position: absolute;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        min-height: var(--app-height);
+        height: var(--app-height);
+        overflow-x: hidden;
+        overflow-y: auto;
+        position: relative;
 }
 
 body {
-	margin: 0;
-	padding: 0;
-	width: 100vw;
-	height: 100vh;
-	overflow: hidden;
-	position: absolute;
-	font-family: "Roboto";
-	-webkit-font-smoothing: antialiased;
-	-moz-osx-font-smoothing: grayscale;
-	touch-action: manipulation;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        min-height: var(--app-height);
+        height: var(--app-height);
+        overflow-x: hidden;
+        overflow-y: auto;
+        position: relative;
+        font-family: "Roboto";
+        -webkit-font-smoothing: antialiased;
+        -moz-osx-font-smoothing: grayscale;
+        touch-action: manipulation;
 }
 
 #root {
-	margin: 0;
-	padding: 0;
-	width: 100vw;
-	height: 100vh;
-	overflow: hidden;
-	position: absolute;
+        margin: 0;
+        padding: 0;
+        width: 100%;
+        min-height: var(--app-height);
+        height: var(--app-height);
+        overflow-x: hidden;
+        overflow-y: auto;
+        position: relative;
 }
 
 code {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,6 +15,22 @@ import "./index.css";
 
 import store from "./store";
 
+const setViewportHeightVar = () => {
+	const viewportHeight = window.visualViewport?.height ?? window.innerHeight ?? document.documentElement.clientHeight;
+	document.documentElement.style.setProperty("--app-height", `${viewportHeight}px`);
+};
+
+setViewportHeightVar();
+
+if (!window.__appHeightListenerAttached) {
+	const syncViewportHeight = () => setViewportHeightVar();
+	window.addEventListener("resize", syncViewportHeight);
+	window.addEventListener("orientationchange", syncViewportHeight);
+	window.visualViewport?.addEventListener("resize", syncViewportHeight);
+	window.visualViewport?.addEventListener("scroll", syncViewportHeight);
+	window.__appHeightListenerAttached = true;
+}
+
 window.isElectron = "electronAPI" in window;
 
 const root = ReactDOM.createRoot(document.getElementById("root"));


### PR DESCRIPTION
## Summary
- gate Electron auto-updater actions to packaged builds and set the Windows app user model id
- render the auto-update UI only in packaged Electron builds to avoid noisy dev errors
- sync root layout to a dynamic viewport height variable for better mobile keyboard handling

## Testing
- pnpm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d0ba5bd88327b8bb14979be3f6f6)