### PR TITLE
Fix socket client default URL resolution

### DIFF
--- a/src/slices/socketSlice.js
+++ b/src/slices/socketSlice.js
@@ -3,8 +3,15 @@ import { getSocketClient, initSocketClient, tearDownSocketClient } from "../help
 
 let lifecycleHandlers = null;
 
+const resolveDefaultSocketURL = () => {
+	if (process.env.NODE_ENV === "development") return "http://localhost:6002";
+	if (globalThis.IN_ELECTRON_ENV) return "https://rebound.nexus";
+	if (typeof window !== "undefined" && window.location?.origin) return window.location.origin;
+	return "";
+};
+
 const initialState = {
-	socketURL: process.env.NODE_ENV === "development" ? "http://localhost:6002" : globalThis.IN_ELECTRON_ENV ? "https://rebound.nexus" : "",
+	socketURL: resolveDefaultSocketURL(),
 	status: "idle", // "idle" | "connecting" | "connected" | "error"
 	error: null,
 	connected: false,
@@ -46,7 +53,8 @@ const detachLifecycleHandlers = () => {
 export const connectSocket = createAsyncThunk("socketApi/connectSocket", async ({ socketURL } = {}, { getState, dispatch, rejectWithValue }) => {
 	try {
 		const state = getState();
-		const url = socketURL ?? state.sockets?.socketURL;
+		const resolvedDefault = resolveDefaultSocketURL();
+		const url = socketURL || state.sockets?.socketURL || resolvedDefault;
 
 		if (!url) return rejectWithValue("Missing socketURL");
 


### PR DESCRIPTION
## Summary
- add helper to resolve the default socket URL by environment
- default production web clients to the current origin instead of leaving the URL empty
- reuse a computed default when connecting so sockets initialize even if state lacks a URL

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928d91c74ac83279a62aa1b3cd02c98)