### PR TITLE
Potential fix for code scanning alert no. 101: Type confusion through parameter tampering

### DIFF
--- a/server/src/live/service.js
+++ b/server/src/live/service.js
@@ -288,14 +288,10 @@ class LiveService {
 		} catch (err) {
 			throw toValidationError(err, "Invalid segment filename.");
 		}
-		let body;
-		if (Buffer.isBuffer(rawBody)) {
-			body = rawBody;
-		} else if (typeof rawBody === "string") {
-			body = Buffer.from(rawBody, "utf8");
-		} else {
+		if (!Buffer.isBuffer(rawBody)) {
 			throw new LiveServiceError(422, "Segment body must be binary data.", "invalid_segment_body_type");
 		}
+		const body = rawBody;
 		if (!body.length) {
 			throw new LiveServiceError(422, "Segment body is required.", "missing_segment_body");
 		}

--- a/server/src/routes/live.js
+++ b/server/src/routes/live.js
@@ -165,6 +165,9 @@ router.put("/api/:sessionId/video.m3u8", ingestLimiter, requireIngestSession, pl
 
 router.put("/api/:sessionId/segments/:filename", ingestLimiter, requireIngestSession, rawSegmentParser, async (req, res) => {
 	try {
+		if (!Buffer.isBuffer(req.body)) {
+			throw new LiveServiceError(422, "Segment body must be binary data.", "invalid_segment_body_type");
+		}
 		await liveRuntime.service.uploadSegment(req.liveSession, req.params.filename, req.body);
 		return res.sendStatus(204);
 	} catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/BrandonCasa/rebound-chat/security/code-scanning/101](https://github.com/BrandonCasa/rebound-chat/security/code-scanning/101)

To fix this safely without changing intended functionality, enforce that segment uploads only accept binary payloads (`Buffer`) and reject all other runtime types (including arrays/strings/objects) before calling service logic.

Best single approach:
- In `server/src/routes/live.js`, add a strict type gate in the segment upload route (`/api/:sessionId/segments/:filename`) that returns a 422 via `sendLiveError` when `req.body` is not a `Buffer`.
- In `server/src/live/service.js`, tighten `uploadSegment` to require `Buffer` only (remove string-to-buffer coercion). This aligns with `rawSegmentParser` intent and eliminates type ambiguity flagged by CodeQL.

This requires no new dependencies and no import changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
