### PR TITLE
Potential fix for code scanning alert no. 100: Type confusion through parameter tampering

### DIFF
--- a/server/src/routes/api/media.js
+++ b/server/src/routes/api/media.js
@@ -107,7 +107,12 @@ router.post(
 			return res.status(503).json({ error: "File store not ready." });
 		}
 
-		const files = req.files || [];
+		const uploadedFiles = req.files;
+		if (!Array.isArray(uploadedFiles)) {
+			return res.status(400).json({ error: "Invalid files payload." });
+		}
+
+		const files = uploadedFiles;
 		if (!files.length) {
 			return res.status(400).json({ error: "At least one file is required." });
 		}


### PR DESCRIPTION
Potential fix for [https://github.com/BrandonCasa/rebound-chat/security/code-scanning/100](https://github.com/BrandonCasa/rebound-chat/security/code-scanning/100)

To fix this safely, validate that `req.files` is actually an array before using `.length` and indexed access. Keep existing behavior for valid uploads, but reject non-array types with a 400 error.

Best targeted change in `server/src/routes/api/media.js`:
- Replace `const files = req.files || [];` with a two-step normalization:
  - read raw value (`uploadedFiles = req.files`)
  - enforce `Array.isArray(uploadedFiles)` and reject otherwise
  - then assign `files = uploadedFiles`
- Keep existing `!files.length` check for “at least one file”.

No new imports or dependencies are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
