### PR TITLE
Fix chat room switching and page overflow

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,8 +8,7 @@ html {
         width: 100%;
         min-height: var(--app-height);
         height: var(--app-height);
-        overflow-x: hidden;
-        overflow-y: auto;
+        overflow: hidden;
         position: relative;
 }
 
@@ -19,8 +18,7 @@ body {
         width: 100%;
         min-height: var(--app-height);
         height: var(--app-height);
-        overflow-x: hidden;
-        overflow-y: auto;
+        overflow: hidden;
         position: relative;
         font-family: "Roboto";
         -webkit-font-smoothing: antialiased;
@@ -34,8 +32,7 @@ body {
         width: 100%;
         min-height: var(--app-height);
         height: var(--app-height);
-        overflow-x: hidden;
-        overflow-y: auto;
+        overflow: hidden;
         position: relative;
 }
 

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -57,6 +57,7 @@ export default function useChatPage() {
 
 	const fetchMessages = useCallback(
 		async (roomOverride) => {
+			const requestedRoom = roomOverride || sockets.currentRoom || pageInfoRef.current.channel;
 			let roomId = pageInfoRef.current.channel || roomOverride || sockets.currentRoom;
 			if (!roomId) {
 				console.error("Cannot fetch messages without an active channel");
@@ -84,9 +85,13 @@ export default function useChatPage() {
 						limit: MESSAGE_PAGE_SIZE,
 					})
 				).unwrap();
+				const resolvedRoom = roomIdOut || roomId;
+				if (resolvedRoom && resolvedRoom !== requestedRoom) {
+					return;
+				}
 				const mapped = msgs || [];
 				setMessages(mapped);
-				updatePageInfo(pageInfo, roomIdOut || roomId, mapped);
+				updatePageInfo(pageInfo, resolvedRoom || roomId, mapped);
 			} catch (err) {
 				console.error("load messages error", err);
 			} finally {
@@ -135,11 +140,15 @@ export default function useChatPage() {
 						limit: MESSAGE_PAGE_SIZE,
 					})
 				).unwrap();
+				const resolvedRoom = roomIdOut || roomId;
+				if (resolvedRoom && resolvedRoom !== pageInfoRef.current.channel) {
+					return;
+				}
 
 				const mapped = olderMessages || [];
 				setMessages((prev) => {
 					const merged = mergeMessages(prev, mapped);
-					updatePageInfo(pageInfo, roomIdOut || roomId, merged);
+					updatePageInfo(pageInfo, resolvedRoom || roomId, merged);
 					return merged;
 				});
 			} catch (err) {
@@ -281,9 +290,10 @@ export default function useChatPage() {
 	}, [sockets.currentRoom]);
 
 	useEffect(() => {
+		resetRoomState();
 		setMessages([]);
 		fetchMessages();
-	}, [sockets.currentRoom, fetchMessages]);
+	}, [sockets.currentRoom, fetchMessages, resetRoomState]);
 
 	useEffect(
 		() => () => {


### PR DESCRIPTION
## Summary
- reset chat pagination and ignore stale room responses so message loading stays aligned when switching rooms
- avoid applying older message fetches to the wrong channel
- prevent the overall page from scrolling outside dedicated scroll areas

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d572b5b48327815eca3b6d8e7cc1)