### PR TITLE
Send uploads for unique chat attachments

### DIFF
--- a/server/src/routes/api/index.js
+++ b/server/src/routes/api/index.js
@@ -6,6 +6,7 @@ import usersApi from "./users.js";
 import chatApi from "./chat.js";
 import dmApi from "./dms.js";
 import contentRoutes from "../content.js";
+import mediaApi from "./media.js";
 import multer from "multer";
 
 const router = Router();
@@ -18,6 +19,7 @@ router.use("/", adminApi);
 
 router.use("/", chatApi);
 router.use("/", dmApi);
+router.use("/", mediaApi);
 
 router.use("/", contentRoutes);
 

--- a/server/src/routes/api/media.js
+++ b/server/src/routes/api/media.js
@@ -1,0 +1,159 @@
+import { Router } from "express";
+import { once } from "events";
+import multer from "multer";
+
+import databaseServer from "../../database/index.js";
+import { auth } from "../auth.js";
+import MediaModel from "../../models/Media/MediaAttachment.js";
+
+const router = Router();
+
+const MAX_FILE_SIZE = 8 * 1024 * 1024;
+const MAX_MEDIA_ATTACHMENTS = 10;
+const upload = multer({ storage: multer.memoryStorage(), limits: { fileSize: MAX_FILE_SIZE } });
+
+const NIBBLE_POPCOUNT = [0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4];
+
+const generateStoredFilename = (userId, originalName) => {
+	const ext = originalName.split(".").pop();
+	return `media-${userId}-${Math.floor(Math.random() * 1000)}-${Date.now()}.${ext}`;
+};
+
+const uploadFileToGrid = async (bucket, file, filename) => {
+	const uploadStream = bucket.openUploadStream(filename, { contentType: file.mimetype });
+	uploadStream.end(file.buffer);
+	await once(uploadStream, "finish");
+};
+
+const hexHammingDistance = (hexA = "", hexB = "") => {
+	const minLength = Math.min(hexA.length, hexB.length);
+	const maxLength = Math.max(hexA.length, hexB.length);
+
+	let distance = 0;
+	for (let i = 0; i < minLength; i++) {
+		const nibbleA = parseInt(hexA[i], 16);
+		const nibbleB = parseInt(hexB[i], 16);
+
+		if (Number.isNaN(nibbleA) || Number.isNaN(nibbleB)) continue;
+
+		const xor = nibbleA ^ nibbleB;
+		distance += NIBBLE_POPCOUNT[xor];
+	}
+
+	// Account for any trailing unmatched nibbles as full differences.
+	distance += (maxLength - minLength) * 4;
+
+	return distance;
+};
+
+router.post("/media/check", auth.required, async (req, res, next) => {
+	const { hashes = [] } = req.body || {};
+
+	if (!Array.isArray(hashes)) {
+		return res.status(400).json({ error: "Payload must include an array of hashes." });
+	}
+
+	try {
+		const coarseValues = hashes.map((entry) => entry?.coarse).filter((hash) => typeof hash === "string" && hash.length);
+
+		const existingMedia = await MediaModel.find({
+			perceptualHashCoarse: { $in: coarseValues },
+		})
+			.select("perceptualHashCoarse perceptualHashDense size contentType url originalName")
+			.lean();
+
+		const results = hashes.map((entry, index) => {
+			if (!entry?.coarse || !entry?.fine) return { index, matches: [] };
+
+			const coarseMatches = existingMedia.filter((media) => media.perceptualHashCoarse === entry.coarse);
+
+			const matches = coarseMatches
+				.map((media) => {
+					const distance = hexHammingDistance(entry.fine, media.perceptualHashDense);
+					const bitLength = Math.min(entry.fine.length, media.perceptualHashDense.length) * 4;
+					const similarity = bitLength ? 100 - (distance / bitLength) * 100 : 0;
+					return {
+						_id: media._id,
+						url: media.url,
+						size: media.size,
+						contentType: media.contentType,
+						originalName: media.originalName,
+						distance,
+						similarity,
+					};
+				})
+				.filter((candidate) => candidate.similarity >= 97); // within 3% hamming distance
+
+			return { index, matches };
+		});
+
+		return res.json({ results });
+	} catch (err) {
+		return next(err);
+	}
+});
+
+router.post("/media/upload", auth.required, upload.array("files", MAX_MEDIA_ATTACHMENTS), async (req, res, next) => {
+	const bucket = databaseServer.gridfsBucket;
+	if (!bucket) {
+		return res.status(503).json({ error: "File store not ready." });
+	}
+
+	const files = req.files || [];
+	if (!files.length) {
+		return res.status(400).json({ error: "At least one file is required." });
+	}
+
+	let hashes = req.body?.hashes;
+	if (typeof hashes === "string") {
+		try {
+			hashes = JSON.parse(hashes);
+		} catch (err) {
+			return res.status(400).json({ error: "Invalid hashes payload." });
+		}
+	}
+
+	if (!Array.isArray(hashes) || hashes.length !== files.length) {
+		return res.status(400).json({ error: "Hash metadata must match uploaded files." });
+	}
+
+	try {
+		const attachments = [];
+
+		for (let i = 0; i < files.length; i++) {
+			const file = files[i];
+			const hashEntry = hashes[i] || {};
+			if (!hashEntry.coarse || !hashEntry.fine) {
+				return res.status(400).json({ error: "Each upload must include coarse and fine hashes." });
+			}
+
+			const filename = generateStoredFilename(req.payload?.id, file.originalname);
+			await uploadFileToGrid(bucket, file, filename);
+			const url = `/content/${filename}`;
+
+			const mediaDoc = await MediaModel.create({
+				sender: req.payload.id,
+				contentType: file.mimetype,
+				size: file.size,
+				originalName: file.originalname,
+				perceptualHashCoarse: hashEntry.coarse,
+				perceptualHashDense: hashEntry.fine,
+				url,
+			});
+
+			attachments.push({
+				mediaId: mediaDoc._id,
+				url: mediaDoc.url,
+				size: mediaDoc.size,
+				contentType: mediaDoc.contentType,
+				originalName: mediaDoc.originalName,
+			});
+		}
+
+		return res.json({ attachments });
+	} catch (err) {
+		return next(err);
+	}
+});
+
+export default router;

--- a/src/components/Chat/ChatInput.jsx
+++ b/src/components/Chat/ChatInput.jsx
@@ -222,21 +222,20 @@ export default function ChatInput({ message, setMessage, sendMessage, users = []
 		[setMessage, users]
 	);
 
-	const handleSend = useCallback(() => {
+	const handleSend = useCallback(async () => {
 		const trimmed = divRef.current?.textContent.trim();
 		const hasContent = Boolean(trimmed);
 		const hasAttachments = attachments.length > 0;
 
 		if (hasContent || hasAttachments) {
-			sendMessage();
-			setMessage("");
+			await sendMessage();
 			setMentionQuery(null);
 			setActiveMentionIdx(0);
 			requestAnimationFrame(() => {
 				if (divRef.current) divRef.current.innerHTML = "";
 			});
 		}
-	}, [attachments.length, sendMessage, setMessage]);
+	}, [attachments.length, sendMessage]);
 
 	const handleKeyDown = (e) => {
 		if (mentionOptions.length) {

--- a/src/routes/ChatPage/useChatPage.js
+++ b/src/routes/ChatPage/useChatPage.js
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useDispatch, useSelector } from "react-redux";
 
+import axios from "axios";
 import { fetchRoomMessages, mapMessages } from "../../slices/chatApiSlice";
 import { parseMentions } from "../../helpers/mentions";
 import { fetchUserProfile } from "../../slices/userApiSlice";
@@ -8,6 +9,7 @@ import { addSnackbar } from "../../slices/snackbarSlice";
 import { setActiveSocketRoom, emitSocketEvent } from "../../slices/socketSlice";
 import { getSocketClient } from "../../helpers/socketClient";
 import { dctHashCoarse16bitFromRgb, dctHashFineColor } from "../../helpers/hashimage";
+import { buildApiConfig, getApiBase } from "../../helpers/api";
 
 const MESSAGE_PAGE_SIZE = 50;
 const MAX_ATTACHMENTS = 10;
@@ -315,15 +317,36 @@ export default function useChatPage() {
 		[dispatch]
 	);
 
-	const sendMessage = (e) => {
-		e?.preventDefault();
-		if (!(Boolean(message?.trim() !== "") || attachments.length > 0) || !sockets.currentRoom) return;
-		const mentions = parseMentions(message, users);
-		uploadAttachments();
-		dispatch(emitSocketEvent({ event: "message_room", args: [sockets.currentRoom, message, mentions] }));
-		setMessage("");
-		setAttachments([]);
-	};
+	const sendMessage = useCallback(
+		async (e) => {
+			e?.preventDefault();
+
+			if (!sockets.currentRoom) return;
+			const trimmedMessage = message?.trim?.() ?? "";
+			if (!trimmedMessage && !attachments.length) return;
+
+			const uploadedAttachments = (await uploadAttachments()) || [];
+			const attachmentLinks = uploadedAttachments.map((entry) => entry?.url).filter(Boolean);
+
+			const composedParts = [];
+			if (trimmedMessage) composedParts.push(trimmedMessage);
+			composedParts.push(...attachmentLinks);
+
+			const composedMessage = composedParts.join("\n");
+			if (!composedMessage) return;
+
+			const mentions = parseMentions(composedMessage, users);
+			dispatch(
+				emitSocketEvent({
+					event: "message_room",
+					args: [sockets.currentRoom, composedMessage, mentions],
+				})
+			);
+			setMessage("");
+			setAttachments([]);
+		},
+		[attachments.length, dispatch, message, sockets.currentRoom, uploadAttachments, users]
+	);
 
 	const clickRoomSelect = (e) => {
 		setRoomAnchorEl(e.currentTarget);
@@ -429,7 +452,7 @@ export default function useChatPage() {
 	};
 
 	const uploadAttachments = useCallback(async () => {
-		if (!sockets.currentRoom) return null;
+		if (!sockets.currentRoom) return [];
 
 		const validAttachments = [];
 		for (const file of attachments) {
@@ -473,13 +496,12 @@ export default function useChatPage() {
 
 		setAttachments(validAttachments);
 
-		if (!validAttachments.length) return null;
+		if (!validAttachments.length) return [];
 
 		try {
 			setUploadingAttachment(true);
 
-			let hashResultsCoarse = [];
-			let hashResultsFine = [];
+			const hashedAttachments = [];
 
 			for (const file of validAttachments) {
 				// Convert File → Image → Canvas → Raw Pixel Data
@@ -504,15 +526,107 @@ export default function useChatPage() {
 					blurRadius: 1.5,
 				});
 
-				const fine = dctHashFineColor(pixels, width, height, 4, { hashSize: 24, dctSize: 128 });
+				const fine = dctHashFineColor(pixels, canvas.width, canvas.height, 4, {
+					hashSize: 24,
+					dctSize: 128,
+				});
 
-				hashResultsCoarse.push(coarse);
-				hashResultsFine.push(fine);
+				hashedAttachments.push({ file, coarse, fine });
 			}
 
-			//WORK TO DO
+			const payload = hashedAttachments.map(({ coarse, fine, file }) => ({
+				coarse,
+				fine,
+				size: file?.size,
+				name: file?.name,
+			}));
 
-			console.log(hashResultsCoarse);
+			const { data } = await axios.post(`${getApiBase()}/media/check`, { hashes: payload }, buildApiConfig(authState.authToken));
+
+			const results = data?.results ?? [];
+			const uploadsToKeep = [];
+			const resolvedAttachments = [];
+
+			hashedAttachments.forEach((entry, idx) => {
+				const matches = results.find((resultEntry) => resultEntry.index === idx)?.matches ?? [];
+				if (!matches.length) {
+					uploadsToKeep.push(entry);
+					return;
+				}
+
+				const bestMatch = matches.reduce((curr, next) => {
+					if (!curr) return next;
+					return next.size > curr.size ? next : curr;
+				}, null);
+
+				const similarityText = typeof bestMatch?.similarity === "number" ? bestMatch.similarity.toFixed(2) : "unknown";
+				const confirmMessage = `A similar image already exists (${similarityText}% similarity). Use the existing file (${((bestMatch?.size ?? 0) / 1024).toFixed(1)} KB) instead of uploading ${entry.file.name}? Click Cancel to upload your version.`;
+
+				const useExisting = bestMatch && window.confirm(confirmMessage);
+
+				if (useExisting && bestMatch.size >= entry.file.size) {
+					dispatch(
+						addSnackbar({
+							snackbarMsg: `Using existing image for ${entry.file.name}.`,
+							snackbarSeverity: "info",
+							autoHideDuration: 2500,
+						})
+					);
+
+					resolvedAttachments.push({
+						url: bestMatch.url,
+						size: bestMatch.size,
+						contentType: bestMatch.contentType,
+						originalName: bestMatch.originalName,
+						mediaId: bestMatch._id,
+					});
+					return;
+				}
+
+				uploadsToKeep.push(entry);
+			});
+
+			if (!uploadsToKeep.length && resolvedAttachments.length) {
+				setAttachments([]);
+				return resolvedAttachments;
+			}
+
+			if (!uploadsToKeep.length) {
+				dispatch(
+					addSnackbar({
+						snackbarMsg: "No new images to upload after similarity check.",
+						snackbarSeverity: "info",
+						autoHideDuration: 2500,
+					})
+				);
+				setAttachments([]);
+				return resolvedAttachments;
+			}
+
+			const uploadMetadata = uploadsToKeep.map(({ coarse, fine, file }) => ({
+				coarse,
+				fine,
+				size: file.size,
+				name: file.name,
+				type: file.type,
+			}));
+
+			const formData = new FormData();
+			uploadsToKeep.forEach(({ file }) => formData.append("files", file));
+			formData.append("hashes", JSON.stringify(uploadMetadata));
+
+			const { data: uploadResponse } = await axios.post(
+				`${getApiBase()}/media/upload`,
+				formData,
+				buildApiConfig(authState.authToken, {
+					headers: { "Content-Type": "multipart/form-data" },
+				})
+			);
+
+			const uploaded = uploadResponse?.attachments ?? [];
+			const combined = [...resolvedAttachments, ...uploaded];
+			setAttachments([]);
+			return combined;
 		} catch (err) {
 			const snackbarMsg = err?.response?.data?.error || "Unable to upload image.";
 			dispatch(
@@ -522,11 +636,10 @@ export default function useChatPage() {
 					autoHideDuration: 2500,
 				})
 			);
+			return [];
 		} finally {
 			setUploadingAttachment(false);
 		}
-
-		return null;
 	}, [attachments, authState.authToken, dispatch, sockets]);
 
 	const addChatAttachment = useCallback(


### PR DESCRIPTION
## Summary
- add a media upload endpoint that stores hashed attachments in GridFS for reuse
- extend the chat attachment flow to upload or reuse images and append their URLs into outgoing messages
- update the chat input send action to await asynchronous attachment handling before clearing the editor

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b98add36483278b2b39539e4cfd8b)