### PR TITLE
Add image uploads to chat

### DIFF
--- a/server/src/models/Message.js
+++ b/server/src/models/Message.js
@@ -1,5 +1,15 @@
 import mongoose, { Schema } from "mongoose";
 
+const AttachmentSchema = new Schema(
+	{
+		url: { type: String, required: true },
+		contentType: { type: String, required: true },
+		size: { type: Number, required: true },
+		originalName: { type: String, required: true },
+	},
+	{ _id: false }
+);
+
 const MessageSchema = new mongoose.Schema(
 	{
 		sender: {
@@ -7,14 +17,15 @@ const MessageSchema = new mongoose.Schema(
 			ref: "User",
 			required: [true, "is required"],
 		},
-                content: { type: String, required: [true, "is required"] },
-                mentions: [
-                        {
-                                user: { type: Schema.Types.ObjectId, ref: "User", required: true },
-                                start: { type: Number, required: true },
-                                end: { type: Number, required: true },
-                        },
-                ],
+		content: { type: String, default: "" },
+		mentions: [
+			{
+				user: { type: Schema.Types.ObjectId, ref: "User", required: true },
+				start: { type: Number, required: true },
+				end: { type: Number, required: true },
+			},
+		],
+		attachments: { type: [AttachmentSchema], default: [] },
 	},
 	{ timestamps: true }
 );

--- a/server/src/routes/api/chat.js
+++ b/server/src/routes/api/chat.js
@@ -5,8 +5,28 @@ import RoomModel from "../../models/Room.js";
 import MessageModel from "../../models/Message.js";
 import logger from "../../logger.js";
 import rateLimit from "express-rate-limit";
+import multer from "multer";
+import { once } from "events";
+import path from "path";
+import databaseServer from "../../database/index.js";
 
 const router = Router();
+
+const MAX_IMAGE_FILE_SIZE = 1 * 1024 * 1024;
+const ALLOWED_IMAGE_TYPES = new Set(["image/png", "image/jpeg", "image/webp", "image/gif"]);
+
+const upload = multer({
+	storage: multer.memoryStorage(),
+	limits: { fileSize: MAX_IMAGE_FILE_SIZE },
+	fileFilter: (_req, file, cb) => {
+		if (!ALLOWED_IMAGE_TYPES.has(file.mimetype)) {
+			cb(new multer.MulterError("LIMIT_UNEXPECTED_FILE"));
+			return;
+		}
+
+		cb(null, true);
+	},
+});
 
 const messagesLimiter = rateLimit({
 	windowMs: 60 * 1000,
@@ -15,6 +35,67 @@ const messagesLimiter = rateLimit({
 	legacyHeaders: false,
 	message: { error: "Too many requests, please try again later." },
 });
+
+router.post("/rooms/:roomId/media", messagesLimiter, auth.required, upload.single("file"), async (req, res, next) => {
+	try {
+		const bucket = databaseServer.gridfsBucket;
+		if (!bucket) {
+			return res.status(503).json({ error: "File store not ready" });
+		}
+
+		const { roomId } = req.params;
+		const roomExists = await RoomModel.exists({ _id: roomId });
+		if (!roomExists) {
+			return res.status(404).json({ error: "Room not found" });
+		}
+
+		if (!req.file) {
+			return res.status(400).json({ error: "Image file is required." });
+		}
+
+		const { mimetype, size, originalname } = req.file;
+
+		if (!ALLOWED_IMAGE_TYPES.has(mimetype)) {
+			return res.status(400).json({ error: "Only PNG, JPEG, WEBP, or GIF images are supported." });
+		}
+
+		const filename = generateStoredFilename(roomId, originalname);
+		await uploadFileToGrid(bucket, req.file, filename);
+
+		return res.status(201).json({
+			attachment: {
+				url: `/content/${filename}`,
+				contentType: mimetype,
+				size,
+				originalName: originalname,
+			},
+		});
+	} catch (err) {
+		logger.error("Error uploading chat media:", err);
+
+		if (err instanceof multer.MulterError) {
+			if (err.code === "LIMIT_FILE_SIZE") {
+				return res.status(400).json({ error: "Images must be 1MB or smaller." });
+			}
+
+			return res.status(400).json({ error: "Unable to upload image." });
+		}
+
+		return next(err);
+	}
+});
+
+const generateStoredFilename = (roomId, originalName) => {
+	const ext = path.extname(originalName || "").replace(/[^A-Za-z0-9.]/g, "");
+	const suffix = Math.random().toString(36).slice(2, 8);
+	return `room-${roomId}-${Date.now()}-${suffix}${ext || ""}`;
+};
+
+const uploadFileToGrid = async (bucket, file, filename) => {
+	const uploadStream = bucket.openUploadStream(filename, { contentType: file.mimetype });
+	uploadStream.end(file.buffer);
+	await once(uploadStream, "finish");
+};
 
 router.get("/rooms/:roomId/messages", messagesLimiter, auth.required, async (req, res, next) => {
 	const { roomId } = req.params;
@@ -67,6 +148,22 @@ router.get("/rooms/:roomId/messages", messagesLimiter, auth.required, async (req
 		logger.error("Error fetching messages:", err);
 		return next(err);
 	}
+});
+
+router.use((err, _req, res, next) => {
+	if (err instanceof multer.MulterError) {
+		if (err.code === "LIMIT_FILE_SIZE") {
+			return res.status(400).json({ error: "Images must be 1MB or smaller." });
+		}
+
+		if (err.code === "LIMIT_UNEXPECTED_FILE") {
+			return res.status(400).json({ error: "Only PNG, JPEG, WEBP, or GIF images are supported." });
+		}
+
+		return res.status(400).json({ error: "Unable to upload image." });
+	}
+
+	return next(err);
 });
 
 export default router;

--- a/server/src/socketio/rooms.js
+++ b/server/src/socketio/rooms.js
@@ -6,6 +6,8 @@ import socketio from "./index.js";
 import "dotenv/config";
 
 const MESSAGE_LIMIT = 50;
+const MAX_ATTACHMENTS = 4;
+const MAX_ATTACHMENT_BYTES = 1 * 1024 * 1024;
 
 async function fetchRecentMessages(roomDoc, limit = MESSAGE_LIMIT) {
 	const messageIds = roomDoc?.messages ?? [];
@@ -19,6 +21,29 @@ async function fetchRecentMessages(roomDoc, limit = MESSAGE_LIMIT) {
 
 	return messages.reverse();
 }
+
+const normalizeAttachments = (rawAttachments) => {
+	if (!Array.isArray(rawAttachments)) return [];
+
+	return rawAttachments
+		.map((attachment) => ({
+			url: typeof attachment?.url === "string" ? attachment.url : null,
+			contentType: typeof attachment?.contentType === "string" ? attachment.contentType : null,
+			size: Number.isFinite(attachment?.size) ? attachment.size : null,
+			originalName: typeof attachment?.originalName === "string" && attachment.originalName.trim() ? attachment.originalName : null,
+		}))
+		.filter(
+			(attachment) =>
+				Boolean(attachment.url) &&
+				Boolean(attachment.originalName) &&
+				typeof attachment.contentType === "string" &&
+				attachment.contentType.startsWith("image/") &&
+				Number.isFinite(attachment.size) &&
+				attachment.size >= 0 &&
+				attachment.size <= MAX_ATTACHMENT_BYTES
+		)
+		.slice(0, MAX_ATTACHMENTS);
+};
 
 class ServerRooms {
 	async getRoomList() {
@@ -161,17 +186,18 @@ class ServerRooms {
 			}
 		});
 
-		socket.on("message_room", async (arg1, arg2, arg3) => {
+		socket.on("message_room", async (arg1, arg2, arg3, arg4) => {
 			try {
 				const [idToName] = await this.getRoomList();
-				let roomId, content, mentions;
+				let roomId, content, mentions, attachmentsRaw;
 
 				if (Array.isArray(arg1) && arg2 === undefined) {
-					[roomId, content, mentions] = arg1;
+					[roomId, content, mentions, attachmentsRaw] = arg1;
 				} else {
 					roomId = arg1;
 					content = arg2;
 					mentions = arg3;
+					attachmentsRaw = arg4;
 				}
 
 				if (!idToName[roomId]) {
@@ -181,7 +207,8 @@ class ServerRooms {
 				const sender = await UserModel.findById(socket.user.id);
 				if (!sender) throw new Error("Sender not found.");
 
-				const msg = new MessageModel({ sender, content, mentions });
+				const attachments = normalizeAttachments(attachmentsRaw);
+				const msg = new MessageModel({ sender, content: content || "", mentions, attachments });
 				await msg.save();
 
 				const roomDoc = await RoomModel.findById(roomId);

--- a/src/components/Chat/ChatInput.jsx
+++ b/src/components/Chat/ChatInput.jsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { styled, useTheme, darken } from "@mui/material/styles";
-import { Box, Chip, Typography, Paper } from "@mui/material";
+import { Box, Chip, Typography, Paper, IconButton, CircularProgress } from "@mui/material";
 import Button from "@mui/material/Button";
 import SendIcon from "@mui/icons-material/Send";
+import ImageIcon from "@mui/icons-material/Image";
 import DOMPurify from "dompurify";
 import { parseMentions, highlightMentions } from "../../helpers/mentions";
 
@@ -111,11 +112,12 @@ const buildHighlightedHtml = (text, mentions) => {
 	return DOMPurify.sanitize(raw);
 };
 
-export default function ChatInput({ message, setMessage, sendMessage, users = [] }) {
+export default function ChatInput({ message, setMessage, sendMessage, users = [], attachments = [], uploadAttachment, removeAttachment, uploadingAttachment }) {
 	const theme = useTheme();
 	const divRef = useRef(null);
 	const [mentionQuery, setMentionQuery] = useState(null);
 	const [activeMentionIdx, setActiveMentionIdx] = useState(0);
+	const fileInputRef = useRef(null);
 
 	// Pre‑compute mentions + highlighted markup -----------------------------
 	const mentions = useMemo(() => parseMentions(message, users), [message, users]);
@@ -216,7 +218,10 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 
 	const handleSend = useCallback(() => {
 		const trimmed = divRef.current?.textContent.trim();
-		if (trimmed) {
+		const hasContent = Boolean(trimmed);
+		const hasAttachments = attachments.length > 0;
+
+		if (hasContent || hasAttachments) {
 			sendMessage();
 			setMessage("");
 			setMentionQuery(null);
@@ -225,7 +230,7 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 				if (divRef.current) divRef.current.innerHTML = "";
 			});
 		}
-	}, [sendMessage, setMessage]);
+	}, [attachments.length, sendMessage, setMessage]);
 
 	const handleKeyDown = (e) => {
 		if (mentionOptions.length) {
@@ -255,6 +260,19 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 	const handleSelectionChange = useCallback(() => {
 		syncFromDom(false);
 	}, [syncFromDom]);
+
+	const handleFileButtonClick = () => {
+		fileInputRef.current?.click();
+	};
+
+	const handleFileChange = async (event) => {
+		const file = event.target?.files?.[0];
+		if (!file || !uploadAttachment) return;
+		await uploadAttachment(file);
+		event.target.value = "";
+	};
+
+	const canSend = Boolean(message?.trim()) || attachments.length > 0;
 
 	return (
 		<Box sx={{ width: "100%", display: "flex", flexDirection: "column", gap: 0.5 }}>
@@ -305,6 +323,34 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 					))}
 				</Box>
 			)}
+			{attachments.length > 0 && (
+				<Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, px: 2 }}>
+					{attachments.map((att) => (
+						<Paper key={att.url} variant="outlined" sx={{ display: "flex", alignItems: "center", gap: 1, p: 1 }}>
+							<Box
+								component="img"
+								src={att.url}
+								alt={att.originalName || "attachment"}
+								sx={{
+									width: 72,
+									height: 72,
+									borderRadius: 1,
+									objectFit: "cover",
+									border: `1px solid ${theme.palette.divider}`,
+								}}
+							/>
+							<Box sx={{ display: "flex", flexDirection: "column", gap: 0.5 }}>
+								<Typography variant="body2" noWrap sx={{ maxWidth: 220 }}>
+									{att.originalName || "Image"}
+								</Typography>
+								<Button size="small" color="secondary" onClick={() => removeAttachment?.(att.url)}>
+									Remove
+								</Button>
+							</Box>
+						</Paper>
+					))}
+				</Box>
+			)}
 			<ChatForm onSubmit={(e) => e.preventDefault()}>
 				<EditableDiv
 					ref={divRef}
@@ -319,7 +365,11 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 					onFocus={handleSelectionChange}
 					aria-label="Chat message input"
 				/>
-				<Button type="button" variant="contained" endIcon={<SendIcon />} sx={{ height: 42 }} onClick={handleSend}>
+				<input ref={fileInputRef} type="file" accept="image/*" hidden onChange={handleFileChange} />
+				<IconButton color="primary" aria-label="Upload image" onClick={handleFileButtonClick} disabled={uploadingAttachment}>
+					{uploadingAttachment ? <CircularProgress size={24} /> : <ImageIcon />}
+				</IconButton>
+				<Button type="button" variant="contained" endIcon={<SendIcon />} sx={{ height: 42 }} onClick={handleSend} disabled={!canSend || uploadingAttachment}>
 					Send
 				</Button>
 			</ChatForm>

--- a/src/components/Chat/IndividualMessage.jsx
+++ b/src/components/Chat/IndividualMessage.jsx
@@ -41,6 +41,8 @@ function IndividualMessage({
 	let sendTimeText = requestedTime ? formatDate(requestedTime) : formatDate(msg.createdAt);
 	const messageRef = React.useRef(null);
 	const longPressHandlers = useLongPress(({ x, y }) => onContextMenu(msg, { x, y }));
+	const messageText = msg.content || "";
+	const messageHasText = Boolean(messageText);
 
 	const onHoverStart = (_event) => {
 		onHoverMessage(currentMsg);
@@ -143,32 +145,52 @@ function IndividualMessage({
 							</Button>
 						</Box>
 					) : (
-						<Typography variant="subtitle1" sx={{ color: theme.palette.text.secondary }}>
-							{highlightMentions(msg.content, msg.mentions || []).map((p) => (
-								<span
-									key={p.key}
-									style={
-										p.mention
-											? {
-													display: "inline-flex",
-													alignItems: "center",
-													padding: "0 4px",
-													borderRadius: 16,
-													backgroundColor: theme.palette.warning.main,
-													cursor: "pointer",
-													color: theme.palette.primary.contrastText,
-													fontSize: "0.75rem",
-													lineHeight: "22px",
-													margin: "0 2px",
-												}
-											: {}
-									}>
-									{p.text}
-								</span>
-							))}
-						</Typography>
+						messageHasText && (
+							<Typography variant="subtitle1" sx={{ color: theme.palette.text.secondary }}>
+								{highlightMentions(messageText, msg.mentions || []).map((p) => (
+									<span
+										key={p.key}
+										style={
+											p.mention
+												? {
+														display: "inline-flex",
+														alignItems: "center",
+														padding: "0 4px",
+														borderRadius: 16,
+														backgroundColor: theme.palette.warning.main,
+														cursor: "pointer",
+														color: theme.palette.primary.contrastText,
+														fontSize: "0.75rem",
+														lineHeight: "22px",
+														margin: "0 2px",
+													}
+												: {}
+										}>
+										{p.text}
+									</span>
+								))}
+							</Typography>
+						)
 					)}
 				</Box>
+				{msg.attachments?.length > 0 && (
+					<Box sx={{ display: "flex", flexWrap: "wrap", gap: 1, mt: messageHasText ? 1 : 0.5 }}>
+						{msg.attachments.map((attachment) => (
+							<Box
+								key={attachment.url}
+								component="img"
+								src={attachment.url}
+								alt={attachment.originalName || "message attachment"}
+								sx={{
+									maxWidth: "100%",
+									width: "min(320px, 100%)",
+									borderRadius: 1,
+									border: `1px solid ${theme.palette.divider}`,
+								}}
+							/>
+						))}
+					</Box>
+				)}
 			</Box>
 		</ListItem>
 	);

--- a/src/routes/ChatPage/ChatPage.jsx
+++ b/src/routes/ChatPage/ChatPage.jsx
@@ -19,6 +19,7 @@ function ChatPage() {
 		authState,
 		message,
 		setMessage,
+		attachments,
 		messages,
 		channels,
 		currentRoom,
@@ -38,6 +39,9 @@ function ChatPage() {
 		setEditingText,
 		setMessages,
 		sendMessage,
+		uploadChatAttachment,
+		removeAttachment,
+		uploadingAttachment,
 		clickRoomSelect,
 		clickUserList,
 		previewUser,
@@ -146,7 +150,16 @@ function ChatPage() {
 				</Box>
 
 				{/* input */}
-				<ChatInput message={message} setMessage={setMessage} sendMessage={sendMessage} users={users} />
+				<ChatInput
+					message={message}
+					setMessage={setMessage}
+					sendMessage={sendMessage}
+					users={users}
+					attachments={attachments}
+					uploadAttachment={uploadChatAttachment}
+					removeAttachment={removeAttachment}
+					uploadingAttachment={uploadingAttachment}
+				/>
 			</Paper>
 		</Box>
 	);

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -7,8 +7,11 @@ import { fetchUserProfile } from "../../slices/userApiSlice";
 import { addSnackbar } from "../../slices/snackbarSlice";
 import { setActiveSocketRoom, emitSocketEvent } from "../../slices/socketSlice";
 import { getSocketClient } from "../../helpers/socketClient";
+import axios from "axios";
+import { buildApiConfig, getApiBase } from "../../helpers/api";
 
 const MESSAGE_PAGE_SIZE = 50;
+const MAX_ATTACHMENTS = 4;
 
 export default function useChatPage() {
 	const authState = useSelector((state) => state.auth);
@@ -19,6 +22,8 @@ export default function useChatPage() {
 	const [messages, setMessages] = useState([]);
 	const [channels, setChannels] = useState({});
 	const [users, setUsers] = useState([]);
+	const [attachments, setAttachments] = useState([]);
+	const [uploadingAttachment, setUploadingAttachment] = useState(false);
 
 	const [roomAnchorEl, setRoomAnchorEl] = useState(null);
 	const [userListAnchorEl, setUserListAnchorEl] = useState(null);
@@ -290,6 +295,7 @@ export default function useChatPage() {
 	useEffect(() => {
 		resetRoomState();
 		setMessages([]);
+		setAttachments([]);
 		if (!sockets.currentRoom) return;
 
 		fetchMessages();
@@ -302,12 +308,93 @@ export default function useChatPage() {
 		[dispatch]
 	);
 
+	const uploadChatAttachment = useCallback(
+		async (file) => {
+			if (!file) return null;
+			if (!sockets.currentRoom) return null;
+
+			if (attachments.length >= MAX_ATTACHMENTS) {
+				dispatch(
+					addSnackbar({
+						snackbarMsg: `You can attach up to ${MAX_ATTACHMENTS} images per message.`,
+						snackbarSeverity: "warning",
+						autoHideDuration: 2500,
+					})
+				);
+				return null;
+			}
+
+			const ALLOWED_IMAGE_TYPES = ["image/png", "image/jpeg", "image/webp", "image/gif"];
+			if (!ALLOWED_IMAGE_TYPES.includes(file.type)) {
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Only PNG, JPEG, WEBP, or GIF images are supported.",
+						snackbarSeverity: "error",
+						autoHideDuration: 2500,
+					})
+				);
+				return null;
+			}
+
+			const MAX_IMAGE_BYTES = 1 * 1024 * 1024;
+			if (file.size > MAX_IMAGE_BYTES) {
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "Images must be 1MB or smaller.",
+						snackbarSeverity: "error",
+						autoHideDuration: 2500,
+					})
+				);
+				return null;
+			}
+
+			const formData = new FormData();
+			formData.append("file", file);
+
+			setUploadingAttachment(true);
+
+			try {
+				const { data } = await axios.post(`${getApiBase()}/rooms/${sockets.currentRoom}/media`, formData, buildApiConfig(authState.authToken));
+
+				if (data?.attachment) {
+					setAttachments((prev) => [...prev, data.attachment]);
+					return data.attachment;
+				}
+			} catch (err) {
+				const snackbarMsg = err?.response?.data?.error || "Unable to upload image.";
+				dispatch(
+					addSnackbar({
+						snackbarMsg,
+						snackbarSeverity: "error",
+						autoHideDuration: 2500,
+					})
+				);
+			} finally {
+				setUploadingAttachment(false);
+			}
+
+			return null;
+		},
+		[attachments.length, authState.authToken, dispatch, sockets.currentRoom]
+	);
+
+	const removeAttachment = useCallback((url) => {
+		setAttachments((prev) => prev.filter((att) => att.url !== url));
+	}, []);
+
 	const sendMessage = (e) => {
 		e?.preventDefault();
-		if (!message || !sockets.currentRoom) return;
+		if ((!message || message.trim() === "") && attachments.length === 0) return;
+		if (!sockets.currentRoom) return;
 		const mentions = parseMentions(message, users);
-		dispatch(emitSocketEvent({ event: "message_room", args: [sockets.currentRoom, message, mentions] }));
+		dispatch(
+			emitSocketEvent({
+				event: "message_room",
+				args: [sockets.currentRoom, message, mentions, attachments],
+			})
+		);
 		setMessage("");
+		setAttachments([]);
 	};
 
 	const clickRoomSelect = (e) => {
@@ -351,7 +438,7 @@ export default function useChatPage() {
 	const startEditSelectedMessage = () => {
 		if (!selectedMessage) return;
 		setEditingMessageId(selectedMessage._id);
-		setEditingText(selectedMessage.content);
+		setEditingText(selectedMessage.content || "");
 		closeMessageMenu();
 	};
 
@@ -397,6 +484,10 @@ export default function useChatPage() {
 		editingText,
 		setEditingText,
 		sendMessage,
+		attachments,
+		uploadChatAttachment,
+		removeAttachment,
+		uploadingAttachment,
 		clickRoomSelect,
 		clickUserList,
 		previewUser,


### PR DESCRIPTION
## Summary
- add backend support for storing message image attachments with a 1 MB limit
- enable chat input to upload images, manage attachments, and send them with messages
- render attached images inline within chat messages

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6928fd99611c83278da5f46070d7d66c)