### PR TITLE
Add perceptual hash duplicate checking for uploads

### DIFF
--- a/server/src/routes/api/index.js
+++ b/server/src/routes/api/index.js
@@ -6,6 +6,7 @@ import usersApi from "./users.js";
 import chatApi from "./chat.js";
 import dmApi from "./dms.js";
 import contentRoutes from "../content.js";
+import mediaApi from "./media.js";
 import multer from "multer";
 
 const router = Router();
@@ -18,6 +19,7 @@ router.use("/", adminApi);
 
 router.use("/", chatApi);
 router.use("/", dmApi);
+router.use("/", mediaApi);
 
 router.use("/", contentRoutes);
 

--- a/server/src/routes/api/media.js
+++ b/server/src/routes/api/media.js
@@ -1,0 +1,77 @@
+import { Router } from "express";
+import { auth } from "../auth.js";
+import MediaModel from "../../models/Media/MediaAttachment.js";
+
+const router = Router();
+
+const NIBBLE_POPCOUNT = [0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4];
+
+const hexHammingDistance = (hexA = "", hexB = "") => {
+	const minLength = Math.min(hexA.length, hexB.length);
+	const maxLength = Math.max(hexA.length, hexB.length);
+
+	let distance = 0;
+	for (let i = 0; i < minLength; i++) {
+		const nibbleA = parseInt(hexA[i], 16);
+		const nibbleB = parseInt(hexB[i], 16);
+
+		if (Number.isNaN(nibbleA) || Number.isNaN(nibbleB)) continue;
+
+		const xor = nibbleA ^ nibbleB;
+		distance += NIBBLE_POPCOUNT[xor];
+	}
+
+	// Account for any trailing unmatched nibbles as full differences.
+	distance += (maxLength - minLength) * 4;
+
+	return distance;
+};
+
+router.post("/media/check", auth.required, async (req, res, next) => {
+	const { hashes = [] } = req.body || {};
+
+	if (!Array.isArray(hashes)) {
+		return res.status(400).json({ error: "Payload must include an array of hashes." });
+	}
+
+	try {
+		const coarseValues = hashes.map((entry) => entry?.coarse).filter((hash) => typeof hash === "string" && hash.length);
+
+		const existingMedia = await MediaModel.find({
+			perceptualHashCoarse: { $in: coarseValues },
+		})
+			.select("perceptualHashCoarse perceptualHashDense size contentType url originalName")
+			.lean();
+
+		const results = hashes.map((entry, index) => {
+			if (!entry?.coarse || !entry?.fine) return { index, matches: [] };
+
+			const coarseMatches = existingMedia.filter((media) => media.perceptualHashCoarse === entry.coarse);
+
+			const matches = coarseMatches
+				.map((media) => {
+					const distance = hexHammingDistance(entry.fine, media.perceptualHashDense);
+					const bitLength = Math.min(entry.fine.length, media.perceptualHashDense.length) * 4;
+					const similarity = bitLength ? 100 - (distance / bitLength) * 100 : 0;
+					return {
+						_id: media._id,
+						url: media.url,
+						size: media.size,
+						contentType: media.contentType,
+						originalName: media.originalName,
+						distance,
+						similarity,
+					};
+				})
+				.filter((candidate) => candidate.similarity >= 97); // within 3% hamming distance
+
+			return { index, matches };
+		});
+
+		return res.json({ results });
+	} catch (err) {
+		return next(err);
+	}
+});
+
+export default router;

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import axios from "axios";
 import { fetchRoomMessages, mapMessages } from "../../slices/chatApiSlice";
 import { parseMentions } from "../../helpers/mentions";
 import { fetchUserProfile } from "../../slices/userApiSlice";
@@ -8,6 +9,7 @@ import { addSnackbar } from "../../slices/snackbarSlice";
 import { setActiveSocketRoom, emitSocketEvent } from "../../slices/socketSlice";
 import { getSocketClient } from "../../helpers/socketClient";
 import { dctHashCoarse16bitFromRgb, dctHashFineColor } from "../../helpers/hashimage";
+import { buildApiConfig, getApiBase } from "../../helpers/api";
 
 const MESSAGE_PAGE_SIZE = 50;
 const MAX_ATTACHMENTS = 10;
@@ -504,15 +506,69 @@ export default function useChatPage() {
 					blurRadius: 1.5,
 				});
 
-				const fine = dctHashFineColor(pixels, width, height, 4, { hashSize: 24, dctSize: 128 });
+				const fine = dctHashFineColor(pixels, canvas.width, canvas.height, 4, {
+					hashSize: 24,
+					dctSize: 128,
+				});
 
 				hashResultsCoarse.push(coarse);
 				hashResultsFine.push(fine);
 			}
 
-			//WORK TO DO
+			const payload = hashResultsCoarse.map((coarse, idx) => ({
+				coarse,
+				fine: hashResultsFine[idx],
+				size: validAttachments[idx]?.size,
+				name: validAttachments[idx]?.name,
+			}));
 
-			console.log(hashResultsCoarse);
+			const { data } = await axios.post(`${getApiBase()}/media/check`, { hashes: payload }, buildApiConfig(authState.authToken));
+
+			const results = data?.results ?? [];
+			const uploadsToKeep = [];
+
+			validAttachments.forEach((file, idx) => {
+				const matches = results.find((entry) => entry.index === idx)?.matches ?? [];
+				if (!matches.length) {
+					uploadsToKeep.push(file);
+					return;
+				}
+
+				const bestMatch = matches.reduce((curr, next) => {
+					if (!curr) return next;
+					return next.size > curr.size ? next : curr;
+				}, null);
+
+				const similarityText = typeof bestMatch?.similarity === "number" ? bestMatch.similarity.toFixed(2) : "unknown";
+				const confirmMessage = `A similar image already exists (${similarityText}% similarity). Use the existing file (${((bestMatch?.size ?? 0) / 1024).toFixed(1)} KB) instead of uploading ${file.name}? Click Cancel to upload your version.`;
+
+				const useExisting = bestMatch && window.confirm(confirmMessage);
+
+				if (useExisting && bestMatch.size >= file.size) {
+					dispatch(
+						addSnackbar({
+							snackbarMsg: `Using existing image for ${file.name}.`,
+							snackbarSeverity: "info",
+							autoHideDuration: 2500,
+						})
+					);
+					return;
+				}
+
+				uploadsToKeep.push(file);
+			});
+
+			if (!uploadsToKeep.length) {
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "No new images to upload after similarity check.",
+						snackbarSeverity: "info",
+						autoHideDuration: 2500,
+					})
+				);
+			}
+
+			setAttachments(uploadsToKeep);
 		} catch (err) {
 			const snackbarMsg = err?.response?.data?.error || "Unable to upload image.";
 			dispatch(


### PR DESCRIPTION
## Summary
- add an authenticated media hash check endpoint to compare coarse and fine perceptual hashes
- integrate chat attachment handling to compute hashes client-side and query for duplicates
- prompt users to use existing similar media when matches are detected before uploading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b98add36483278b2b39539e4cfd8b)