### PR TITLE
Show attachments in chat messages

### DIFF
--- a/server/src/routes/api/chat.js
+++ b/server/src/routes/api/chat.js
@@ -46,6 +46,7 @@ router.get("/rooms/:roomId/messages", messagesLimiter, auth.required, async (req
 			.sort({ _id: -1 })
 			.limit(limit + 1)
 			.populate({ path: "sender", select: "displayName avatarUrl" })
+			.populate({ path: "attachments", select: "url contentType size originalName" })
 			.lean();
 
 		const hasExtra = results.length > limit;

--- a/server/src/socketio/dms.js
+++ b/server/src/socketio/dms.js
@@ -11,7 +11,10 @@ class ServerDMs {
 		}).populate({
 			path: "messages",
 			options: { sort: { createdAt: 1 } },
-			populate: { path: "sender", select: "displayName avatarUrl" },
+			populate: [
+				{ path: "sender", select: "displayName avatarUrl" },
+				{ path: "attachments", select: "url contentType size originalName" },
+			],
 		});
 		if (!thread) {
 			thread = new DmThreadModel({ participants: [id1, id2], messages: [] });
@@ -55,7 +58,10 @@ class ServerDMs {
 				await thread.populate({
 					path: "messages",
 					options: { sort: { createdAt: 1 } },
-					populate: { path: "sender", select: "displayName avatarUrl" },
+					populate: [
+						{ path: "sender", select: "displayName avatarUrl" },
+						{ path: "attachments", select: "url contentType size originalName" },
+					],
 				});
 				const sockets = await socketio.io.in(threadId).fetchSockets();
 				sockets.forEach((s) => {
@@ -84,10 +90,10 @@ class ServerDMs {
 				msg.mentions = mentions;
 				await msg.save();
 
-				const msgDoc = await msg.populate({
-					path: "sender",
-					select: "displayName avatarUrl",
-				});
+				const msgDoc = await msg.populate([
+					{ path: "sender", select: "displayName avatarUrl" },
+					{ path: "attachments", select: "url contentType size originalName" },
+				]);
 
 				const sockets = await socketio.io.in(threadId).fetchSockets();
 				sockets.forEach((s) => {

--- a/server/src/socketio/rooms.js
+++ b/server/src/socketio/rooms.js
@@ -8,6 +8,18 @@ import "dotenv/config";
 const MESSAGE_LIMIT = 50;
 const attachmentPopulate = { path: "attachments", select: "url contentType size originalName" };
 
+const populateMessage = async (messageDoc) => {
+	if (!messageDoc) return null;
+	const populated = await messageDoc.populate([{ path: "sender", select: "displayName avatarUrl" }, attachmentPopulate]);
+	return populated.toObject();
+};
+
+const normalizeAttachmentIds = (attachments) => {
+	if (!Array.isArray(attachments)) return undefined;
+	const ids = attachments.filter(Boolean).map((attachment) => attachment.mediaId || attachment._id || attachment);
+	return ids.length ? ids : undefined;
+};
+
 async function fetchRecentMessages(roomDoc, limit = MESSAGE_LIMIT) {
 	const messageIds = roomDoc?.messages ?? [];
 	if (!messageIds.length) return [];
@@ -171,7 +183,6 @@ class ServerRooms {
 				if (Array.isArray(arg1) && arg2 === undefined) {
 					[roomId, content, mentions, attachments] = arg1;
 				} else {
-					console.log(arg4);
 					roomId = arg1;
 					content = arg2;
 					mentions = arg3;
@@ -184,28 +195,27 @@ class ServerRooms {
 
 				const sender = await UserModel.findById(socket.user.id);
 				if (!sender) throw new Error("Sender not found.");
-				console.log(attachments);
 
 				const msg = new MessageModel({
 					sender,
 					content: content || "lol",
 					mentions,
 					room: roomId,
-					attachments: Array.isArray(attachments) ? attachments.map((attachment) => attachment.mediaId) : undefined,
+					attachments: normalizeAttachmentIds(attachments),
 				});
 				await msg.save();
 
 				const roomDoc = await RoomModel.findById(roomId);
 				roomDoc.messages.push(msg);
 				await roomDoc.save();
-				await msg.populate([{ path: "sender", select: "displayName avatarUrl" }, attachmentPopulate]);
+				const populatedMsg = await populateMessage(msg);
 
 				const [usersInRoom, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
 				socketsInRoom.forEach((s) => {
 					if (s.user.id === socket.user.id) {
-						s.emit("message_sent", roomId, msg);
+						s.emit("message_sent", roomId, populatedMsg);
 					} else {
-						s.emit("new_message", roomId, msg);
+						s.emit("new_message", roomId, populatedMsg);
 					}
 				});
 
@@ -231,11 +241,11 @@ class ServerRooms {
 				msg.content = content;
 				msg.mentions = mentions;
 				await msg.save();
-				await msg.populate([{ path: "sender", select: "displayName avatarUrl" }, attachmentPopulate]);
+				const populatedMsg = await populateMessage(msg);
 
 				const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
 				socketsInRoom.forEach((s) => {
-					s.emit("messages_updated", roomId, { type: "edit", message: msg });
+					s.emit("messages_updated", roomId, { type: "edit", message: populatedMsg });
 				});
 			} catch (err) {
 				logger.error("Error handling edit_message:", err);

--- a/server/src/socketio/rooms.js
+++ b/server/src/socketio/rooms.js
@@ -6,6 +6,7 @@ import socketio from "./index.js";
 import "dotenv/config";
 
 const MESSAGE_LIMIT = 50;
+const attachmentPopulate = { path: "attachments", select: "url contentType size originalName" };
 
 async function fetchRecentMessages(roomDoc, limit = MESSAGE_LIMIT) {
 	const messageIds = roomDoc?.messages ?? [];
@@ -15,6 +16,7 @@ async function fetchRecentMessages(roomDoc, limit = MESSAGE_LIMIT) {
 		.sort({ _id: -1 })
 		.limit(limit)
 		.populate({ path: "sender", select: "displayName avatarUrl" })
+		.populate(attachmentPopulate)
 		.lean();
 
 	return messages.reverse();
@@ -196,7 +198,7 @@ class ServerRooms {
 				const roomDoc = await RoomModel.findById(roomId);
 				roomDoc.messages.push(msg);
 				await roomDoc.save();
-				await msg.populate({ path: "sender", select: "displayName avatarUrl" });
+				await msg.populate([{ path: "sender", select: "displayName avatarUrl" }, attachmentPopulate]);
 
 				const [usersInRoom, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
 				socketsInRoom.forEach((s) => {
@@ -229,7 +231,7 @@ class ServerRooms {
 				msg.content = content;
 				msg.mentions = mentions;
 				await msg.save();
-				await msg.populate({ path: "sender", select: "displayName avatarUrl" });
+				await msg.populate([{ path: "sender", select: "displayName avatarUrl" }, attachmentPopulate]);
 
 				const [, socketsInRoom] = await socketio.getSocketsInRoom(roomId);
 				socketsInRoom.forEach((s) => {

--- a/src/components/Chat/IndividualMessage.jsx
+++ b/src/components/Chat/IndividualMessage.jsx
@@ -4,6 +4,7 @@ import React from "react";
 import useLongPress from "../../helpers/useLongPress";
 import { highlightMentions } from "../../helpers/mentions";
 import { profileMediaUrl } from "../../helpers/mediaUrl";
+import MessageAttachments from "./MessageAttachments";
 
 const formatDate = (timestamp) => {
 	const messageDate = new Date(timestamp);
@@ -53,6 +54,8 @@ function IndividualMessage({
 		e.preventDefault();
 		onContextMenu(msg, { x: e.clientX, y: e.clientY });
 	};
+
+	const hasContent = Boolean(msg.content);
 
 	return (
 		<ListItem
@@ -143,30 +146,35 @@ function IndividualMessage({
 							</Button>
 						</Box>
 					) : (
-						<Typography variant="subtitle1" sx={{ color: theme.palette.text.secondary }}>
-							{highlightMentions(msg.content, msg.mentions || []).map((p) => (
-								<span
-									key={p.key}
-									style={
-										p.mention
-											? {
-													display: "inline-flex",
-													alignItems: "center",
-													padding: "0 4px",
-													borderRadius: 16,
-													backgroundColor: theme.palette.warning.main,
-													cursor: "pointer",
-													color: theme.palette.primary.contrastText,
-													fontSize: "0.75rem",
-													lineHeight: "22px",
-													margin: "0 2px",
-												}
-											: {}
-									}>
-									{p.text}
-								</span>
-							))}
-						</Typography>
+						<>
+							{hasContent && (
+								<Typography variant="subtitle1" sx={{ color: theme.palette.text.secondary }}>
+									{highlightMentions(msg.content, msg.mentions || []).map((p) => (
+										<span
+											key={p.key}
+											style={
+												p.mention
+													? {
+															display: "inline-flex",
+															alignItems: "center",
+															padding: "0 4px",
+															borderRadius: 16,
+															backgroundColor: theme.palette.warning.main,
+															cursor: "pointer",
+															color: theme.palette.primary.contrastText,
+															fontSize: "0.75rem",
+															lineHeight: "22px",
+															margin: "0 2px",
+														}
+													: {}
+											}>
+											{p.text}
+										</span>
+									))}
+								</Typography>
+							)}
+							<MessageAttachments attachments={msg.attachments} />
+						</>
 					)}
 				</Box>
 			</Box>

--- a/src/components/Chat/MessageAttachments.jsx
+++ b/src/components/Chat/MessageAttachments.jsx
@@ -1,0 +1,51 @@
+import React from "react";
+import { Box, useTheme } from "@mui/material";
+
+function MessageAttachments({ attachments = [] }) {
+	const theme = useTheme();
+	const visibleAttachments = (attachments || []).filter((attachment) => attachment?.url);
+
+	if (!visibleAttachments.length) return null;
+
+	return (
+		<Box
+			sx={{
+				display: "grid",
+				gridTemplateColumns: "repeat(auto-fit, minmax(120px, 1fr))",
+				gap: 1,
+				width: "100%",
+				mt: 1,
+			}}>
+			{visibleAttachments.map((attachment) => {
+				const key = attachment._id || attachment.url || attachment.originalName;
+				return (
+					<Box
+						key={key}
+						component="a"
+						href={attachment.url}
+						target="_blank"
+						rel="noreferrer"
+						sx={{
+							display: "block",
+							width: "100%",
+							borderRadius: 1,
+							border: `1px solid ${theme.palette.divider}`,
+							overflow: "hidden",
+							backgroundColor: theme.palette.background.paper,
+						}}>
+						<Box
+							component="img"
+							src={attachment.url}
+							alt={attachment.originalName || "Attachment"}
+							loading="lazy"
+							decoding="async"
+							style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+						/>
+					</Box>
+				);
+			})}
+		</Box>
+	);
+}
+
+export default React.memo(MessageAttachments);

--- a/src/helpers/mediaUrl.js
+++ b/src/helpers/mediaUrl.js
@@ -1,9 +1,14 @@
 import { getApiBase } from "./api";
 
-export const profileMediaUrl = (urlIn, fallback) => {
+export const resolveMediaUrl = (urlIn) => {
 	const base = getApiBase();
+	if (!urlIn) return "";
 
 	if (urlIn?.startsWith("/") && !urlIn?.startsWith(base) && urlIn?.split("/")?.length - 1 > 1) return base + urlIn;
-	if (!urlIn || urlIn === "" || urlIn === undefined || urlIn === null) return `${globalThis.IN_ELECTRON_ENV ? "" : "/"}${fallback}`;
 	return urlIn;
+};
+
+export const profileMediaUrl = (urlIn, fallback) => {
+	if (!urlIn || urlIn === "" || urlIn === undefined || urlIn === null) return `${globalThis.IN_ELECTRON_ENV ? "" : "/"}${fallback}`;
+	return resolveMediaUrl(urlIn);
 };

--- a/src/slices/chatApiSlice.js
+++ b/src/slices/chatApiSlice.js
@@ -1,7 +1,7 @@
 import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
 import axios from "axios";
 import { buildApiConfig, getApiBase } from "../helpers/api";
-import { profileMediaUrl } from "../helpers/mediaUrl";
+import { profileMediaUrl, resolveMediaUrl } from "../helpers/mediaUrl";
 
 const base = getApiBase();
 
@@ -12,6 +12,12 @@ export const mapMessages = (msgs) => {
 			...m.sender,
 			avatarUrl: profileMediaUrl(m?.sender?.avatarUrl, "defaultpfp.webp"),
 		},
+		attachments: Array.isArray(m.attachments)
+			? m.attachments.filter(Boolean).map((attachment) => ({
+					...attachment,
+					url: resolveMediaUrl(attachment?.url),
+				}))
+			: [],
 	}));
 };
 


### PR DESCRIPTION
## Summary
- populate message attachments when fetching chat history and sending updates over sockets
- normalize attachment URLs client-side and render media previews in chat messages with lazy-loading

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692baf0b83788327a749b118be536c9d)