### PR TITLE
Configure CORS allowlist for electron client

### DIFF
--- a/server/src/app.js
+++ b/server/src/app.js
@@ -9,6 +9,7 @@ import methodOverride from "method-override";
 import morgan from "morgan";
 
 import customPassport from "./config/passport.js";
+import { corsOptions } from "./config/cors.js";
 import databaseServer from "./database/index.js";
 import logger from "./logger.js";
 import routes from "./routes/index.js";
@@ -39,7 +40,8 @@ class ServerBackend {
 	_initMiddleware() {
 		this.app.set("trust proxy", 1);
 
-		this.app.use(cors({ optionsSuccessStatus: 200 }));
+		this.app.use(cors(corsOptions));
+		this.app.options("*", cors(corsOptions));
 		const globalLimiter = rateLimit({
 			windowMs: 5 * 60 * 1000,
 			max: 150,

--- a/server/src/config/cors.js
+++ b/server/src/config/cors.js
@@ -1,0 +1,29 @@
+const DEFAULT_ALLOWED_ORIGINS = ["http://localhost:3000", "https://rebound.nexus", "app://-"];
+
+const parseEnvOrigins = () =>
+	process.env.ALLOWED_ORIGINS?.split(",")
+		.map((origin) => origin.trim())
+		.filter(Boolean) ?? [];
+
+const resolveAllowedOrigins = () => {
+	const envOrigins = parseEnvOrigins();
+	return envOrigins.length ? envOrigins : DEFAULT_ALLOWED_ORIGINS;
+};
+
+const isOriginAllowed = (origin) => !origin || resolveAllowedOrigins().includes(origin);
+
+const originDelegate = (origin, callback) => {
+	if (isOriginAllowed(origin)) {
+		return callback(null, true);
+	}
+
+	return callback(new Error("Not allowed by CORS"));
+};
+
+const corsOptions = {
+	origin: originDelegate,
+	credentials: true,
+	optionsSuccessStatus: 200,
+};
+
+export { corsOptions, originDelegate, resolveAllowedOrigins };

--- a/server/src/socketio/index.js
+++ b/server/src/socketio/index.js
@@ -7,6 +7,7 @@ import serverDMs from "./dms.js";
 import serverWatchers from "./watchers.js";
 import UserModel from "../models/User.js";
 import { parseCookieHeader, validateAccessToken } from "../utils/auth.js";
+import { originDelegate as corsOriginDelegate } from "../config/cors.js";
 
 class SocketBackend {
 	constructor() {
@@ -16,7 +17,7 @@ class SocketBackend {
 	start(port = 6002) {
 		this.io = new Server({
 			path: "/socket.io",
-			cors: { origin: true, credentials: true },
+			cors: { origin: corsOriginDelegate, credentials: true },
 		});
 
 		this.io.use(this._authenticate.bind(this));


### PR DESCRIPTION
## Summary
- add centralized CORS configuration with an allowlist that includes the Electron scheme and optional environment overrides
- apply the allowlist and credential support to Express along with explicit preflight handling
- reuse the same CORS origin delegate for Socket.IO connections

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692917b3110483278eb8a2ce77837a4d)