### PR TITLE
Simplify viewport height styling

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -1,39 +1,36 @@
 :root {
-        --app-height: 100vh;
+	--app-height: 100vh;
 }
 
-html {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        min-height: var(--app-height);
-        height: var(--app-height);
-        overflow: hidden;
-        position: relative;
+@supports (height: 100dvh) {
+	:root {
+		--app-height: 100dvh;
+	}
+}
+
+@supports (height: 100svh) {
+	:root {
+		--app-height: 100svh;
+	}
+}
+
+html,
+body,
+#root {
+	margin: 0;
+	padding: 0;
+	width: 100%;
+	min-height: var(--app-height);
+	height: var(--app-height);
+	overflow: hidden;
+	position: relative;
 }
 
 body {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        min-height: var(--app-height);
-        height: var(--app-height);
-        overflow: hidden;
-        position: relative;
-        font-family: "Roboto";
-        -webkit-font-smoothing: antialiased;
-        -moz-osx-font-smoothing: grayscale;
-        touch-action: manipulation;
-}
-
-#root {
-        margin: 0;
-        padding: 0;
-        width: 100%;
-        min-height: var(--app-height);
-        height: var(--app-height);
-        overflow: hidden;
-        position: relative;
+	font-family: "Roboto";
+	-webkit-font-smoothing: antialiased;
+	-moz-osx-font-smoothing: grayscale;
+	touch-action: manipulation;
 }
 
 code {

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -15,22 +15,6 @@ import "./index.css";
 
 import store from "./store";
 
-const setViewportHeightVar = () => {
-	const viewportHeight = window.visualViewport?.height ?? window.innerHeight ?? document.documentElement.clientHeight;
-	document.documentElement.style.setProperty("--app-height", `${viewportHeight}px`);
-};
-
-setViewportHeightVar();
-
-if (!window.__appHeightListenerAttached) {
-	const syncViewportHeight = () => setViewportHeightVar();
-	window.addEventListener("resize", syncViewportHeight);
-	window.addEventListener("orientationchange", syncViewportHeight);
-	window.visualViewport?.addEventListener("resize", syncViewportHeight);
-	window.visualViewport?.addEventListener("scroll", syncViewportHeight);
-	window.__appHeightListenerAttached = true;
-}
-
 window.isElectron = "electronAPI" in window;
 
 const root = ReactDOM.createRoot(document.getElementById("root"));

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -292,6 +292,8 @@ export default function useChatPage() {
 	useEffect(() => {
 		resetRoomState();
 		setMessages([]);
+		if (!sockets.currentRoom) return;
+
 		fetchMessages();
 	}, [sockets.currentRoom, fetchMessages, resetRoomState]);
 


### PR DESCRIPTION
## Summary
- use CSS dynamic viewport units to size the app without JS height listeners
- keep root layout sizing consistent across html, body, and root elements

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928da5632e4832793c808e27a1b7b0b)