### PR TITLE
Potential fix for code scanning alert no. 101: Type confusion through parameter tampering

### DIFF
--- a/server/src/live/service.js
+++ b/server/src/live/service.js
@@ -288,7 +288,14 @@ class LiveService {
 		} catch (err) {
 			throw toValidationError(err, "Invalid segment filename.");
 		}
-		const body = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody || "");
+		let body;
+		if (Buffer.isBuffer(rawBody)) {
+			body = rawBody;
+		} else if (typeof rawBody === "string") {
+			body = Buffer.from(rawBody, "utf8");
+		} else {
+			throw new LiveServiceError(422, "Segment body must be binary data.", "invalid_segment_body_type");
+		}
 		if (!body.length) {
 			throw new LiveServiceError(422, "Segment body is required.", "missing_segment_body");
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/BrandonCasa/rebound-chat/security/code-scanning/101](https://github.com/BrandonCasa/rebound-chat/security/code-scanning/101)

To fix this safely, enforce that segment payloads are only accepted as binary input (`Buffer`) or, if needed for compatibility, as plain strings; reject arrays and all other types before conversion. This removes type confusion from parameter tampering and prevents implicit `Buffer.from(...)` coercion on attacker-controlled non-string/non-buffer inputs.

Best minimal fix (no functional change for valid clients): update `uploadSegment` in `server/src/live/service.js` around lines 291–294:
- Replace `const body = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(rawBody || "");`
- With explicit type checks:
  - If `rawBody` is `Buffer`, use as-is.
  - Else if `typeof rawBody === "string"`, convert with `Buffer.from(rawBody, "utf8")`.
  - Else throw `LiveServiceError(422, "Segment body must be binary data.", "invalid_segment_body_type")`.
- Keep existing empty-body validation (`!body.length`) unchanged.

No new imports or dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
